### PR TITLE
Many fixes and changes

### DIFF
--- a/src/main/scala/com/github/klassic/AST.scala
+++ b/src/main/scala/com/github/klassic/AST.scala
@@ -1,5 +1,7 @@
 package com.github.klassic
 
+import com.github.klassic.Type.TypeVariable
+
 /**
  * @author Kota Mizushima
  */
@@ -26,7 +28,7 @@ object AST {
 
   case class Import(location: Location, simpleName: String, fqcn: String)
 
-  case class RecordDeclaration(location: Location, name: String, ts: List[Type], members: List[(String, Type)])
+  case class RecordDeclaration(location: Location, name: String, ts: List[TypeVariable], members: List[(String, Type)])
 
   case class VariantDeclaration(location: Location, id: String, params: List[Type], constructors: List[DataConstructor]) extends AST
 

--- a/src/main/scala/com/github/klassic/Interpreter.scala
+++ b/src/main/scala/com/github/klassic/Interpreter.scala
@@ -352,8 +352,9 @@ class Interpreter {evaluator =>
         val (typedExpression, _) = typer.doType(rewriter.doRewrite(program.block), TypeEnvironment(typer.BuiltinEnvironment, Set.empty, typer.BuiltinRecordEnvironment ++ recordEnvironment, typer.BuiltinModuleEnvironment, None), tv, typer.EmptySubstitution)
         val runtimeRecordEnvironment: RecordEnvironment = BuiltinRecordEnvironment
         recordEnvironment.foreach { case (name, members) =>
-            val rmembers = members.map { case (rname, rscheme) => rname -> rscheme.description}
-            runtimeRecordEnvironment.records += (name -> rmembers)
+          val (xts, xmembers) = members
+          val rmembers = xmembers.map { case (rname, rscheme) => rname -> rscheme.description}
+          runtimeRecordEnvironment.records += (name -> rmembers)
         }
         evaluate(typedExpression, env = BuiltinEnvironment, recordEnv = runtimeRecordEnvironment, moduleEnv = BuiltinModuleEnvironment)
       case parser.Failure(m, n) => throw new InterpreterException(n.pos + ":" + m)

--- a/src/main/scala/com/github/klassic/Parser.scala
+++ b/src/main/scala/com/github/klassic/Parser.scala
@@ -131,7 +131,7 @@ class Parser extends RegexParsers {
     case _ => false
   }
 
-  lazy val typeVariable: Parser[Type] = qident ^^ {id => TypeVariable(id) }
+  lazy val typeVariable: Parser[TypeVariable] = qident ^^ {id => TypeVariable(id) }
 
   lazy val typeDescription: Parser[Type] = (
     qident ^^ {id => TypeVariable(id) }
@@ -250,14 +250,14 @@ class Parser extends RegexParsers {
   | invocation
   )
 
-  lazy val invocation: Parser[AST] = % ~ recordAccess ~ ((CL(DOT) ~> ident) ~ opt(CL(LPAREN) ~> repsep(expression, CL(COMMA)) <~ RPAREN)).* ^^ {
+  lazy val invocation: Parser[AST] = % ~ recordAccess ~ ((CL(ARROW2) ~> ident) ~ opt(CL(LPAREN) ~> repsep(expression, CL(COMMA)) <~ RPAREN)).* ^^ {
     case location ~ self ~ Nil =>
       self
     case location ~ self ~ npList  =>
       npList.foldLeft(self){case (self, name ~ params) => MethodCall(location, self, name.name, params.getOrElse(Nil))}
   }
 
-  lazy val recordAccess: Parser[AST] = % ~ application ~ ((CL(ARROW2) ~> (% ~ ident))).* ^^ {
+  lazy val recordAccess: Parser[AST] = % ~ application ~ ((CL(DOT) ~> (% ~ ident))).* ^^ {
     case location ~ self ~ names =>
       val ns = names.map{ case l ~ n => (l, n.name)}
       ns.foldLeft(self) { case (e, (l, n)) =>

--- a/src/main/scala/com/github/klassic/Type.scala
+++ b/src/main/scala/com/github/klassic/Type.scala
@@ -35,7 +35,9 @@ object Type {
 
   case object ErrorType extends Type("!")
 
-  case class RecordType(name: String, paramTypes: List[Type]) extends Type(s"record ${name}<${paramTypes.mkString(", ")}>")
+  case class RecordType(name: String, paramTypes: List[Type]) extends Type(
+    s"#${name}${if(paramTypes == Nil) "" else s"<${paramTypes.mkString(", ")}>"}"
+  )
 
   case class FunctionType(paramTypes: List[Type], returnType: Type) extends Type(s"(${paramTypes.mkString(", ")}) => ${returnType}")
 

--- a/src/main/scala/com/github/klassic/TypeEnvironment.scala
+++ b/src/main/scala/com/github/klassic/TypeEnvironment.scala
@@ -3,7 +3,7 @@ package com.github.klassic
 import com.github.klassic.Type._
 import scala.collection.mutable
 
-case class TypeEnvironment(variables: Map[String, TypeScheme], immutableVariables: Set[String], records: Map[String, List[(String, TypeScheme)]], modules: Map[String, Map[String, TypeScheme]], parent: Option[TypeEnvironment]) {
+case class TypeEnvironment(variables: Map[String, TypeScheme], immutableVariables: Set[String], records: Map[String, (List[TypeVariable], List[(String, TypeScheme)])], modules: Map[String, Map[String, TypeScheme]], parent: Option[TypeEnvironment]) {
   def lookup(name: String): Option[TypeScheme] = {
     val result1 = variables.get(name)
     val result2  = result1.orElse(parent.flatMap{p => p.lookup(name)})
@@ -18,7 +18,7 @@ case class TypeEnvironment(variables: Map[String, TypeScheme], immutableVariable
   def updateMutableVariable(name: String, scheme: TypeScheme): TypeEnvironment = {
     this.copy(variables = this.variables + (name -> scheme))
   }
-  def updateRecord(recordName: String, members: List[(String, TypeScheme)]): TypeEnvironment = {
+  def updateRecord(recordName: String, members: (List[TypeVariable], List[(String, TypeScheme)])): TypeEnvironment = {
     this.copy(records = this.records + (recordName -> members))
   }
   def updateModule(moduleName: String, members: Map[String, TypeScheme]): TypeEnvironment = {

--- a/src/test/scala/com/github/klassic/ExpressionSpec.scala
+++ b/src/test/scala/com/github/klassic/ExpressionSpec.scala
@@ -65,10 +65,10 @@ class ExpressionSpec extends SpecHelper {
         |val buf = new java.lang.StringBuffer
         |mutable i = 0
         |while(i <= 5) {
-        |  buf.append("#{i}")
+        |  buf->append("#{i}")
         |  i = i + 1
         |}
-        |buf.toString()
+        |buf->toString()
       """.stripMargin -> ObjectValue("012345")
 
     )
@@ -125,7 +125,7 @@ class ExpressionSpec extends SpecHelper {
       """
          |val newList = new java.util.ArrayList
          |foreach(a in [1, 2, 3, 4, 5]) {
-         |  newList.add((a :> Int) * 2)
+         |  newList->add((a :> Int) * 2)
          |}
          |newList
       """.stripMargin -> ObjectValue(listOf(2, 4, 6, 8, 10))

--- a/src/test/scala/com/github/klassic/RecordSpec.scala
+++ b/src/test/scala/com/github/klassic/RecordSpec.scala
@@ -38,7 +38,7 @@ class RecordSpec extends SpecHelper {
         |  age: Int
         |}
         |val p = new #Person("Hoge", 7)
-        |p->name
+        |p.name
       """.stripMargin -> ObjectValue("Hoge"),
       """
         |record Tuple<a', b'> {
@@ -46,7 +46,7 @@ class RecordSpec extends SpecHelper {
         |  _2: b'
         |}
         |val t = new #Tuple(1, 2)
-        |t->_1
+        |t._1
       """.stripMargin -> BoxedInt(1)
     )
 

--- a/test-programs/builtin_functions.kl
+++ b/test-programs/builtin_functions.kl
@@ -15,8 +15,8 @@ val time = stopwatch( => {
 println("it took #{time} milli seconds")
 assertResult(5)(add(2, 3))
 val list = new java.util.ArrayList
-list.add(4)
-list.add(1)
-list.add(2)
-list.add(3)
+list->add(4)
+list->add(1)
+list->add(2)
+list->add(3)
 assertResult([4 1 2 3])((list :> List<Int>))

--- a/test-programs/object.kl
+++ b/test-programs/object.kl
@@ -1,10 +1,10 @@
 val list = new java.util.ArrayList
-list.add(1)
-list.add(2)
+list->add(1)
+list->add(2)
 assertResult([1, 2])(list :> List<Int>)
 val buffer = new java.lang.StringBuffer
-buffer.append("A").append("B").append("C")
-assertResult("ABC")(buffer.toString)
+buffer->append("A")->append("B")->append("C")
+assertResult("ABC")(buffer->toString)
 val a = ["FOO", "BAR", "BAZ"]
 val b = [
   "FOO"
@@ -12,4 +12,4 @@ val b = [
   "BAZ"
 ]
 assertResult(a)(b)
-assertResult("F")("FOO".substring(0, 1))
+assertResult("F")("FOO"->substring(0, 1))

--- a/test-programs/record.kl
+++ b/test-programs/record.kl
@@ -9,14 +9,19 @@ record Pair <a', b'> {
 }
 
 val point = new #Point(1000, 2000)
-assertResult(1000)(point->x)
-assertResult(2000)(point->y)
+assertResult(1000)(point.x)
+assertResult(2000)(point.y)
 
 val person = new #Person("Kota Mizushima", 33)
-assertResult("Kota Mizushima")(person->name)
-assertResult(33)(person->age)
+assertResult("Kota Mizushima")(person.name)
+assertResult(33)(person.age)
 
-val pair = new #Pair(1, 2)
-assertResult(1)(pair->_1)
-assertResult(2)(pair->_2)
+val pair1 = new #Pair(1, 2)
+assertResult(1)(pair1._1)
+assertResult(2)(pair1._2)
+
+val pair2 = new #Pair(1.5, 2.5)
+assertResult(1.5)(pair2._1)
+assertResult(2.5)(pair2._2)
+
 


### PR DESCRIPTION
Now use '.' to access a member of a record.
Now use '->' to access a member of an object.
Fix a bug related to parametric record.