### PR TITLE
Some refactorings

### DIFF
--- a/src/main/scala/com/github/klassic/Evaluator.scala
+++ b/src/main/scala/com/github/klassic/Evaluator.scala
@@ -1,0 +1,30 @@
+package com.github.klassic
+
+import java.io.{BufferedReader, File, FileInputStream, InputStreamReader}
+
+import com.github.klassic.AST.Program
+
+class Evaluator extends (String => Value) {
+  val parser = new Parser
+  val typer = new Typer
+  val rewriter = new SyntaxRewriter
+  val interpreter = new Interpreter
+  override final def apply(program: String): Value = {
+    evaluateString(program)
+  }
+  def evaluateFile(file: File): Value = using(new BufferedReader(new InputStreamReader(new FileInputStream(file)))){in =>
+    val program = Iterator.continually(in.read()).takeWhile(_ != -1).map(_.toChar).mkString
+    evaluateString(program, file.getName)
+  }
+  def evaluateString(program: String, fileName: String = "<no file>"): Value = {
+    val parser = new Parser
+    parser.parse(program) match {
+      case parser.Success(program: Program, _) =>
+        val transformedProgram = rewriter.transform(program)
+        val typedProgram = typer.transform(transformedProgram)
+        interpreter.interpret(typedProgram)
+      case parser.Failure(m, n) => throw new InterpreterException(n.pos + ":" + m)
+      case parser.Error(m, n) => throw new InterpreterException(n.pos + ":" + m)
+    }
+  }
+}

--- a/src/main/scala/com/github/klassic/Main.scala
+++ b/src/main/scala/com/github/klassic/Main.scala
@@ -9,12 +9,12 @@ import scala.collection.Iterator.continually
  */
 object Main {
   def main(args: Array[String]): Unit = {
-    val interpreter = new Interpreter
+    val evaluator = new Evaluator
     parseCommandLine(args) match {
       case Some(("-e", line)) =>
-        println(interpreter.evaluateString(line))
+        println(evaluator.evaluateString(line))
       case Some(("-f", fileName)) =>
-        interpreter.evaluateFile(new File(fileName))
+        evaluator.evaluateFile(new File(fileName))
       case _ =>
         Console.err.println(
           """

--- a/src/main/scala/com/github/klassic/SyntaxRewriter.scala
+++ b/src/main/scala/com/github/klassic/SyntaxRewriter.scala
@@ -2,8 +2,9 @@ package com.github.klassic
 
 import com.github.klassic.AST.{FunctionCall, ListLiteral, MapLiteral, NewObject, _}
 import com.github.klassic.Type.{BooleanType, DynamicType}
+
 /**
-  * Created by kota_mizushima on 2016/11/17.
+  * @Author Kota Mizushima
   */
 class SyntaxRewriter {
   object SymbolGenerator {
@@ -14,7 +15,13 @@ class SyntaxRewriter {
       name
     }
   }
+
   import SymbolGenerator.symbol
+
+  def transform(program: AST.Program): AST.Program = {
+    program.copy(block = doRewrite(program.block).asInstanceOf[AST.Block])
+  }
+
   def doRewrite(node: AST): AST = node match {
     case Block(location, expressions) =>
       def rewriteBlock(es: List[AST]): List[AST] = es match {

--- a/src/main/scala/com/github/klassic/TypedAST.scala
+++ b/src/main/scala/com/github/klassic/TypedAST.scala
@@ -1,6 +1,6 @@
 package com.github.klassic
 
-import com.github.klassic.Type.DynamicType
+import com.github.klassic.Type.{DynamicType, TypeScheme, TypeVariable}
 
 /**
  * @author Kota Mizushima
@@ -12,6 +12,8 @@ sealed abstract class TypedAST {
 }
 
 object TypedAST {
+  type RecordEnvironment = Map[String, (List[TypeVariable], List[(String, TypeScheme)])]
+
   sealed trait IntegerSuffix
 
   case object ByteSuffix extends IntegerSuffix
@@ -24,7 +26,7 @@ object TypedAST {
 
   case object FloatSuffix extends FloatSuffix
 
-  case class Program(val location: Location, imports: List[Import], block: Block)
+  case class Program(val location: Location, imports: List[Import], block: Block, records: RecordEnvironment)
 
   case class Import(val location: Location, simpleName: String, fqcn: String)
 

--- a/src/main/scala/com/github/klassic/Typer.scala
+++ b/src/main/scala/com/github/klassic/Typer.scala
@@ -6,7 +6,7 @@ import com.github.klassic.Type.{TypeConstructor, _}
 import scala.collection.mutable
 
 /**
-  * Created by kota_mizushima on 2016/06/02.
+  * @author Kota Mizushima
   */
 class Typer {
   type Environment = Map[String, TypeScheme]
@@ -253,6 +253,13 @@ class Typer {
     val r = new SyntaxRewriter
     val (typedE, s) = doType(r.doRewrite(e), TypeEnvironment(environment, Set.empty, records, modules, None), a, EmptySubstitution)
     s(a)
+  }
+
+  def transform(program: AST.Program): TypedAST.Program = {
+    val tv = newTypeVariable()
+    val recordEnvironment: RecordEnvironment = processRecords(program.records)
+    val (typedExpression, _) = doType(program.block, TypeEnvironment(BuiltinEnvironment, Set.empty, BuiltinRecordEnvironment ++ recordEnvironment, BuiltinModuleEnvironment, None), tv, EmptySubstitution)
+    TypedAST.Program(program.location, Nil, typedExpression.asInstanceOf[TypedAST.Block], recordEnvironment)
   }
 
   var current: AST = null

--- a/src/main/scala/com/github/klassic/package.scala
+++ b/src/main/scala/com/github/klassic/package.scala
@@ -14,7 +14,7 @@ package object klassic {
     val reader = new BufferedReader(new InputStreamReader(new FileInputStream(fileName), "UTF-8"))
     using(reader)(f)
   }
-  def using[A <: { def close(): Unit}, B](resource: A)(f: A => B): B = try {
+  def using[A <: AutoCloseable, B](resource: A)(f: A => B): B = try {
     f(resource)
   } finally {
     scala.util.control.Exception.allCatch(resource.close())

--- a/src/main/scala/com/github/klassic/package.scala
+++ b/src/main/scala/com/github/klassic/package.scala
@@ -22,15 +22,17 @@ package object klassic {
 
   val p = new Parser
   val t = new Typer
-  val i = new Interpreter
+  val e = new Evaluator
 
   def typeOf(input: String): Type = {
     t.typeOf(p.parseExpression(input).get)
   }
 
   def evaluate(input: String): Value = {
-    i.evaluateString(input)
+    e.evaluateString(input)
   }
 
-  def tv(name: String): TypeVariable = TypeVariable(name)
+  def tv(name: String): TypeVariable = {
+    TypeVariable(name)
+  }
 }

--- a/src/test/scala/com/github/klassic/CommentSpec.scala
+++ b/src/test/scala/com/github/klassic/CommentSpec.scala
@@ -19,7 +19,7 @@ class CommentSpec extends SpecHelper {
     )
     expectations.zipWithIndex.foreach{ case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
 
@@ -41,7 +41,7 @@ class CommentSpec extends SpecHelper {
       )
       expectations.zipWithIndex.foreach{ case ((in, expected), i) =>
         it(s"expectations ${i}") {
-          assert(expected == I.evaluateString(in))
+          assert(expected == E(in))
         }
       }
     }

--- a/src/test/scala/com/github/klassic/ExpressionSpec.scala
+++ b/src/test/scala/com/github/klassic/ExpressionSpec.scala
@@ -40,7 +40,7 @@ class ExpressionSpec extends SpecHelper {
 
     expectations.foreach{ case (in, expected) =>
       it(s"${in} evaluates to ${expected}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }
@@ -74,7 +74,7 @@ class ExpressionSpec extends SpecHelper {
     )
     expectations.zipWithIndex.foreach{ case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }
@@ -89,7 +89,7 @@ class ExpressionSpec extends SpecHelper {
 
     expectations.zipWithIndex.foreach { case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }
@@ -115,7 +115,7 @@ class ExpressionSpec extends SpecHelper {
     )
     expectations.zipWithIndex.foreach{ case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }
@@ -133,7 +133,7 @@ class ExpressionSpec extends SpecHelper {
 
     expectations.zipWithIndex.foreach{ case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assertResult(expected)(I.evaluateString(in))
+        assertResult(expected)(E(in))
       }
     }
   }
@@ -150,7 +150,7 @@ class ExpressionSpec extends SpecHelper {
 
     expectations.zipWithIndex.foreach{ case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assertResult(expected)(I.evaluateString(in))
+        assertResult(expected)(E(in))
       }
     }
   }
@@ -182,7 +182,7 @@ class ExpressionSpec extends SpecHelper {
 
     expectations.zipWithIndex.foreach{ case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assertResult(expected)(I.evaluateString(in))
+        assertResult(expected)(E(in))
       }
     }
   }

--- a/src/test/scala/com/github/klassic/FileBasedProgramSpec.scala
+++ b/src/test/scala/com/github/klassic/FileBasedProgramSpec.scala
@@ -10,7 +10,7 @@ class FileBasedProgramSpec extends SpecHelper {
     })) {
       it(s"program ${program} runs successfully") {
         try {
-          I.evaluateFile(program)
+          E.evaluateFile(program)
           assert(true)
         }catch {
           case e:Throwable =>

--- a/src/test/scala/com/github/klassic/ListSpec.scala
+++ b/src/test/scala/com/github/klassic/ListSpec.scala
@@ -16,7 +16,7 @@ class ListSpec extends SpecHelper {
 
     expectations.foreach{ case (in, expected) =>
       it(s"${in} evaluates to ${expected}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }
@@ -35,7 +35,7 @@ class ListSpec extends SpecHelper {
     )
     expectations.zipWithIndex.foreach{ case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }
@@ -58,7 +58,7 @@ class ListSpec extends SpecHelper {
 
     expectations.zipWithIndex.foreach { case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }
@@ -80,7 +80,7 @@ class ListSpec extends SpecHelper {
     )
     expectations.zipWithIndex.foreach{ case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }
@@ -102,7 +102,7 @@ class ListSpec extends SpecHelper {
     )
     expectations.zipWithIndex.foreach{ case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }

--- a/src/test/scala/com/github/klassic/LiteralSpec.scala
+++ b/src/test/scala/com/github/klassic/LiteralSpec.scala
@@ -21,7 +21,7 @@ class LiteralSpec extends SpecHelper {
     )
     expectations.zipWithIndex.foreach { case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }
@@ -42,7 +42,7 @@ class LiteralSpec extends SpecHelper {
     )
     expectations.zipWithIndex.foreach{ case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }
@@ -59,7 +59,7 @@ class LiteralSpec extends SpecHelper {
 
     expectations.zipWithIndex.foreach{ case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
 
@@ -75,7 +75,7 @@ class LiteralSpec extends SpecHelper {
 
       expectations.zipWithIndex.foreach{ case ((in, expected), i) =>
         it(s"expectations ${i}") {
-          assert(expected == I.evaluateString(in))
+          assert(expected == E(in))
         }
       }
     }
@@ -93,7 +93,7 @@ class LiteralSpec extends SpecHelper {
     )
     expectations.zipWithIndex.foreach{ case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }
@@ -135,7 +135,7 @@ class LiteralSpec extends SpecHelper {
     )
     expectations.zipWithIndex.foreach { case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }
@@ -150,7 +150,7 @@ class LiteralSpec extends SpecHelper {
     )
     expectations.zipWithIndex.foreach { case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }

--- a/src/test/scala/com/github/klassic/MapSpec.scala
+++ b/src/test/scala/com/github/klassic/MapSpec.scala
@@ -16,7 +16,7 @@ class MapSpec extends SpecHelper {
 
     expectations.foreach{ case (in, expected) =>
       it(s"${in} evaluates to ${expected}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }
@@ -35,7 +35,7 @@ class MapSpec extends SpecHelper {
     )
     expectations.zipWithIndex.foreach{ case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }
@@ -54,7 +54,7 @@ class MapSpec extends SpecHelper {
     )
     expectations.zipWithIndex.foreach{ case ((in, expected), i) =>
       it(s"expectations ${i}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }

--- a/src/test/scala/com/github/klassic/RecordSpec.scala
+++ b/src/test/scala/com/github/klassic/RecordSpec.scala
@@ -25,7 +25,7 @@ class RecordSpec extends SpecHelper {
 
     expectations.foreach{ case (in, expected) =>
       it(s"${in} evaluates to ${expected}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E.evaluateString(in))
       }
     }
   }
@@ -52,7 +52,7 @@ class RecordSpec extends SpecHelper {
 
     expectations.foreach{ case (in, expected) =>
       it(s"${in} evaluates to ${expected}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }

--- a/src/test/scala/com/github/klassic/SpecHelper.scala
+++ b/src/test/scala/com/github/klassic/SpecHelper.scala
@@ -5,7 +5,7 @@ import java.util.ArrayList
 import java.util.HashMap
 
 trait SpecHelper extends FunSpec with DiagrammedAssertions {
-  val I = new Interpreter
+  val E = new Evaluator
   def listOf[T](elements: T*): ArrayList[T] = {
     val newList = new ArrayList[T]
     elements.foreach{e =>
@@ -23,7 +23,7 @@ trait SpecHelper extends FunSpec with DiagrammedAssertions {
   def expect[A, B](label: String)(expectation: (String, Value)): Unit = expectation match {
     case (actual, expected) =>
       it(label) {
-        assertResult(expected)(I.evaluateString(actual))
+        assertResult(expected)(E.evaluateString(actual))
       }
   }
 }

--- a/src/test/scala/com/github/klassic/ToDoSpec.scala
+++ b/src/test/scala/com/github/klassic/ToDoSpec.scala
@@ -6,7 +6,7 @@ class ToDoSpec extends SpecHelper {
   describe("ToDo() function") {
     it("throw NotImplementedException when it is evaluated") {
       intercept[NotImplementedError] {
-        I.evaluateString(
+        E(
           """
             |def fact(n) = if(n < 2) ToDo() else n * fact(n - 1)
             |fact(0)

--- a/src/test/scala/com/github/klassic/TypeCheckerSpec.scala
+++ b/src/test/scala/com/github/klassic/TypeCheckerSpec.scala
@@ -24,7 +24,7 @@ class TypeCheckerSpec extends SpecHelper {
 
     expectations.zipWithIndex.foreach { case ((in, expected), i) =>
       it(s"expectation  ${i}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }
@@ -39,7 +39,7 @@ class TypeCheckerSpec extends SpecHelper {
 
     expectations.zipWithIndex.foreach { case ((in, expected), i) =>
       it(s"expectation  ${i}") {
-        assertResult(expected)(I.evaluateString(in))
+        assertResult(expected)(E(in))
       }
     }
   }
@@ -60,7 +60,7 @@ class TypeCheckerSpec extends SpecHelper {
     inputs.zipWithIndex.foreach{ case (in, i) =>
       it(s"expectation  ${i}") {
         val e = intercept[TyperException] {
-          I.evaluateString(in)
+          E(in)
         }
         println(e)
       }
@@ -80,7 +80,7 @@ class TypeCheckerSpec extends SpecHelper {
 
     expectations.zipWithIndex.foreach { case ((in, expected), i) =>
       it(s"expectation  ${i}") {
-        assert(expected == I.evaluateString(in))
+        assert(expected == E(in))
       }
     }
   }
@@ -97,7 +97,7 @@ class TypeCheckerSpec extends SpecHelper {
     illTypedPrograms.zipWithIndex.foreach { case (in, i) =>
       it(s"expectation  ${i}") {
         val e = intercept[TyperException] {
-          I.evaluateString(in)
+          E(in)
         }
         println(e)
       }
@@ -115,7 +115,7 @@ class TypeCheckerSpec extends SpecHelper {
     illTypedPrograms.zipWithIndex.foreach { case (in, i) =>
       it(s"expectation  ${i}") {
         val e = intercept[TyperException] {
-          I.evaluateString(in)
+          E(in)
         }
         println(e)
       }
@@ -132,7 +132,7 @@ class TypeCheckerSpec extends SpecHelper {
     illTypedPrograms.zipWithIndex.foreach { case (in, i) =>
       it(s"expectation  ${i}") {
         val e = intercept[TyperException] {
-          I.evaluateString(in)
+          E(in)
         }
         println(e)
       }


### PR DESCRIPTION
* Use `AutoClosable` instead of Structural Types
* Split `Interpreter` into `Evaluator` and `Interpreter`