### PR TITLE
Add convenient syntax for function application:

### DIFF
--- a/test-programs/functions.kl
+++ b/test-programs/functions.kl
@@ -4,3 +4,7 @@ def myFoldLeft(list) = (z) => (f) => {
 assertResult(10)(myFoldLeft([1 2 3 4])(0)((x, y) => x + y))
 assertResult("ABC")(myFoldLeft(["A" "B" "C"])("")((x, y) => x + y))
 assertResult([4 3 2 1])(myFoldLeft([1 2 3 4])([])((x, y) => y #cons x))
+assertResult([4 3 2 1])(myFoldLeft([1 2 3 4])([]){x, y => y #cons x})
+
+val sum = myFoldLeft([1 2 3 4 5])(0){x, y => x + y}
+assertResult(15)(sum)


### PR DESCRIPTION
`f((x, y) => x + y)` can be written as `f{x, y => x + y}`