### PR TITLE
Add 'map' syntax

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,11 +3,10 @@ import sbt.librarymanagement.Developer
 organization := "com.github.klassic"
 
 name := "klassic"
+
 version := "0.1.0-snapshot"
 
-version := "0.1.0-beta1"
-
-scalaVersion := "3.3.0"
+scalaVersion := "2.13.13"
 
 publishMavenStyle := true
 
@@ -40,7 +39,7 @@ libraryDependencies ++= Seq(
 ).map(_.cross(CrossVersion.for3Use2_13))
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" %  "3.2.16"
+  "org.scalatest" %% "scalatest" %  "3.2.18"
 )
 
 libraryDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.4
+sbt.version=1.9.9

--- a/src/test/scala/com/github/klassic/ListSpec.scala
+++ b/src/test/scala/com/github/klassic/ListSpec.scala
@@ -119,4 +119,22 @@ class ListSpec extends SpecHelper {
       """.stripMargin, ObjectValue(listOf(2, 3, 4))
     )
   }
+
+  describe("map syntax") {
+    expect("for empty list")(
+      """
+        |[] map x => x + 1
+    """.stripMargin, ObjectValue(listOf())
+    )
+    expect("for a non empty list and block that add arg to 1")(
+      """
+        |[1 2 3] map x => x + 1
+    """.stripMargin, ObjectValue(listOf(2, 3, 4))
+    )
+    expect("for a non empty list and non-param block that add arg to 1")(
+      """
+        |[1 2 3] map =>e + 1
+""".stripMargin, ObjectValue(listOf(2, 3, 4))
+    )
+  }
 }

--- a/test-programs/map_syntax.kl
+++ b/test-programs/map_syntax.kl
@@ -1,0 +1,1 @@
+assertResult([1 2 3])([0 1 2] map x => x + 1)


### PR DESCRIPTION
a form of `map` syntax:

```
list 'map' <identifier> '=>' expression
```

e.g. `[1 2 3] map x => x + 1 // [2 3 4]`

```
list 'map' '=>' expression
```

which is expanded  to:

```
list 'map' 'e' '=>' expression
```

e.g. `[1 2 3] map => e + 1 // [2 3 4]`