### PR TITLE
Add function and object support to VM

### DIFF
--- a/src/main/scala/com/github/klassic/Evaluator.scala
+++ b/src/main/scala/com/github/klassic/Evaluator.scala
@@ -11,6 +11,7 @@ class Evaluator extends (String => Value) {
   val placeholderDesugerer = new PlaceholderDesugerer
   val rewriter = new SyntaxRewriter
   val interpreter = new Interpreter
+  val vmInterpreter = new vm.VmInterpreter
   override final def apply(program: String): Value = {
     evaluateString(program)
   }
@@ -32,5 +33,14 @@ class Evaluator extends (String => Value) {
     val rewrittenProgram = rewriter.process(placeHolderIsDesugaredProgram, session)
     val typedProgram = typer.process(rewrittenProgram, session)
     interpreter.process(typedProgram, session)
+  }
+
+  def evaluateStringWithVm(program: String): Value = {
+    val session = new InteractiveSession
+    val parsedProgram = parser.process(program, session)
+    val placeHolderIsDesugaredProgram = placeholderDesugerer.process(parsedProgram, session)
+    val rewrittenProgram = rewriter.process(placeHolderIsDesugaredProgram, session)
+    val typedProgram = typer.process(rewrittenProgram, session)
+    vmInterpreter.process(typedProgram, session)
   }
 }

--- a/src/main/scala/com/github/klassic/vm/Instruction.scala
+++ b/src/main/scala/com/github/klassic/vm/Instruction.scala
@@ -1,0 +1,23 @@
+package com.github.klassic.vm
+
+import com.github.klassic.{Value, TypedAst}
+
+sealed trait Instruction
+case class Push(value: Value) extends Instruction
+case class Load(name: String) extends Instruction
+case class Store(name: String) extends Instruction
+case object Add extends Instruction
+case object Sub extends Instruction
+case object Mul extends Instruction
+case object Div extends Instruction
+case object Neg extends Instruction
+case class Jump(target: Int) extends Instruction
+case class JumpIfFalse(target: Int) extends Instruction
+case object Return extends Instruction
+case class PushFunction(literal: TypedAst.FunctionLiteral) extends Instruction
+case class Call(argCount: Int) extends Instruction
+case class CallMethod(name: String, argCount: Int) extends Instruction
+case class NewObject(className: String, argCount: Int) extends Instruction
+case object LessThan extends Instruction
+case object Equal extends Instruction
+case object GreaterThan extends Instruction

--- a/src/main/scala/com/github/klassic/vm/VirtualMachine.scala
+++ b/src/main/scala/com/github/klassic/vm/VirtualMachine.scala
@@ -1,0 +1,229 @@
+package com.github.klassic.vm
+
+import scala.collection.mutable
+import com.github.klassic._
+
+class VirtualMachine {
+  private val stack = mutable.Stack[Value]()
+
+  def run(code: Vector[Instruction], env: RuntimeEnvironment = new RuntimeEnvironment(None)): Value = {
+    var pc = 0
+    var running = true
+    var result: Value = UnitValue
+    while (pc < code.length && running) {
+      code(pc) match {
+        case Push(v) =>
+          stack.push(v)
+          pc += 1
+        case Load(name) =>
+          stack.push(env(name))
+          pc += 1
+        case Store(name) =>
+          env.update(name, stack.pop())
+          pc += 1
+        case Add =>
+          val b = stack.pop()
+          val a = stack.pop()
+          val r = (a, b) match {
+            case (BoxedInt(x), BoxedInt(y)) => BoxedInt(x + y)
+            case (BoxedLong(x), BoxedLong(y)) => BoxedLong(x + y)
+            case (BoxedShort(x), BoxedShort(y)) => BoxedShort((x + y).toShort)
+            case (BoxedByte(x), BoxedByte(y)) => BoxedByte((x + y).toByte)
+            case (BoxedFloat(x), BoxedFloat(y)) => BoxedFloat(x + y)
+            case (BoxedDouble(x), BoxedDouble(y)) => BoxedDouble(x + y)
+            case _ => throw new RuntimeException("type error on add")
+          }
+          stack.push(r)
+          pc += 1
+        case Sub =>
+          val b = stack.pop()
+          val a = stack.pop()
+          val r = (a, b) match {
+            case (BoxedInt(x), BoxedInt(y)) => BoxedInt(x - y)
+            case (BoxedLong(x), BoxedLong(y)) => BoxedLong(x - y)
+            case (BoxedShort(x), BoxedShort(y)) => BoxedShort((x - y).toShort)
+            case (BoxedByte(x), BoxedByte(y)) => BoxedByte((x - y).toByte)
+            case (BoxedFloat(x), BoxedFloat(y)) => BoxedFloat(x - y)
+            case (BoxedDouble(x), BoxedDouble(y)) => BoxedDouble(x - y)
+            case _ => throw new RuntimeException("type error on sub")
+          }
+          stack.push(r)
+          pc += 1
+        case Mul =>
+          val b = stack.pop()
+          val a = stack.pop()
+          val r = (a, b) match {
+            case (BoxedInt(x), BoxedInt(y)) => BoxedInt(x * y)
+            case (BoxedLong(x), BoxedLong(y)) => BoxedLong(x * y)
+            case (BoxedShort(x), BoxedShort(y)) => BoxedShort((x * y).toShort)
+            case (BoxedByte(x), BoxedByte(y)) => BoxedByte((x * y).toByte)
+            case (BoxedFloat(x), BoxedFloat(y)) => BoxedFloat(x * y)
+            case (BoxedDouble(x), BoxedDouble(y)) => BoxedDouble(x * y)
+            case _ => throw new RuntimeException("type error on mul")
+          }
+          stack.push(r)
+          pc += 1
+        case Div =>
+          val b = stack.pop()
+          val a = stack.pop()
+          val r = (a, b) match {
+            case (BoxedInt(x), BoxedInt(y)) => BoxedInt(x / y)
+            case (BoxedLong(x), BoxedLong(y)) => BoxedLong(x / y)
+            case (BoxedShort(x), BoxedShort(y)) => BoxedShort((x / y).toShort)
+            case (BoxedByte(x), BoxedByte(y)) => BoxedByte((x / y).toByte)
+            case (BoxedFloat(x), BoxedFloat(y)) => BoxedFloat(x / y)
+            case (BoxedDouble(x), BoxedDouble(y)) => BoxedDouble(x / y)
+            case _ => throw new RuntimeException("type error on div")
+          }
+          stack.push(r)
+          pc += 1
+        case Neg =>
+          val a = stack.pop()
+          val r = a match {
+            case BoxedInt(x) => BoxedInt(-x)
+            case BoxedLong(x) => BoxedLong(-x)
+            case BoxedShort(x) => BoxedShort((-x).toShort)
+            case BoxedByte(x) => BoxedByte((-x).toByte)
+            case BoxedFloat(x) => BoxedFloat(-x)
+            case BoxedDouble(x) => BoxedDouble(-x)
+            case _ => throw new RuntimeException("type error on neg")
+          }
+          stack.push(r)
+          pc += 1
+        case Jump(target) =>
+          pc = target
+        case JumpIfFalse(target) =>
+          stack.pop() match {
+            case BoxedBoolean(false) => pc = target
+            case BoxedBoolean(true) => pc += 1
+            case _ => throw new RuntimeException("condition must be boolean")
+          }
+        case Return =>
+          result = if (stack.nonEmpty) stack.pop() else UnitValue
+          running = false
+        case PushFunction(lit) =>
+          stack.push(FunctionValue(lit, None, Some(env)))
+          pc += 1
+        case Call(n) =>
+          val args = Array.fill[Value](n)(UnitValue)
+          var i = n - 1
+          while(i >= 0){
+            args(i) = stack.pop(); i -= 1
+          }
+          stack.pop() match {
+            case FunctionValue(lit, _, cenv) =>
+              val local = new RuntimeEnvironment(cenv)
+              (lit.params.map(_.name) zip args).foreach{ case (n, v) => local.update(n, v) }
+              val code = new VmCompiler().compileFunction(lit)
+              val r = new VirtualMachine().run(code, local)
+              stack.push(r)
+            case NativeFunctionValue(body) =>
+              val argList = args.toList
+              if(body.isDefinedAt(argList)) stack.push(body(argList))
+              else throw new RuntimeException("parameters are not matched")
+            case other => throw new RuntimeException(s"${other} is not function")
+          }
+          pc += 1
+        case CallMethod(name, n) =>
+          val args = Array.fill[Value](n)(UnitValue)
+          var i = n - 1
+          while(i >= 0){ args(i) = stack.pop(); i -= 1 }
+          stack.pop() match {
+            case ObjectValue(obj) =>
+              val search = findMethod(obj, name, args)
+              search match {
+                case UnboxedVersionMethodFound(m) =>
+                  val actual = args.map(Value.fromKlassic)
+                  stack.push(Value.toKlassic(m.invoke(obj, actual:_*)))
+                case BoxedVersionMethodFound(m) =>
+                  val actual = args.map(Value.fromKlassic)
+                  stack.push(Value.toKlassic(m.invoke(obj, actual:_*)))
+                case NoMethodFound =>
+                  throw new RuntimeException(s"method ${name} not found")
+              }
+            case other => throw new RuntimeException(s"${other} has no methods")
+          }
+          pc += 1
+        case NewObject(className, n) =>
+          val args = Array.fill[Value](n)(UnitValue)
+          var i = n - 1
+          while(i >= 0){ args(i) = stack.pop(); i -= 1 }
+          findConstructor(Class.forName(className), args) match {
+            case UnboxedVersionConstructorFound(cons) =>
+              val actual = args.map(Value.fromKlassic)
+              stack.push(Value.toKlassic(cons.newInstance(actual:_*).asInstanceOf[AnyRef]))
+            case BoxedVersionConstructorFound(cons) =>
+              val actual = args.map(Value.fromKlassic)
+              stack.push(Value.toKlassic(cons.newInstance(actual:_*).asInstanceOf[AnyRef]))
+            case NoConstructorFound =>
+              throw new RuntimeException(s"constructor for ${className} not found")
+          }
+          pc += 1
+        case LessThan =>
+          val b = stack.pop(); val a = stack.pop()
+          val r = (a, b) match {
+            case (BoxedInt(x), BoxedInt(y)) => BoxedBoolean(x < y)
+            case (BoxedLong(x), BoxedLong(y)) => BoxedBoolean(x < y)
+            case (BoxedShort(x), BoxedShort(y)) => BoxedBoolean(x < y)
+            case (BoxedByte(x), BoxedByte(y)) => BoxedBoolean(x < y)
+            case (BoxedFloat(x), BoxedFloat(y)) => BoxedBoolean(x < y)
+            case (BoxedDouble(x), BoxedDouble(y)) => BoxedBoolean(x < y)
+            case _ => throw new RuntimeException("type error on <")
+          }
+          stack.push(r); pc += 1
+        case GreaterThan =>
+          val b = stack.pop(); val a = stack.pop()
+          val r = (a, b) match {
+            case (BoxedInt(x), BoxedInt(y)) => BoxedBoolean(x > y)
+            case (BoxedLong(x), BoxedLong(y)) => BoxedBoolean(x > y)
+            case (BoxedShort(x), BoxedShort(y)) => BoxedBoolean(x > y)
+            case (BoxedByte(x), BoxedByte(y)) => BoxedBoolean(x > y)
+            case (BoxedFloat(x), BoxedFloat(y)) => BoxedBoolean(x > y)
+            case (BoxedDouble(x), BoxedDouble(y)) => BoxedBoolean(x > y)
+            case _ => throw new RuntimeException("type error on >")
+          }
+          stack.push(r); pc += 1
+        case Equal =>
+          val b = stack.pop(); val a = stack.pop()
+          val r = BoxedBoolean(a == b)
+          stack.push(r); pc += 1
+      }
+    }
+    result
+  }
+
+  private def findMethod(self: AnyRef, name: String, params: Array[Value]): MethodSearchResult = {
+    val selfClass = self.getClass
+    val nameMatchedMethods = selfClass.getMethods.filter(_.getName == name)
+    val maybeUnboxedMethod = nameMatchedMethods.find { m =>
+      val parameterCountMatches = m.getParameterCount == params.length
+      val parameterTypes = Value.classesOfValues(params)
+      val parameterTypesMatches = (m.getParameterTypes zip parameterTypes).forall { case (arg, param) => arg.isAssignableFrom(param) }
+      parameterCountMatches && parameterTypesMatches
+    }.map { m => m.setAccessible(true); UnboxedVersionMethodFound(m) }
+    val maybeBoxedMethod = nameMatchedMethods.find { m =>
+      val parameterCountMatches = m.getParameterCount == params.length
+      val boxedParameterTypes = Value.boxedClassesOfValues(params)
+      val boxedParameterTypesMatches = (m.getParameterTypes zip boxedParameterTypes).forall { case (arg, param) => arg.isAssignableFrom(param) }
+      parameterCountMatches && boxedParameterTypesMatches
+    }.map { m => m.setAccessible(true); BoxedVersionMethodFound(m) }
+    maybeUnboxedMethod.orElse(maybeBoxedMethod).getOrElse(NoMethodFound)
+  }
+
+  private def findConstructor(target: Class[_], params: Array[Value]): ConstructorSearchResult = {
+    val constructors = target.getConstructors
+    val maybeUnboxed = constructors.find { c =>
+      val parameterCountMatches = c.getParameterCount == params.length
+      val unboxedParameterTypes = Value.classesOfValues(params)
+      val parameterTypesMatches = (c.getParameterTypes zip unboxedParameterTypes).forall { case (arg, param) => arg.isAssignableFrom(param) }
+      parameterCountMatches && parameterTypesMatches
+    }.map(UnboxedVersionConstructorFound)
+    val maybeBoxed = constructors.find { c =>
+      val parameterCountMatches = c.getParameterCount == params.length
+      val boxedParameterTypes = Value.boxedClassesOfValues(params)
+      val parameterTypesMatches = (c.getParameterTypes zip boxedParameterTypes).forall { case (arg, param) => arg.isAssignableFrom(param) }
+      parameterCountMatches && parameterTypesMatches
+    }.map(BoxedVersionConstructorFound)
+    maybeUnboxed.orElse(maybeBoxed).getOrElse(NoConstructorFound)
+  }
+}

--- a/src/main/scala/com/github/klassic/vm/VmCompiler.scala
+++ b/src/main/scala/com/github/klassic/vm/VmCompiler.scala
@@ -1,0 +1,106 @@
+package com.github.klassic.vm
+
+import scala.collection.mutable.ArrayBuffer
+import com.github.klassic._
+import com.github.klassic.TypedAst._
+import com.github.klassic.Operator
+
+class VmCompiler {
+  def compile(block: Block): Vector[Instruction] = {
+    val code = ArrayBuffer.empty[Instruction]
+    compileNode(block, code)
+    code += Return
+    code.toVector
+  }
+
+  private def compileNode(node: TypedNode, code: ArrayBuffer[Instruction]): Unit = node match {
+    case Block(_, _, exprs) =>
+      exprs.foreach(compileNode(_, code))
+    case IntNode(_, _, v) => code += Push(BoxedInt(v))
+    case LongNode(_, _, v) => code += Push(BoxedLong(v))
+    case ShortNode(_, _, v) => code += Push(BoxedShort(v))
+    case ByteNode(_, _, v) => code += Push(BoxedByte(v))
+    case DoubleNode(_, _, v) => code += Push(BoxedDouble(v))
+    case FloatNode(_, _, v) => code += Push(BoxedFloat(v))
+    case BooleanNode(_, _, v) => code += Push(BoxedBoolean(v))
+    case StringNode(_, _, v) => code += Push(ObjectValue(v))
+    case UnitNode(_, _) => code += Push(UnitValue)
+    case Id(_, _, name) => code += Load(name)
+    case Assignment(_, _, name, value) =>
+      compileNode(value, code)
+      code += Store(name)
+      code += Push(UnitValue)
+    case LetDeclaration(_, _, name, _, value, body, _) =>
+      compileNode(value, code)
+      code += Store(name)
+      compileNode(body, code)
+    case BinaryExpression(_, _, Operator.ADD, l, r) =>
+      compileNode(l, code)
+      compileNode(r, code)
+      code += Add
+    case BinaryExpression(_, _, Operator.SUBTRACT, l, r) =>
+      compileNode(l, code); compileNode(r, code); code += Sub
+    case BinaryExpression(_, _, Operator.MULTIPLY, l, r) =>
+      compileNode(l, code); compileNode(r, code); code += Mul
+    case BinaryExpression(_, _, Operator.DIVIDE, l, r) =>
+      compileNode(l, code); compileNode(r, code); code += Div
+    case BinaryExpression(_, _, Operator.LESS_THAN, l, r) =>
+      compileNode(l, code); compileNode(r, code); code += LessThan
+    case BinaryExpression(_, _, Operator.GREATER_THAN, l, r) =>
+      compileNode(l, code); compileNode(r, code); code += GreaterThan
+    case BinaryExpression(_, _, Operator.EQUAL, l, r) =>
+      compileNode(l, code); compileNode(r, code); code += Equal
+    case MinusOp(_, _, op) =>
+      compileNode(op, code); code += Neg
+    case PlusOp(_, _, op) =>
+      compileNode(op, code)
+    case IfExpression(_, _, cond, thenN, elseN) =>
+      compileNode(cond, code)
+      val jmpFalsePos = code.length
+      code += JumpIfFalse(-1)
+      compileNode(thenN, code)
+      val jmpEndPos = code.length
+      code += Jump(-1)
+      val elsePos = code.length
+      compileNode(elseN, code)
+      val end = code.length
+      code(jmpFalsePos) = JumpIfFalse(elsePos)
+      code(jmpEndPos) = Jump(end)
+    case WhileExpression(_, _, cond, body) =>
+      val start = code.length
+      compileNode(cond, code)
+      val jmpOutPos = code.length
+      code += JumpIfFalse(-1)
+      compileNode(body, code)
+      code += Jump(start)
+      val end = code.length
+      code(jmpOutPos) = JumpIfFalse(end)
+    case ValueNode(v) => code += Push(v)
+    case literal@FunctionLiteral(_, _, _, _, _) =>
+      code += PushFunction(literal)
+    case LetFunctionDefinition(_, _, name, body, _, expr) =>
+      code += PushFunction(body)
+      code += Store(name)
+      compileNode(expr, code)
+    case FunctionCall(_, _, func, params) =>
+      compileNode(func, code)
+      params.foreach(compileNode(_, code))
+      code += Call(params.length)
+    case MethodCall(_, _, self, name, params) =>
+      compileNode(self, code)
+      params.foreach(compileNode(_, code))
+      code += CallMethod(name, params.length)
+    case ObjectNew(_, _, className, params) =>
+      params.foreach(compileNode(_, code))
+      code += NewObject(className, params.length)
+    case n =>
+      throw new RuntimeException(s"unsupported node: $n")
+  }
+
+  def compileFunction(func: FunctionLiteral): Vector[Instruction] = {
+    val code = ArrayBuffer.empty[Instruction]
+    compileNode(func.proc, code)
+    code += Return
+    code.toVector
+  }
+}

--- a/src/main/scala/com/github/klassic/vm/VmInterpreter.scala
+++ b/src/main/scala/com/github/klassic/vm/VmInterpreter.scala
@@ -1,0 +1,17 @@
+package com.github.klassic.vm
+
+import com.github.klassic._
+
+class VmInterpreter extends Processor[TypedAst.Program, Value, InteractiveSession] {
+  private val compiler = new VmCompiler
+  private val vm = new VirtualMachine
+  private val interpreter = new Interpreter
+
+  override val name: String = "VmInterpreter"
+
+  override def process(input: TypedAst.Program, session: InteractiveSession): Value = {
+    val code = compiler.compile(input.block)
+    val env = new RuntimeEnvironment(Some(interpreter.BuiltinEnvironment))
+    vm.run(code, env)
+  }
+}


### PR DESCRIPTION
## Summary
- expand VM instruction set to include closures, calls, comparisons and reflection-based object handling
- implement these instructions in `VirtualMachine`
- extend `VmCompiler` to compile function literals, calls, method calls and object creation
- run VM with builtin environment in `VmInterpreter`

## Testing
- `sbt -no-colors test`