### PR TITLE
modules/imports: add module declarations and enhanced import support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,7 @@ dist
 .cache-main
 .bsp/
 .bloop/
+.sbtboot/
+.sbtglobal/
 .metals/
 .vscode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- SBT-based Scala 3 project with some Java runtime helpers.
+- Source: `src/main/scala/com/github/klassic/...`, Java runtime in `src/main/java/klassic/runtime`.
+- Tests: `src/test/scala/...` using ScalaTest; fixtures in `src/test/resources`.
+- Benchmarks: `src/jmh/scala/...` (JMH).
+- Examples and scripts: `examples/`, `test-programs/`, and `.kl` files at repo root.
+
+## Build, Test, and Development Commands
+- Prerequisites: JDK 8+ (11+ recommended) and `sbt`.
+- Compile: `sbt compile` — compiles main sources.
+- Run REPL: `sbt console` — opens Scala REPL with useful imports preloaded.
+- Run tests: `sbt test` (single suite: `sbt "testOnly com.github.klassic.TypeCheckerSpec"`).
+- Assemble fat jar: `sbt assembly` — outputs `target/scala-3.3.6/klassic.jar`.
+- Run interpreter: `java -jar target/scala-3.3.6/klassic.jar -e "println(1+2)"` or with a file.
+- Benchmarks: `sbt "jmh:run -i 3 -wi 3 -f1 .*Basic.*"`.
+
+## Coding Style & Naming Conventions
+- Language: Scala 3.3.6 (plus minimal Java). Use 2-space indentation, standard Scala brace style.
+- Naming: packages lowercase; types/objects `CamelCase`; methods/vals `lowerCamelCase`; constants `UPPER_SNAKE_CASE`.
+- Organization: match package paths (e.g., `com.github.klassic` → `src/main/scala/com/github/klassic`).
+- Prefer immutable `val` and pure functions; keep side effects explicit.
+- Formatting: no enforced formatter in repo; keep diffs minimal and follow surrounding style.
+
+## Testing Guidelines
+- Framework: ScalaTest (`AnyFunSpec` with `describe`/`it` and `Diagrams`).
+- Location: `src/test/scala/...`; name files `*Spec.scala` or `*Test.scala`.
+- Add tests for behavior changes (parser, typer, runtime); include negative tests where relevant (`intercept[...]`).
+- Run fast locally with `sbt test`; target a suite via `testOnly` while iterating.
+
+## Commit & Pull Request Guidelines
+- Commits: imperative mood, concise subject (<72 chars), scope prefix when helpful (e.g., `parser: handle underscores`).
+- PRs: clear description, rationale, and before/after examples; link issues; include tests and doc updates.
+- CI must be green (`sbt compile test assembly` as needed). Avoid large, mixed refactors.
+
+## Security & Publishing Notes
+- Do not commit secrets. Sonatype credentials are read from `~/.ivy2/.credentials` or `~/.m2/settings.xml` (see `build.sbt`).
+- Verify no sensitive data lands in sources, tests, or example programs.
+
+## Agent-Specific Instructions
+- Keep changes surgical; preserve file layout and naming.
+- Prefer `rg` for search; run `sbt test` before/after modifying core logic.
+- Avoid repository-wide reformatting; match existing style in touched files.
+

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,37 @@
+# Module & Import Improvements (Roadmap)
+
+## Import Enhancements
+- Aliases + selective together: `import foo.bar.{baz, qux} as fb` and per‑symbol aliasing `import Map.{size => msize}`.
+- Exclude + alias combos: `import Map.{size => _, get} as M`.
+- Wildcard with filters: `import Map.{* , size => _}` for all except size.
+- Conflict detection: warn/error on name collisions (local > selective > wildcard) with `--strict-imports`.
+
+## Selector & Resolution
+- FQCN selector polish: support nested calls and spacing forms consistently.
+- Prefer zero‑copy aliasing in module env (share map) to avoid duplication; document immutability expectations.
+
+## Module Typing
+- Persist user module type info (TScheme snapshots) alongside runtime export (e.g., `.klassic-mod.json`).
+- On import, load persisted types; fall back to current runtime inference only if absent.
+- Improve function arity/shape inference from closures (detect currying; infer `(a,b)=>c` vs `a=>b=>c`).
+
+## Visibility & Re‑export
+- Visibility keywords: `public`/`private` for `def`/`val`; export only public.
+- Re‑export syntax: `export other.mod.{foo, bar}` and `export other.mod.*`.
+
+## Initialization & Order
+- `init { ... }` block per module; run once upon first import.
+- Import graph + cycle detection; clear error for cycles and partial initialization.
+
+## Multi‑file Modules
+- Module path discovery: map `user.util` to `src/kl/user/util.kl` (configurable `KPATH`).
+- Precompiled cache for modules to speed up repeated imports.
+
+## Typeclass Integration
+- Importing instances: `import show.instances.{ShowInt, ShowString}` to register instances into the environment.
+- Duplicate instance policy: explicit selection or error under strict mode.
+
+## Tooling & DX
+- Lints: unused import, shadowed names, re‑export loops.
+- sbt tasks: `klassic/modules` (graph), `klassic/import-lint` (checks), `klassic/clean-mod-cache`.
+- Docs: update README with module/alias/selective patterns and gotchas.

--- a/src/main/scala/com/github/klassic/Ast.scala
+++ b/src/main/scala/com/github/klassic/Ast.scala
@@ -19,9 +19,9 @@ object Ast {
 
   case object FloatSuffix extends FloatSuffix
 
-  case class Program(location: Location, grammar: Option[macro_peg.Ast.Grammar], imports: List[Import], records: List[RecordDeclaration], typeClasses: List[TypeClassDeclaration], instances: List[InstanceDeclaration], block: Block)
+  case class Program(location: Location, module: Option[String], grammar: Option[macro_peg.Ast.Grammar], imports: List[Import], records: List[RecordDeclaration], typeClasses: List[TypeClassDeclaration], instances: List[InstanceDeclaration], block: Block)
 
-  case class Import(location: Location, simpleName: String, fqcn: String)
+  case class Import(location: Location, simpleName: String, fqcn: String, alias: Option[String] = None, only: Option[List[String]] = None, excludes: Set[String] = Set.empty)
 
   case class RecordDeclaration(location: Location, name: String, ts: List[TVariable], members: List[(String, Type)], methods: List[MethodDefinition])
 

--- a/src/main/scala/com/github/klassic/TypedAst.scala
+++ b/src/main/scala/com/github/klassic/TypedAst.scala
@@ -22,9 +22,7 @@ object TypedAst {
 
   case object FloatSuffix extends FloatSuffix
 
-  case class Program(location: Location, imports: List[Import], block: Block, records: RecordEnvironment, typeClasses: Map[String, Type.TTypeClass], instances: Map[(String, Type), Type.TInstance], instanceDeclarations: List[Ast.InstanceDeclaration] = Nil)
-
-  case class Import(location: Location, simpleName: String, fqcn: String)
+  case class Program(location: Location, module: Option[String], imports: List[Ast.Import], block: Block, records: RecordEnvironment, typeClasses: Map[String, Type.TTypeClass], instances: Map[(String, Type), Type.TInstance], instanceDeclarations: List[Ast.InstanceDeclaration] = Nil)
 
   case class Block(type_ : Type, location: Location, expressions: List[TypedNode]) extends TypedNode
 

--- a/src/test/scala/com/github/klassic/FileBasedProgramSpec.scala
+++ b/src/test/scala/com/github/klassic/FileBasedProgramSpec.scala
@@ -12,8 +12,9 @@ class FileBasedProgramSpec extends SpecHelper {
         try {
           E.evaluateFile(program)
           assert(true)
-        }catch {
-          case e:Throwable =>
+        } catch {
+          case e: Throwable =>
+            println(s"FAILED program: ${program}")
             e.printStackTrace()
             assert(false)
         }

--- a/src/test/scala/com/github/klassic/ModuleImportSpec.scala
+++ b/src/test/scala/com/github/klassic/ModuleImportSpec.scala
@@ -1,0 +1,111 @@
+package com.github.klassic
+
+class ModuleImportSpec extends SpecHelper {
+  describe("module declaration header") {
+    it("parses module header without semicolon and evaluates body") {
+      val result = E(
+        """
+          |module foo.bar
+          |1 + 1
+        """.stripMargin
+      )
+      assertResult(BoxedInt(2))(result)
+    }
+
+    it("parses module header with semicolon and evaluates body") {
+      val result = E(
+        """
+          |module foo.bar;
+          |1 + 1
+        """.stripMargin
+      )
+      assertResult(BoxedInt(2))(result)
+    }
+  }
+
+  describe("import built-in modules and use members unqualified") {
+    it("imports Map module and uses size on a map literal") {
+      val result = E(
+        """
+          |import Map
+          |size(%["A": 1, "B": 2])
+        """.stripMargin
+      )
+      assertResult(BoxedInt(2))(result)
+    }
+
+    it("imports Set module and uses contains on a set literal (curried)") {
+      val result = E(
+        """
+          |import Set
+          |contains(%(1, 2, 3))(2)
+        """.stripMargin
+      )
+      assertResult(BoxedBoolean(true))(result)
+    }
+
+    it("imports with alias and selective members") {
+      val result = E(
+        """
+          |import Map as M
+          |import Map.{size}
+          |size(%["A": 1])
+        """.stripMargin
+      )
+      assertResult(BoxedInt(1))(result)
+      // selector via alias should also work
+      val selector = E(
+        """
+          |import Map as M
+          |M#size(%["A": 1])
+        """.stripMargin
+      )
+      assertResult(BoxedInt(1))(selector)
+    }
+  }
+
+  describe("import user-defined modules") {
+    it("imports a user module by simple name and calls a function") {
+      // Define and export the module
+      E(
+        """
+          |module m
+          |def twice(x) = x + x
+        """.stripMargin
+      )
+      // Import and use it in a separate program
+      val result = E(
+        """
+          |import m
+          |twice(21)
+        """.stripMargin
+      )
+      assertResult(BoxedInt(42))(result)
+    }
+
+    it("imports a user module by fully-qualified name and calls a function") {
+      // Define and export the module under a namespace
+      E(
+        """
+          |module user.util
+          |def inc(x) = x + 1
+        """.stripMargin
+      )
+      // Import using the FQCN; alias-free selector with FQCN is also supported
+      val result = E(
+        """
+          |import user.util
+          |inc(41)
+        """.stripMargin
+      )
+      assertResult(BoxedInt(42))(result)
+
+      val selector = E(
+        """
+          |user.util#inc(41)
+        """.stripMargin
+      )
+      assertResult(BoxedInt(42))(selector)
+    }
+  }
+}

--- a/src/test/scala/com/github/klassic/TempParseSpec.scala
+++ b/src/test/scala/com/github/klassic/TempParseSpec.scala
@@ -1,0 +1,13 @@
+package com.github.klassic
+
+class TempParseSpec extends SpecHelper {
+  ignore("parse lambda with operator #cons") {
+    val result = E(
+      """
+        |((x, y) => y #cons x)
+      """.stripMargin
+    )
+    assert(result != null)
+  }
+}
+


### PR DESCRIPTION
- parser: add `module` header; import alias/selective/excludes; improve selector token parsing
- ast: Program carries optional module; Import has alias/only/excludes
- typer: bring imported members into scope (only/excludes); alias modules; support runtime-discovered modules in selector/imports; propagate module/ imports to typed AST
- vm: support cross-code closure calls; runtime import semantics (bind unqualified, alias module); export current program as a module (fqcn and simple name)
- tests: add ModuleImportSpec; add TempParseSpec (ignored); tweak FileBasedProgramSpec logging
- docs: add AGENTS.md and IMPROVEMENTS.md
- chore: update .gitignore for sbt boot/global dirs