### PR TITLE
fix: type-check arguments to a function-typed parameter

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -2127,7 +2127,24 @@ impl TypeChecker {
                 }
                 Ok(self.resolve(&result))
             }
-            Type::Dynamic | Type::Null | Type::Var(_) => Ok(Type::Dynamic),
+            Type::Var(id) => {
+                // The callee is an unresolved type variable — typically a
+                // function-typed parameter like `f` in `def apply(f, x) =
+                // f(x)`. Unify it with a function type built from the
+                // argument types so the parameter's signature is recovered
+                // and the arguments are type-checked, instead of erasing the
+                // whole call to `Dynamic` (which silently accepts a
+                // wrongly-typed argument and crashes at run time).
+                let arg_types = arguments
+                    .iter()
+                    .map(|argument| self.infer_expr(argument))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let result = self.fresh_var();
+                let function = Type::Function(arg_types, Box::new(result.clone()));
+                self.unify(Type::Var(id), function, span)?;
+                Ok(self.resolve(&result))
+            }
+            Type::Dynamic | Type::Null => Ok(Type::Dynamic),
             other => Err(type_error(
                 span,
                 format!("{} is not callable", display_type(&other)),
@@ -2271,7 +2288,24 @@ impl TypeChecker {
                 }
                 Ok(self.resolve(&result))
             }
-            Type::Dynamic | Type::Null | Type::Var(_) => Ok(Type::Dynamic),
+            Type::Var(id) => {
+                // The callee is an unresolved type variable — typically a
+                // function-typed parameter like `f` in `def apply(f, x) =
+                // f(x)`. Unify it with a function type built from the
+                // argument types so the parameter's signature is recovered
+                // and the arguments are type-checked, instead of erasing the
+                // whole call to `Dynamic` (which silently accepts a
+                // wrongly-typed argument and crashes at run time).
+                let arg_types = arguments
+                    .iter()
+                    .map(|argument| self.infer_expr(argument))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let result = self.fresh_var();
+                let function = Type::Function(arg_types, Box::new(result.clone()));
+                self.unify(Type::Var(id), function, span)?;
+                Ok(self.resolve(&result))
+            }
+            Type::Dynamic | Type::Null => Ok(Type::Dynamic),
             other => Err(type_error(
                 span,
                 format!("{} is not callable", display_type(&other)),

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -296,6 +296,45 @@ fn native_generic_arithmetic_monomorphizes() {
     assert_eq!(String::from_utf8_lossy(&run.stdout), "7\n7.0\nab\n");
 }
 
+/// Calling a function-typed parameter recovers its signature: `def
+/// apply(f, x) = f(x)` infers `((a) -> b, a) -> b`, so valid calls work
+/// and a wrongly-typed argument (`apply(g, true)` with `g: (Int) -> Int`)
+/// is a compile-time type error — instead of the call erasing to Dynamic
+/// and crashing at run time.
+#[test]
+fn higher_order_param_application_is_typed() {
+    let good = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "def apply(f, x) = f(x)\ndef g(n: Int): Int = n * 2\nprintln(apply(g, 5))\nprintln(apply((n) => n + 1, 10))",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        good.status.success(),
+        "valid higher-order application should evaluate\nstderr:\n{}",
+        String::from_utf8_lossy(&good.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&good.stdout), "10\n11\n()\n");
+
+    let bad = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "def apply(f, x) = f(x)\ndef g(n: Int): Int = n\napply(g, true)",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        !bad.status.success(),
+        "apply(g, true) should be a type error"
+    );
+    assert!(
+        String::from_utf8_lossy(&bad.stderr).contains("Int is not compatible with Boolean"),
+        "expected an argument type error, got:\n{}",
+        String::from_utf8_lossy(&bad.stderr)
+    );
+}
+
 /// Syntax errors for the parenthesization Klassic requires (and the
 /// `field: value` record syntax) carry a keyword-specific hint instead
 /// of the bare `expected (`, so users coming from Kotlin/Scala/Rust see


### PR DESCRIPTION
## Summary

Closes a real soundness hole (surfaced by the `+`-typeclass adversarial review): applying a callee whose type is still an **unresolved type variable** — typically a function-typed parameter like `f` in `def apply(f, x) = f(x)` — erased the whole call to `Dynamic` without unifying the callee with a function type or checking its arguments.

```klassic
def apply(f, x) = f(x)
def g(n: Int): Int = n
apply(g, true)   // BEFORE: type-checks, then crashes at run time
                 // AFTER:  type error — Int is not compatible with Boolean
```

Because `f(x)` returned `Dynamic` and never linked `f` to `x`, `apply` generalized to `(a, b) -> Dynamic` and accepted any argument.

## Fix

In both `infer_call` and `infer_constrained_call`, the `Type::Var` callee arm now infers the argument types, builds `Function(arg_types, fresh_result)`, and unifies the callee variable with it — recovering the parameter's signature and type-checking the arguments. `apply` now infers `((a) -> b, a) -> b`.

## Verified — adversarially

Two independent agents attacked the change:

- **Soundness**: *"SOUND — could not find any program that type-checks through a function-typed parameter or a type-variable callee yet produces a wrong value or runtime crash."* Mismatched arg type/arity, nested/curried `f(x)(y)`, returned closures, callback-to-callback, recursion through a param, a param called at two different types in one body, and `Plus`/`Num` interactions (`def ap(f,x)=f(x)+1`) are all now compile-time errors, matching the evaluator.
- **Regression**: *"No regression — ship it."* Every well-typed HOF (apply/compose/twice/flip/pipe/curry, returned/mutually-recursive closures, map/nested-map, functions in vals/lists/records, multi-arity params, thunks, polymorphic identity) still type-checks and runs, with eval and native byte-identical. **Let-polymorphism is preserved** — the same HOF is still usable at multiple function types in one program (no over-monomorphization).

### Out of scope (pre-existing, separate)

The builtin `map` / `foldLeft` / `join` method types declare their lambda parameter as `Dynamic`, so `[1 2 3].map((b: Bool) => ...)` over an `Int` list is still accepted — a distinct soundness gap that does not go through the changed type-variable callee arm and is left for a follow-up.

## Test plan

- `cargo test` green; `cargo fmt --check` clean; `cargo clippy --all-targets --all-features -- -D warnings` clean.
- New integration test `higher_order_param_application_is_typed` (valid call → value; `apply(g, true)` → type error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)