### PR TITLE
fix: type-check list `.map` against the element type

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -4345,7 +4345,20 @@ impl TypeChecker {
                 "isEmpty" => Some(Type::Function(vec![], Box::new(Type::Bool))),
                 "contains" => Some(Type::Function(vec![Type::Dynamic], Box::new(Type::Bool))),
                 "join" => Some(Type::Function(vec![Type::String], Box::new(Type::String))),
-                "map" => Some(Type::Function(vec![Type::Dynamic], Box::new(Type::Dynamic))),
+                // `xs.map(f)` over a `List<a>` is element-aware: `f` must
+                // accept the element type `a` and the result is `List<b>` for
+                // whatever `f` returns. This rejects, e.g., a `(b: Bool) => _`
+                // mapper applied to a `List<Int>` instead of silently typing
+                // the call as `Dynamic`.
+                "map" => {
+                    let result = self.fresh_var();
+                    let mapper =
+                        Type::Function(vec![inner.as_ref().clone()], Box::new(result.clone()));
+                    Some(Type::Function(
+                        vec![mapper],
+                        Box::new(Type::List(Box::new(result))),
+                    ))
+                }
                 // Accepts both `xs.foldLeft(init, f)` (two args at
                 // once) and `xs.foldLeft(init)(f)` (curried) — the
                 // latter partial-applies this type, and the runtime

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -335,6 +335,44 @@ fn higher_order_param_application_is_typed() {
     );
 }
 
+/// `xs.map(f)` is typed against the receiver's element type instead of
+/// `Dynamic`: a mapper that wants a different element type is rejected,
+/// and the call's result is a properly typed `List<b>` (so it chains and
+/// flows into typed contexts) rather than `Dynamic`.
+#[test]
+fn list_map_is_element_typed() {
+    let good = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "println([1 2 3].map((x) => x * 2))\nprintln([1 2 3].map((x) => \"n#{x}\"))\nprintln([1 2 3].map((x) => x + 1).map((y) => y * 10))",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        good.status.success(),
+        "element-typed map should evaluate\nstderr:\n{}",
+        String::from_utf8_lossy(&good.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&good.stdout),
+        "[2, 4, 6]\n[n1, n2, n3]\n[20, 30, 40]\n()\n"
+    );
+
+    let bad = Command::new(klassic_bin())
+        .args(["-e", "println([1 2 3].map((b: Bool) => b))"])
+        .output()
+        .expect("binary should run");
+    assert!(
+        !bad.status.success(),
+        "a Bool mapper over a List<Int> should be a type error"
+    );
+    assert!(
+        String::from_utf8_lossy(&bad.stderr).contains("Int is not compatible with Boolean"),
+        "expected an element type error, got:\n{}",
+        String::from_utf8_lossy(&bad.stderr)
+    );
+}
+
 /// Syntax errors for the parenthesization Klassic requires (and the
 /// `field: value` record syntax) carry a keyword-specific hint instead
 /// of the bare `expected (`, so users coming from Kotlin/Scala/Rust see


### PR DESCRIPTION
## What

`xs.map(f)` over a `List<a>` previously typed its mapper parameter and
result as `Dynamic`. As a result:

- an ill-typed mapper was silently accepted —
  `[1 2 3].map((b: Bool) => b)` type-checked instead of erroring, and
- the call's result lost its element type (`Dynamic`), so it couldn't
  chain or flow into a typed context with any checking.

This types the `map` method off the receiver's known element type as
`((a) -> b) -> List<b>`:

- a mapper that wants a different element type than the list holds is now
  a compile-time error (`Int is not compatible with Boolean`), and
- the result is a proper `List<b>`, so `.map(...).map(...)` chains and
  feeds typed contexts correctly.

Closes the `.map` soundness gap an adversarial review of the operator
type-class work surfaced. The sibling `foldLeft`/`join` `Dynamic`
lambda-param gaps are deliberately left for a separate, broader change.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test` all green (636 tests).
- New `list_map_is_element_typed` cli_smoke test: good chained / retyped
  cases plus the rejected `Bool`-over-`List<Int>` case.
- eval and native produce identical output for `.map` programs (parity probed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)