### PR TITLE
fix: type-check list and set `.contains` against the element type

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -4343,7 +4343,14 @@ impl TypeChecker {
                 "tail" => Some(Type::Function(vec![], Box::new(Type::List(inner.clone())))),
                 "size" => Some(Type::Function(vec![], Box::new(Type::Int))),
                 "isEmpty" => Some(Type::Function(vec![], Box::new(Type::Bool))),
-                "contains" => Some(Type::Function(vec![Type::Dynamic], Box::new(Type::Bool))),
+                // `xs.contains(x)` over a `List<a>` requires `x` to be the
+                // element type `a` rather than `Dynamic`, so e.g.
+                // `[1 2 3].contains("s")` on a `List<Int>` is a type error
+                // instead of a silently-accepted always-false membership test.
+                "contains" => Some(Type::Function(
+                    vec![inner.as_ref().clone()],
+                    Box::new(Type::Bool),
+                )),
                 "join" => Some(Type::Function(vec![Type::String], Box::new(Type::String))),
                 // `xs.map(f)` over a `List<a>` is element-aware: `f` must
                 // accept the element type `a` and the result is `List<b>` for
@@ -4399,7 +4406,10 @@ impl TypeChecker {
                 _ => None,
             },
             Type::Set(inner) => match field {
-                "contains" => Some(Type::Function(vec![Type::Dynamic], Box::new(Type::Bool))),
+                // `s.contains(x)` requires `x` to be the element type, matching
+                // `add`/`remove` below: a cross-type membership test such as
+                // `%(1 2 3).contains("s")` is rejected instead of typed `Dynamic`.
+                "contains" => Some(Type::Function(vec![(*inner).clone()], Box::new(Type::Bool))),
                 "isEmpty" => Some(Type::Function(vec![], Box::new(Type::Bool))),
                 "size" => Some(Type::Function(vec![], Box::new(Type::Int))),
                 "add" => Some(Type::Function(

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -373,6 +373,58 @@ fn list_map_is_element_typed() {
     );
 }
 
+/// `xs.contains(x)` on a `List<a>` / `Set<a>` is typed against the
+/// element type `a` instead of `Dynamic`, so a same-type membership test
+/// still works but a cross-type one (`[1 2 3].contains("s")`) is a type
+/// error rather than a silently-accepted always-false test.
+#[test]
+fn collection_contains_is_element_typed() {
+    let good = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "println([1 2 3].contains(2))\nprintln([\"a\" \"b\"].contains(\"b\"))\nprintln(%(1 2 3).contains(9))",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        good.status.success(),
+        "element-typed contains should evaluate\nstderr:\n{}",
+        String::from_utf8_lossy(&good.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&good.stdout),
+        "true\ntrue\nfalse\n()\n"
+    );
+
+    let bad_list = Command::new(klassic_bin())
+        .args(["-e", "println([1 2 3].contains(\"foo\"))"])
+        .output()
+        .expect("binary should run");
+    assert!(
+        !bad_list.status.success(),
+        "a String argument to List<Int>.contains should be a type error"
+    );
+    assert!(
+        String::from_utf8_lossy(&bad_list.stderr).contains("Int is not compatible with String"),
+        "expected an element type error, got:\n{}",
+        String::from_utf8_lossy(&bad_list.stderr)
+    );
+
+    let bad_set = Command::new(klassic_bin())
+        .args(["-e", "println(%(1 2 3).contains(\"foo\"))"])
+        .output()
+        .expect("binary should run");
+    assert!(
+        !bad_set.status.success(),
+        "a String argument to Set<Int>.contains should be a type error"
+    );
+    assert!(
+        String::from_utf8_lossy(&bad_set.stderr).contains("Int is not compatible with String"),
+        "expected an element type error, got:\n{}",
+        String::from_utf8_lossy(&bad_set.stderr)
+    );
+}
+
 /// Syntax errors for the parenthesization Klassic requires (and the
 /// `field: value` record syntax) carry a keyword-specific hint instead
 /// of the bare `expected (`, so users coming from Kotlin/Scala/Rust see
@@ -13829,7 +13881,7 @@ fn builds_native_executable_for_runtime_line_to_string() {
         std::env::temp_dir().join(format!("klassic-native-runtime-line-to-string-{unique}"));
     fs::write(
         &source_path,
-        "val probe = head(args())\nval lines = tail(args())\nval trailing = (probe + \",\").split(\",\")\nval empty = split(\"\", \",\")\nprintln(toString(lines))\nprintln(\"lines=\" + lines)\nprintln(toString(trailing))\nprintln(\"empty=\" + empty)\nprintln(lines.contains(\"beta\"))\nprintln(contains(lines)(\"gamma\"))\nprintln(lines.contains(probe))\nprintln(lines.contains(length(probe)))\nassertResult(\"[beta, gamma]\")(toString(lines))\nassertResult(\"lines=[beta, gamma]\")(\"lines=\" + lines)\nassertResult(\"[alpha, ]\")(toString(trailing))\nassertResult(\"empty=[]\")(\"empty=\" + empty)\nassert(lines.contains(\"beta\"))\nassert(contains(lines)(\"gamma\"))\nassert(!lines.contains(probe))\nassert(!lines.contains(length(probe)))\n",
+        "val probe = head(args())\nval lines = tail(args())\nval trailing = (probe + \",\").split(\",\")\nval empty = split(\"\", \",\")\nprintln(toString(lines))\nprintln(\"lines=\" + lines)\nprintln(toString(trailing))\nprintln(\"empty=\" + empty)\nprintln(lines.contains(\"beta\"))\nprintln(contains(lines)(\"gamma\"))\nprintln(lines.contains(probe))\nassertResult(\"[beta, gamma]\")(toString(lines))\nassertResult(\"lines=[beta, gamma]\")(\"lines=\" + lines)\nassertResult(\"[alpha, ]\")(toString(trailing))\nassertResult(\"empty=[]\")(\"empty=\" + empty)\nassert(lines.contains(\"beta\"))\nassert(contains(lines)(\"gamma\"))\nassert(!lines.contains(probe))\n",
     )
     .expect("source should write");
 
@@ -13870,7 +13922,7 @@ fn builds_native_executable_for_runtime_line_to_string() {
     );
     assert_eq!(
         String::from_utf8_lossy(&run.stdout),
-        "[beta, gamma]\nlines=[beta, gamma]\n[alpha, ]\nempty=[]\ntrue\ntrue\nfalse\nfalse\n"
+        "[beta, gamma]\nlines=[beta, gamma]\n[alpha, ]\nempty=[]\ntrue\ntrue\nfalse\n"
     );
     assert!(run.stderr.is_empty());
 }


### PR DESCRIPTION
## What

`xs.contains(x)` on a `List<a>` and `s.contains(x)` on a `Set<a>` typed the
argument as `Dynamic`, so a cross-type membership test was silently accepted
and always returned `false` at runtime:

```kl
[1 2 3].contains("foo")   // typed OK before, always false
%(1 2 3).contains("foo")  // ditto
```

This is the same soundness gap class as #454 (`.map`). The argument is now
typed as the receiver's element type `a`, so a cross-type test is a
compile-time error while same-type membership keeps working. It also makes
`Set.contains` consistent with its already element-typed `add`/`remove`.

```
<expression>: type mismatch: Int is not compatible with String
```

## Test plan

- New `collection_contains_is_element_typed` cli_smoke test: good List/Set
  same-type cases evaluate; cross-type List and Set cases are rejected with
  an element type error.
- Updated `builds_native_executable_for_runtime_line_to_string`: dropped the
  two `contains(length(probe))` probes (a `List<String>` queried with an
  `Int`) that relied on the old `Dynamic` behavior; same-type "absent"
  coverage via `contains(probe)` is retained.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
  and `cargo test` all green. eval and native agree on the valid cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)