### PR TITLE
fix: type-check Map key/value method arguments against the map type

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -4377,10 +4377,20 @@ impl TypeChecker {
                 _ => None,
             },
             Type::Map(key, value) => match field {
-                "containsKey" | "containsValue" => {
-                    Some(Type::Function(vec![Type::Dynamic], Box::new(Type::Bool)))
+                // `m.containsKey(k)` / `m.containsValue(v)` / `m.get(k)` take the
+                // map's declared key/value type rather than `Dynamic`, matching
+                // `getOrElse`/`put`/`remove` below: a wrong-typed lookup such as
+                // `%["a": 1].get(99)` is a type error instead of being silently
+                // accepted. `get` keeps a `Dynamic` result because it returns
+                // null for an absent key.
+                "containsKey" => Some(Type::Function(vec![(*key).clone()], Box::new(Type::Bool))),
+                "containsValue" => {
+                    Some(Type::Function(vec![(*value).clone()], Box::new(Type::Bool)))
                 }
-                "get" => Some(Type::Function(vec![Type::Dynamic], Box::new(Type::Dynamic))),
+                "get" => Some(Type::Function(
+                    vec![(*key).clone()],
+                    Box::new(Type::Dynamic),
+                )),
                 "getOrElse" => Some(Type::Function(
                     vec![(*key).clone(), (*value).clone()],
                     Box::new((*value).clone()),

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -425,6 +425,62 @@ fn collection_contains_is_element_typed() {
     );
 }
 
+/// `m.containsKey(k)` / `m.containsValue(v)` / `m.get(k)` are typed against
+/// the map's declared key/value type instead of `Dynamic`, so a same-type
+/// lookup still works while a wrong-typed one is a type error rather than a
+/// silently-accepted always-false / always-null lookup. Mirrors the
+/// already-element-typed `getOrElse`/`put`/`remove`.
+#[test]
+fn map_key_value_methods_are_typed() {
+    let good = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "val m = %[\"a\": 1 \"b\": 2]\nprintln(m.containsKey(\"a\"))\nprintln(m.containsValue(2))\nprintln(m.get(\"b\"))\nprintln(m.containsKey(\"z\"))",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        good.status.success(),
+        "typed map lookups should evaluate\nstderr:\n{}",
+        String::from_utf8_lossy(&good.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&good.stdout),
+        "true\ntrue\n2\nfalse\n()\n"
+    );
+
+    // Each wrong-typed lookup over a Map<String, Int> is a type error.
+    let cases = [
+        (
+            "println(%[\"a\": 1].containsKey(42))",
+            "String is not compatible with Int",
+        ),
+        (
+            "println(%[\"a\": 1].containsValue(true))",
+            "Int is not compatible with Boolean",
+        ),
+        (
+            "println(%[\"a\": 1].get(99))",
+            "String is not compatible with Int",
+        ),
+    ];
+    for (src, expected) in cases {
+        let bad = Command::new(klassic_bin())
+            .args(["-e", src])
+            .output()
+            .expect("binary should run");
+        assert!(
+            !bad.status.success(),
+            "`{src}` should be a key/value type error"
+        );
+        assert!(
+            String::from_utf8_lossy(&bad.stderr).contains(expected),
+            "`{src}` expected `{expected}`, got:\n{}",
+            String::from_utf8_lossy(&bad.stderr)
+        );
+    }
+}
+
 /// Syntax errors for the parenthesization Klassic requires (and the
 /// `field: value` record syntax) carry a keyword-specific hint instead
 /// of the bare `expected (`, so users coming from Kotlin/Scala/Rust see


### PR DESCRIPTION
## What

`m.containsKey(k)`, `m.containsValue(v)` and `m.get(k)` on a `Map<k, v>` typed
their argument as `Dynamic`, so a wrong-typed lookup was silently accepted and
returned a meaningless always-false / always-null result:

```kl
%["a": 1].containsKey(42)     // typed OK before, always false
%["a": 1].containsValue(true) // ditto
%["a": 1].get(99)             // typed OK before, always null
```

This is the same soundness gap class as #454 (`.map`) and #455 (`.contains`).
The argument is now typed as the map's declared key/value type — matching the
already element-typed `getOrElse`/`put`/`remove` — so a wrong-typed lookup is a
compile-time error while same-type lookups keep working:

```
<expression>: type mismatch: String is not compatible with Int
```

`get` keeps a `Dynamic` result type because it returns `null` for an absent key.

## Test plan

- New `map_key_value_methods_are_typed` cli_smoke test: same-type
  `containsKey`/`containsValue`/`get` evaluate; wrong-typed cases are each
  rejected with a key/value type error.
- Independently verified valid usages still work (`get("a")`, Int-keyed maps,
  the `m.get(k) == null` null-compare pattern, `examples/stdlib-v0.2-demo.kl`).
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
  and `cargo test` all green. eval and native agree on the valid program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)