### PR TITLE
fix: correct negative isOdd, unstable sortBy, and empty indent in stdlib

### DIFF
--- a/stdlib/prelude.kl
+++ b/stdlib/prelude.kl
@@ -46,7 +46,7 @@ def stdlibMod(n, m) = n - (n / m) * m
 
 def stdlibIsEven(n) = stdlibMod(n, 2) == 0
 
-def stdlibIsOdd(n) = stdlibMod(n, 2) == 1
+def stdlibIsOdd(n) = stdlibMod(n, 2) != 0
 
 def stdlibReverse(xs) = foldLeft(xs)([])((acc, x) => cons(x)(acc))
 

--- a/stdlib/std/list.kl
+++ b/stdlib/std/list.kl
@@ -143,20 +143,22 @@ def foldRight(xs, init, f) = foldLeft(reverse(xs))(init)((acc, x) => f(x, acc))
 // ---------- sort / sortBy ---------------------------------------------------
 
 // Insertion-sort helper: insert `x` into an already-sorted list.
-// Works for any ordered type (Int, Double) because it uses `<=`.
+// Uses `<` (not `<=`) so the sort is stable: `x` is placed after any
+// earlier elements that compare equal, preserving their input order.
 def insertSorted(sorted, x) =
   if(isEmpty(sorted)) [x]
-  else if(x <= head(sorted)) cons(x)(sorted)
+  else if(x < head(sorted)) cons(x)(sorted)
   else cons(head(sorted))(insertSorted(tail(sorted), x))
 
 // Sort a list of numbers (Int or Double) in ascending order.
 // Uses insertion sort via `foldLeft` — O(n²) but pure and simple.
 def sort(xs) = foldLeft(xs)([])(insertSorted)
 
-// Insertion-sort helper that compares by a key function.
+// Insertion-sort helper that compares by a key function. Uses `<`
+// (not `<=`) so equal-key elements keep their input order (stable sort).
 def insertSortedBy(key, sorted, x) =
   if(isEmpty(sorted)) [x]
-  else if(key(x) <= key(head(sorted))) cons(x)(sorted)
+  else if(key(x) < key(head(sorted))) cons(x)(sorted)
   else cons(head(sorted))(insertSortedBy(key, tail(sorted), x))
 
 // Sort `xs` by the numeric value returned by `key(x)`.

--- a/stdlib/std/string.kl
+++ b/stdlib/std/string.kl
@@ -88,7 +88,7 @@ def indentJoinLines(ls, prefix) =
   foldLeft(tail(ls))(prefix + toString(head(ls)))((acc, x) => acc + "\n" + prefix + toString(x))
 
 // Indent every line of `s` by `n` spaces.
-def indent(s, n) = indentJoinLines(split(s, "\n"), stringSpaces(n))
+def indent(s, n) = if(s == "") "" else indentJoinLines(split(s, "\n"), stringSpaces(n))
 
 // ---------- stripPrefix / stripSuffix ---------------------------------------
 

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -481,6 +481,48 @@ fn map_key_value_methods_are_typed() {
     }
 }
 
+/// Regressions for three stdlib correctness bugs: `stdlibIsOdd` returned
+/// false for negative odd numbers, `sortBy`/`sort` reversed the relative
+/// order of equal-key elements (unstable sort), and `indent("")` produced
+/// bare indentation spaces instead of an empty string.
+#[test]
+fn stdlib_correctness_regressions() {
+    let cases = [
+        ("println(stdlibIsOdd(-3))", "true\n()\n"),
+        ("println(stdlibIsOdd(-4))", "false\n()\n"),
+        // Equal keys keep their input order (stable sort).
+        (
+            "import std.list.{sortBy}\nprintln(sortBy([[1 100] [1 200] [1 300]], (p) => head(p)))",
+            "[[1, 100], [1, 200], [1, 300]]\n()\n",
+        ),
+        (
+            "import std.list.{sortBy}\nprintln(sortBy([[2 1] [1 1] [2 2] [1 2]], (p) => head(p)))",
+            "[[1, 1], [1, 2], [2, 1], [2, 2]]\n()\n",
+        ),
+        // Indenting the empty string yields the empty string, not spaces.
+        (
+            "import std.string.{indent}\nprintln(\"[\" + indent(\"\", 2) + \"]\")",
+            "[]\n()\n",
+        ),
+    ];
+    for (src, expected) in cases {
+        let out = Command::new(klassic_bin())
+            .args(["-e", src])
+            .output()
+            .expect("binary should run");
+        assert!(
+            out.status.success(),
+            "`{src}` should evaluate\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout),
+            expected,
+            "wrong output for `{src}`"
+        );
+    }
+}
+
 /// Syntax errors for the parenthesization Klassic requires (and the
 /// `field: value` record syntax) carry a keyword-specific hint instead
 /// of the bare `expected (`, so users coming from Kotlin/Scala/Rust see


### PR DESCRIPTION
## What

Three independent stdlib correctness bugs, each surfaced by running the function and comparing to the expected result:

- **`stdlibIsOdd` is false for negative odd numbers.** It used `stdlibMod(n, 2) == 1`, but Klassic integer division truncates toward zero so `stdlibMod(-3, 2) == -1`. `stdlibIsOdd(-3)` returned `false`. Fixed to `!= 0`, matching `std.math.isOdd`.
- **`sort`/`sortBy` are unstable.** Their insertion-sort helpers compared with `<=`, placing each newly inserted element *before* existing equal(-key) elements, reversing their relative order on every insertion: `sortBy([[1 100] [1 200] [1 300]], head)` returned `[[1, 300], [1, 200], [1, 100]]`. Changed to `<` so equal elements keep their input order (stable sort).
- **`indent("")` returns bare spaces.** `split("", sep)` yields `[""]`, so the empty string got indented to `"  "`. Guarded so `indent("", n)` returns `""`.

## Test plan

- New `stdlib_correctness_regressions` cli_smoke test: negative/positive `isOdd`, stable `sortBy` with equal keys, and empty `indent`.
- Verified the existing `std_list_sort_zip_partition_group_mkstring` test (distinct-key sort) still passes — the stability change only affects equal-key ordering.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)