### PR TITLE
docs: fix Show<Bool> type-class instance to use Boolean

### DIFF
--- a/docs/book/src/tour/type-classes.md
+++ b/docs/book/src/tour/type-classes.md
@@ -21,8 +21,8 @@ instance Show<Int> where {
   def show(x: Int): String = "Int: " + x
 }
 
-instance Show<Bool> where {
-  def show(b: Bool): String = if (b) "yes" else "no"
+instance Show<Boolean> where {
+  def show(b: Boolean): String = if (b) "yes" else "no"
 }
 ```
 


### PR DESCRIPTION
## What

The Type Classes tour declared `instance Show<Bool>`, but type-class dispatch is
keyed by the runtime type name, which for booleans is `Boolean`. As written,
`show(true)` fails at runtime:

```
<expression>: no matching instance method `show` for given arguments
```

Changed the instance head and parameter annotation to `Boolean` so the example
runs.

## Test plan

Execution-verified the corrected example against the evaluator:

```
show(42)    => Int: 42
show(true)  => yes
show(false) => no
```

Docs-only change; the Rust build/test suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)