### PR TITLE
fix: accept thin arrow `->` as `=>` in type annotations

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -5124,6 +5124,15 @@ fn split_function_type(text: &str) -> Option<(String, String)> {
                 let right = text[chars[index + 1].0 + 1..].trim().to_string();
                 return Some((left, right));
             }
+            // Accept the thin arrow `->` as an alias for `=>` in type
+            // annotations, so `(Int) -> Int` parses as a function type
+            // instead of an opaque Named type (`-` never appears in an
+            // annotation except as part of `->`).
+            '-' if paren == 0 && angle == 0 && chars[index + 1].1 == '>' => {
+                let left = text[..chars[index].0].trim().to_string();
+                let right = text[chars[index + 1].0 + 1..].trim().to_string();
+                return Some((left, right));
+            }
             _ => {}
         }
         index += 1;

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -523,6 +523,27 @@ fn stdlib_correctness_regressions() {
     }
 }
 
+/// A `->` (thin arrow) in a type annotation is accepted as an alias for
+/// `=>`, so `(Int) -> Int` parses as a function type (in `val` and
+/// parameter annotations, and curried) instead of an opaque Named type
+/// that yields a misleading "not callable" / "not compatible" error.
+#[test]
+fn thin_arrow_type_annotation() {
+    let out = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "val f: (Int) -> Int = (x) => x + 1\ndef apply(g: (Int) -> Int, x: Int): Int = g(x)\nval c: (Int) -> (Int) -> Int = (a) => (b) => a + b\nprintln(f(10))\nprintln(apply((n) => n * 2, 5))\nprintln(c(3)(4))",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        out.status.success(),
+        "`->` annotations should type-check\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "11\n10\n7\n()\n");
+}
+
 /// Syntax errors for the parenthesization Klassic requires (and the
 /// `field: value` record syntax) carry a keyword-specific hint instead
 /// of the bare `expected (`, so users coming from Kotlin/Scala/Rust see


### PR DESCRIPTION
## What

A `->` in a type annotation was parsed as an opaque Named type, giving a
misleading error instead of a function type:

```kl
val f: (Int) -> Int = (x) => x + 1
// before: type mismatch: (Int)->Int is not compatible with (Int) => Int

def apply(g: (Int) -> Int, x: Int): Int = g(x)
// before: (Int)->Int is not callable
```

`split_function_type` only recognized the fat arrow `=>`. It now also accepts
the thin arrow `->` (a `-` never appears in an annotation except as part of
`->`), so the thin arrow parses as a function type in `val`/parameter
annotations and curried forms. This only makes previously-rejected annotations
type-check — it cannot change any program that already compiled.

## Test plan

- New `thin_arrow_type_annotation` cli_smoke test: `->` in `val`, parameter, and
  curried `(Int) -> (Int) -> Int` positions.
- Verified `=>` still works and a mixed `->`/`=>` signature type-checks.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
  `cargo test` all green. eval and native agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)