### PR TITLE
docs: fix stale native-extension-method and match-expression claims

### DIFF
--- a/docs/book/src/reference/extension-methods.md
+++ b/docs/book/src/reference/extension-methods.md
@@ -62,18 +62,11 @@ receiver.
 
 ## Native compilation
 
-Native build (`klassic build file.kl`) does not yet support
-extension method dispatch. The compiler rejects an
-`extension { ... }` block with:
-
-```
-error: extension methods are not yet supported in native builds; see
-       docs/roadmap-targets-stdlib.md
-```
-
-Until the native-side dispatcher catches up, scripts that rely on
-extension methods should run through the evaluator (`klassic
-file.kl` or `klassic run file.kl`).
+Native build (`klassic build file.kl`) supports extension methods. Each
+method desugars into an ordinary function whose first parameter is the
+receiver, so `"hi".shout()` compiles to the same code as `shout("hi")`
+and produces identical output under the evaluator and a native
+executable.
 
 ## Stdlib usage
 

--- a/docs/book/src/tour/control-flow.md
+++ b/docs/book/src/tour/control-flow.md
@@ -67,6 +67,16 @@ they are used.
 
 ## Match-on-shape
 
-Klassic does not yet have an algebraic `match` expression. Use chained
-`if` / `else` for pattern-style dispatch, or method-style calls on
-records.
+Klassic has an algebraic `match` expression for pattern dispatch over
+[enums](../reference/enums.md):
+
+```kl
+enum Color { case Red; case Green }
+val c = Red
+println(c match { case Red => "r"; case Green => "g" })   // r
+```
+
+`match` also binds constructor payloads, matches literals, and supports
+`if` guards; see the [Enums](../reference/enums.md) reference for the
+full surface. Chained `if` / `else` still works for plain boolean
+dispatch.


### PR DESCRIPTION
## What

Two book pages stated capabilities the compiler has since gained:

- **extension-methods.md** claimed native build "does not yet support extension
  method dispatch" and rejects `extension { ... }`. Native build supports
  extension methods (they desugar to ordinary functions). Verified
  `"hi".shout()` builds and runs (`HI`) under both eval and a native executable.
- **control-flow.md** claimed Klassic "does not yet have an algebraic `match`
  expression". It does — replaced the false claim with a working `match` example
  and a pointer to the Enums reference.

## Test plan

Both replacement examples were execution-verified (eval and native):

```
"hi".shout()                                  => HI   (eval + native)
c match { case Red => "r"; case Green => "g" } => r    (eval + native)
```

Docs-only change; the Rust build/test suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)