### PR TITLE
fix: point match-arm type mismatch at the body, not the pattern

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -1592,7 +1592,9 @@ impl TypeChecker {
                     }
                     let body_type = self.infer_expr(&arm.body)?;
                     self.pop_scope();
-                    arm_type = self.unify(arm_type, body_type, arm.span)?;
+                    // Point a cross-arm type mismatch at the conflicting body
+                    // expression, not at the start of the arm's pattern.
+                    arm_type = self.unify(arm_type, body_type, arm.body.span())?;
                 }
                 self.check_match_coverage(&scrutinee_type, arms, *span)?;
                 Ok(self.resolve(&arm_type))

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -544,6 +544,28 @@ fn thin_arrow_type_annotation() {
     assert_eq!(String::from_utf8_lossy(&out.stdout), "11\n10\n7\n()\n");
 }
 
+/// A type mismatch between match arms points at the conflicting body
+/// expression, not at the start of the arm's pattern, so the caret lands
+/// on the value that actually has the wrong type.
+#[test]
+fn match_arm_mismatch_points_at_body() {
+    let bad = Command::new(klassic_bin())
+        .args(["-e", "val x = 0\nx match { case 0 => 1; case _ => \"s\" }"])
+        .output()
+        .expect("binary should run");
+    assert!(
+        !bad.status.success(),
+        "mismatched arm body types should be a type error"
+    );
+    let stderr = String::from_utf8_lossy(&bad.stderr);
+    // The body `"s"` is at line 2, column 34; the arm's pattern is earlier,
+    // so a `2:34` span proves the caret moved onto the body expression.
+    assert!(
+        stderr.contains("2:34") && stderr.contains("Int is not compatible with String"),
+        "expected the error to point at the body `\"s\"` (2:34), got:\n{stderr}"
+    );
+}
+
 /// Syntax errors for the parenthesization Klassic requires (and the
 /// `field: value` record syntax) carry a keyword-specific hint instead
 /// of the bare `expected (`, so users coming from Kotlin/Scala/Rust see


### PR DESCRIPTION
## What

A type mismatch between match arms was reported with the arm's span, which
starts at the pattern, so the caret landed on the pattern token instead of the
body that actually had the wrong type:

```kl
x match { case A => 1; case B => "two" }
//                          ^ before: caret on `B` (the pattern)
//                                   ^ after: caret on `"two"` (the body)
```

Use `arm.body.span()` for the cross-arm unification so the diagnostic points at
the conflicting value.

## Test plan

- New `match_arm_mismatch_points_at_body` cli_smoke test asserts the error span
  lands on the body literal (`2:34`) rather than the earlier pattern.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
  `cargo test` all green. Diagnostic-only change; codegen and runtime values are
  unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)