### PR TITLE
feat: report unreachable match arms for duplicate constructors

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -4108,12 +4108,33 @@ impl TypeChecker {
         span: Span,
     ) -> Result<(), Diagnostic> {
         let mut closed = false;
+        let mut closed_variants: HashSet<String> = HashSet::new();
         for arm in arms {
             if closed {
                 return Err(type_error(
                     arm.span,
                     "unreachable match arm: a preceding pattern already matches every value",
                 ));
+            }
+            // A later unguarded arm for a constructor that an earlier
+            // unguarded arm already matches with irrefutable payloads is
+            // dead (e.g. a second `case None` or `case Some(_)`). An arm
+            // with a refutable payload such as `case Some(1)` does not
+            // close the variant, so `case Some(x)` after it stays live.
+            if arm.guard.is_none()
+                && let klassic_syntax::Pattern::Constructor { name, args, .. } = &arm.pattern
+            {
+                if closed_variants.contains(name) {
+                    return Err(type_error(
+                        arm.span,
+                        format!(
+                            "unreachable match arm: `{name}` is already matched by a preceding arm"
+                        ),
+                    ));
+                }
+                if args.iter().all(pattern_is_irrefutable) {
+                    closed_variants.insert(name.clone());
+                }
             }
             if arm.guard.is_none() && pattern_is_irrefutable(&arm.pattern) {
                 closed = true;

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -566,6 +566,57 @@ fn match_arm_mismatch_points_at_body() {
     );
 }
 
+/// A match arm whose constructor an earlier unguarded, irrefutably-bound
+/// arm already matches is reported as unreachable — but a refutable
+/// earlier payload (`case S(1)`) does not close the variant, and guards
+/// keep later arms live, so neither is a false positive.
+#[test]
+fn duplicate_match_constructor_is_unreachable() {
+    let unreachable = [
+        // Repeated nullary constructor.
+        "enum C { case R; case G }\nval c = R\nc match { case R => 1; case R => 2; case G => 3 }",
+        // Repeated constructor with irrefutable payloads.
+        "enum O { case S(v: Int); case N }\nval o = S(1)\no match { case S(x) => x; case S(y) => y; case N => 0 }",
+    ];
+    for src in unreachable {
+        let out = Command::new(klassic_bin())
+            .args(["-e", src])
+            .output()
+            .expect("binary should run");
+        assert!(!out.status.success(), "`{src}` should be unreachable");
+        assert!(
+            String::from_utf8_lossy(&out.stderr).contains("unreachable match arm"),
+            "`{src}` expected an unreachable-arm error, got:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    // Not duplicates: a refutable `case S(1)` leaves `case S(x)` live, and
+    // a guard keeps a second same-constructor arm reachable.
+    let valid = [
+        (
+            "enum O { case S(v: Int); case N }\nval o = S(1)\nprintln(o match { case S(1) => 100; case S(x) => x; case N => 0 })",
+            "100\n()\n",
+        ),
+        (
+            "enum O { case S(v: Int); case N }\nval o = S(7)\nprintln(o match { case S(x) if x > 0 => 1; case S(y) => 2; case N => 0 })",
+            "1\n()\n",
+        ),
+    ];
+    for (src, expected) in valid {
+        let out = Command::new(klassic_bin())
+            .args(["-e", src])
+            .output()
+            .expect("binary should run");
+        assert!(
+            out.status.success(),
+            "`{src}` should be a valid match\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert_eq!(String::from_utf8_lossy(&out.stdout), expected);
+    }
+}
+
 /// Syntax errors for the parenthesization Klassic requires (and the
 /// `field: value` record syntax) carry a keyword-specific hint instead
 /// of the bare `expected (`, so users coming from Kotlin/Scala/Rust see


### PR DESCRIPTION
## What

A repeated constructor arm was silently accepted:

```kl
c match { case R => 1; case R => 2; case G => 3 }
//                          ^ dead code, no diagnostic before
```

`check_match_coverage` now tracks constructors already matched by an earlier
unguarded arm whose payloads are all irrefutable (wildcards/variables, or
none), and reports a later arm for the same constructor as an unreachable
match arm.

No false positives: a refutable earlier payload (`case S(1)`) does not close
the variant, so `case S(x)` after it stays live, and guarded arms never close a
variant.

## Test plan

- New `duplicate_match_constructor_is_unreachable` cli_smoke test: repeated
  nullary and irrefutable-payload constructors error; `case S(1)` → `case S(x)`
  and a guarded same-constructor arm stay valid.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
  `cargo test` all green. Compile-time diagnostic only; codegen/runtime unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)