### PR TITLE
fix: allow immediate dot-access on a record literal

### DIFF
--- a/crates/klassic-syntax/src/lib.rs
+++ b/crates/klassic-syntax/src/lib.rs
@@ -980,15 +980,16 @@ impl Parser {
         let expr = match self.peek().kind {
             TokenKind::Module => self.parse_module_header(),
             TokenKind::Import => self.parse_import_expression(),
-            TokenKind::Record => {
-                if matches!(
+            // Only intercept record *declarations* here. A record *literal*
+            // (`record { ... }`) falls through to `parse_assignment` so the
+            // postfix loop can apply to it, e.g. `record { x: 1 }.x`.
+            TokenKind::Record
+                if !matches!(
                     self.tokens.get(self.index + 1).map(|token| &token.kind),
                     Some(TokenKind::LBrace)
-                ) {
-                    self.parse_record_literal()
-                } else {
-                    self.parse_record_declaration()
-                }
+                ) =>
+            {
+                self.parse_record_declaration()
             }
             TokenKind::TypeClass => self.parse_typeclass_declaration(),
             TokenKind::Instance => self.parse_instance_declaration(),

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -617,6 +617,26 @@ fn duplicate_match_constructor_is_unreachable() {
     }
 }
 
+/// A structural record literal can be dot-accessed immediately
+/// (`record { x: 1 }.x`), including chained access, instead of requiring
+/// a `val` binding first.
+#[test]
+fn record_literal_immediate_dot_access() {
+    let out = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "println(record { x: 1; y: 2 }.x)\nprintln(record { a: record { b: 5 } }.a.b)",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        out.status.success(),
+        "record literal dot-access should evaluate\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "1\n5\n()\n");
+}
+
 /// Syntax errors for the parenthesization Klassic requires (and the
 /// `field: value` record syntax) carry a keyword-specific hint instead
 /// of the bare `expected (`, so users coming from Kotlin/Scala/Rust see


### PR DESCRIPTION
## What

`record { x: 1; y: 2 }.x` failed to parse:

```
<expression>: expected `)`
```

`parse_expression` dispatched record literals straight to `parse_record_literal`,
bypassing the postfix loop that handles `.field`. Only record *declarations* need
that early dispatch, so the arm is now guarded to fire only for declarations; a
record *literal* falls through to `parse_assignment` → `parse_primary` (which
already parses `record { ... }`), letting postfix dot-access apply.

## Test plan

- New `record_literal_immediate_dot_access` cli_smoke test: direct
  (`record { x: 1 }.x`) and chained (`record { a: record { b: 5 } }.a.b`) access.
- Verified record declarations, bare record literals, and access via a `val`
  binding still work, and a record-literal-dot program agrees between eval and
  native.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
  `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)