### PR TITLE
feat: stateful interpolation lexer for arbitrary-depth string holes

### DIFF
--- a/crates/klassic-eval/src/lib.rs
+++ b/crates/klassic-eval/src/lib.rs
@@ -12,8 +12,7 @@ use std::time::{Duration, Instant};
 use klassic_rewrite::rewrite_expression;
 use klassic_span::{Diagnostic, DiagnosticKind, Severity, SourceFile, Span};
 use klassic_syntax::{
-    BinaryOp, Expr, RecordField, TypeAnnotation, TypeClassConstraint, parse_inline_expression,
-    parse_source,
+    BinaryOp, Expr, RecordField, StringPart, TypeAnnotation, TypeClassConstraint, parse_source,
 };
 use klassic_types::proof::{ProofConfig, analyze_proofs};
 use klassic_types::{
@@ -1038,7 +1037,20 @@ fn eval_expr_inner(
             klassic_syntax::FloatLiteralKind::Double => Value::Double(*value),
         }),
         Expr::Bool { value, .. } => Ok(Value::Bool(*value)),
-        Expr::String { value, span } => interpolate_string(value, *span, environment),
+        Expr::String { value, .. } => Ok(Value::String(value.clone())),
+        Expr::StringInterpolation { parts, .. } => {
+            let mut result = String::new();
+            for part in parts {
+                match part {
+                    StringPart::Literal(text) => result.push_str(text),
+                    StringPart::Interpolation(hole) => {
+                        let value = eval_expr(hole, environment, state)?;
+                        result.push_str(&value.to_string());
+                    }
+                }
+            }
+            Ok(Value::String(result))
+        }
         Expr::Null { .. } => Ok(Value::Null),
         Expr::Unit { .. } => Ok(Value::Unit),
         Expr::Identifier { name, span } => resolve_identifier(name, *span, environment),
@@ -3618,80 +3630,6 @@ fn prefer_instance_dispatch(name: &str, argument_values: &[Value]) -> bool {
             ],
         )
     )
-}
-
-fn interpolate_string(
-    value: &str,
-    span: Span,
-    environment: &mut Environment,
-) -> Result<Value, Diagnostic> {
-    if !value.contains("#{") {
-        return Ok(Value::String(value.to_string()));
-    }
-
-    let mut result = String::new();
-    let chars = value.chars().collect::<Vec<_>>();
-    let mut index = 0usize;
-    while index < chars.len() {
-        if chars[index] == '#' && chars.get(index + 1) == Some(&'{') {
-            index += 2;
-            let mut expr = String::new();
-            let mut paren_depth = 0usize;
-            let mut bracket_depth = 0usize;
-            while index < chars.len() {
-                let ch = chars[index];
-                match ch {
-                    '{' => expr.push(ch),
-                    '(' => {
-                        paren_depth += 1;
-                        expr.push(ch);
-                    }
-                    ')' => {
-                        paren_depth = paren_depth.saturating_sub(1);
-                        expr.push(ch);
-                    }
-                    '[' => {
-                        bracket_depth += 1;
-                        expr.push(ch);
-                    }
-                    ']' => {
-                        bracket_depth = bracket_depth.saturating_sub(1);
-                        expr.push(ch);
-                    }
-                    '}' if paren_depth == 0 && bracket_depth == 0 => break,
-                    _ => expr.push(ch),
-                }
-                index += 1;
-            }
-            if index >= chars.len() || chars[index] != '}' {
-                return Err(Diagnostic::runtime(span, "unterminated interpolation"));
-            }
-            index += 1;
-            let normalized = strip_dynamic_cast(expr.trim());
-            let parsed = parse_inline_expression("<interpolation>", &normalized).map_err(|_| {
-                Diagnostic::runtime(span, "failed to parse interpolation expression")
-            })?;
-            let mut state = EvaluationState::default();
-            let interpolated = eval_expr(&parsed, environment, &mut state)?;
-            result.push_str(&interpolated.to_string());
-        } else {
-            result.push(chars[index]);
-            index += 1;
-        }
-    }
-
-    Ok(Value::String(result))
-}
-
-fn strip_dynamic_cast(expression: &str) -> String {
-    let trimmed = expression.trim();
-    if let Some(prefix) = trimmed.strip_suffix(":> *") {
-        prefix.trim_end().to_string()
-    } else if let Some(prefix) = trimmed.strip_suffix(":>*") {
-        prefix.trim_end().to_string()
-    } else {
-        trimmed.to_string()
-    }
 }
 
 #[cfg(test)]

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -7,7 +7,7 @@ use klassic_runtime::STDLIB_MODULES;
 use klassic_span::{Diagnostic, SourceFile, Span};
 use klassic_syntax::{
     BinaryOp, EnumVariant, Expr, FloatLiteralKind, IntLiteralKind, MatchArm, Pattern, RecordField,
-    TypeAnnotation, TypeClassConstraint, UnaryOp, parse_inline_expression, parse_source,
+    StringPart, TypeAnnotation, TypeClassConstraint, UnaryOp, parse_source,
 };
 use klassic_types::proof::{ProofConfig, analyze_proofs};
 use klassic_types::typecheck_program;
@@ -5406,20 +5406,20 @@ impl NativeCodeGenerator {
                 Ok(NativeValue::Bool)
             }
             Expr::Null { .. } => Ok(NativeValue::Null),
-            Expr::String { value, span } => {
-                if value.contains("#{") {
-                    let Some(value) =
-                        self.static_interpolated_string_value_preserving_effects(value, *span)
-                    else {
-                        return self.emit_runtime_interpolated_string(value, *span);
-                    };
-                    return Ok(self.emit_static_string(value));
-                }
+            Expr::String { value, .. } => {
                 let label = self.asm.data_label_with_bytes(value.as_bytes());
                 Ok(NativeValue::StaticString {
                     label,
                     len: value.len(),
                 })
+            }
+            Expr::StringInterpolation { parts, span } => {
+                let Some(value) =
+                    self.static_interpolated_string_value_preserving_effects(parts, *span)
+                else {
+                    return self.emit_runtime_interpolated_string(parts, *span);
+                };
+                Ok(self.emit_static_string(value))
             }
             Expr::ListLiteral { elements, span } => {
                 if let Some(values) = elements
@@ -25482,11 +25482,14 @@ impl NativeCodeGenerator {
             Expr::Null { .. } => Some(StaticValue::Null),
             Expr::Unit { .. } => Some(StaticValue::Unit),
             Expr::String { value, .. } => {
-                let value = if value.contains("#{") {
-                    self.static_interpolated_string_value(value)?
-                } else {
-                    value.clone()
-                };
+                let label = self.asm.data_label_with_bytes(value.as_bytes());
+                Some(StaticValue::StaticString {
+                    label,
+                    len: value.len(),
+                })
+            }
+            Expr::StringInterpolation { parts, .. } => {
+                let value = self.static_interpolated_string_value(parts)?;
                 let label = self.asm.data_label_with_bytes(value.as_bytes());
                 Some(StaticValue::StaticString {
                     label,
@@ -26882,8 +26885,8 @@ impl NativeCodeGenerator {
         bindings: &[(&str, StaticValue)],
     ) -> Option<StaticValue> {
         match expr {
-            Expr::String { value, .. } if value.contains("#{") => self
-                .static_interpolated_string_value_with_bindings(value, bindings)
+            Expr::StringInterpolation { parts, .. } => self
+                .static_interpolated_string_value_with_bindings(parts, bindings)
                 .map(|value| self.static_string_value(value)),
             Expr::Identifier { name, .. } => bindings
                 .iter()
@@ -31229,7 +31232,7 @@ impl NativeCodeGenerator {
             return self.static_string_from_value(&value);
         }
         match expr {
-            Expr::String { value, .. } if !value.contains("#{") => Some(value.clone()),
+            Expr::String { value, .. } => Some(value.clone()),
             Expr::Binary {
                 lhs,
                 op: BinaryOp::Add,
@@ -31264,7 +31267,7 @@ impl NativeCodeGenerator {
             return true;
         }
         match expr {
-            Expr::String { value, .. } if value.contains("#{") => true,
+            Expr::StringInterpolation { .. } => true,
             Expr::Identifier { name, .. } => matches!(
                 self.lookup_var(name).map(|slot| slot.value),
                 Some(NativeValue::RuntimeString { .. })
@@ -31485,108 +31488,63 @@ impl NativeCodeGenerator {
             .is_some_and(|value| self.static_string_list_content_from_value(&value).is_some())
     }
 
-    fn static_interpolated_string_value(&mut self, value: &str) -> Option<String> {
-        self.static_interpolated_string_value_inner(value, &[], None, false)
+    fn static_interpolated_string_value(&mut self, parts: &[StringPart]) -> Option<String> {
+        self.static_interpolated_string_parts(parts, &[], None, false)
     }
 
     fn static_interpolated_string_value_preserving_effects(
         &mut self,
-        value: &str,
+        parts: &[StringPart],
         span: Span,
     ) -> Option<String> {
-        self.static_interpolated_string_value_inner(value, &[], None, true)?;
-        self.static_interpolated_string_value_inner(value, &[], Some(span), false)
+        self.static_interpolated_string_parts(parts, &[], None, true)?;
+        self.static_interpolated_string_parts(parts, &[], Some(span), false)
     }
 
     fn static_interpolated_string_value_with_bindings(
         &mut self,
-        value: &str,
+        parts: &[StringPart],
         bindings: &[(&str, StaticValue)],
     ) -> Option<String> {
-        self.static_interpolated_string_value_inner(value, bindings, None, false)
+        self.static_interpolated_string_parts(parts, bindings, None, false)
     }
 
-    fn static_interpolated_string_value_inner(
+    /// Resolve an interpolated string at compile time from its structured
+    /// parts, returning `None` when any hole is not statically known.
+    fn static_interpolated_string_parts(
         &mut self,
-        value: &str,
+        parts: &[StringPart],
         bindings: &[(&str, StaticValue)],
         preserve_effects_span: Option<Span>,
         preview_effects: bool,
     ) -> Option<String> {
         let mut result = String::new();
-        let chars = value.chars().collect::<Vec<_>>();
-        let mut index = 0usize;
-        while index < chars.len() {
-            if chars[index] == '#' && chars.get(index + 1) == Some(&'{') {
-                index += 2;
-                let mut expr = String::new();
-                let mut brace_depth = 0usize;
-                let mut paren_depth = 0usize;
-                let mut bracket_depth = 0usize;
-                while index < chars.len() {
-                    let ch = chars[index];
-                    match ch {
-                        '{' => {
-                            brace_depth += 1;
-                            expr.push(ch);
-                        }
-                        '}' if brace_depth == 0 && paren_depth == 0 && bracket_depth == 0 => {
-                            break;
-                        }
-                        '}' => {
-                            brace_depth = brace_depth.saturating_sub(1);
-                            expr.push(ch);
-                        }
-                        '(' => {
-                            paren_depth += 1;
-                            expr.push(ch);
-                        }
-                        ')' => {
-                            paren_depth = paren_depth.saturating_sub(1);
-                            expr.push(ch);
-                        }
-                        '[' => {
-                            bracket_depth += 1;
-                            expr.push(ch);
-                        }
-                        ']' => {
-                            bracket_depth = bracket_depth.saturating_sub(1);
-                            expr.push(ch);
-                        }
-                        _ => expr.push(ch),
+        for part in parts {
+            match part {
+                StringPart::Literal(text) => result.push_str(text),
+                StringPart::Interpolation(hole) => {
+                    let hole = self.lower_interpolation_enums(rewrite_expression((**hole).clone()));
+                    let value = if preview_effects && bindings.is_empty() {
+                        self.preview_static_value_after_effectful_eval(&hole)?
+                    } else if let Some(span) = preserve_effects_span
+                        && bindings.is_empty()
+                    {
+                        self.static_value_from_argument_preserving_effects(
+                            &hole,
+                            span,
+                            "native string interpolation",
+                        )
+                        .ok()?
+                    } else if bindings.is_empty() {
+                        self.static_value_from_expr(&hole)?
+                    } else {
+                        self.static_value_from_expr_with_bindings(&hole, bindings)?
+                    };
+                    if self.static_value_has_conditional_builtin_display(&value) {
+                        return None;
                     }
-                    index += 1;
+                    result.push_str(&self.static_value_display_string(&value));
                 }
-                if index >= chars.len() || chars[index] != '}' {
-                    return None;
-                }
-                index += 1;
-                let normalized = strip_dynamic_cast(expr.trim());
-                let parsed = parse_inline_expression("<interpolation>", &normalized).ok()?;
-                let parsed = rewrite_expression(parsed);
-                let value = if preview_effects && bindings.is_empty() {
-                    self.preview_static_value_after_effectful_eval(&parsed)?
-                } else if let Some(span) = preserve_effects_span
-                    && bindings.is_empty()
-                {
-                    self.static_value_from_argument_preserving_effects(
-                        &parsed,
-                        span,
-                        "native string interpolation",
-                    )
-                    .ok()?
-                } else if bindings.is_empty() {
-                    self.static_value_from_expr(&parsed)?
-                } else {
-                    self.static_value_from_expr_with_bindings(&parsed, bindings)?
-                };
-                if self.static_value_has_conditional_builtin_display(&value) {
-                    return None;
-                }
-                result.push_str(&self.static_value_display_string(&value));
-            } else {
-                result.push(chars[index]);
-                index += 1;
             }
         }
         Some(result)
@@ -32742,13 +32700,12 @@ impl NativeCodeGenerator {
         expr: &Expr,
         span: Span,
     ) -> Result<(), Diagnostic> {
-        if let Expr::String {
-            value,
+        if let Expr::StringInterpolation {
+            parts,
             span: string_span,
         } = expr
-            && value.contains("#{")
         {
-            return self.emit_print_interpolated_string(fd, value, *string_span);
+            return self.emit_print_interpolated_string(fd, parts, *string_span);
         }
 
         if let Expr::Binary {
@@ -32923,159 +32880,59 @@ impl NativeCodeGenerator {
     fn emit_print_interpolated_string(
         &mut self,
         fd: u64,
-        value: &str,
+        parts: &[StringPart],
         span: Span,
     ) -> Result<(), Diagnostic> {
-        let chars = value.chars().collect::<Vec<_>>();
-        let mut literal = String::new();
-        let mut index = 0usize;
-        while index < chars.len() {
-            if chars[index] == '#' && chars.get(index + 1) == Some(&'{') {
-                if !literal.is_empty() {
-                    let label = self.asm.data_label_with_bytes(literal.as_bytes());
-                    self.emit_write_data(fd, label, literal.len());
-                    literal.clear();
-                }
-                index += 2;
-                let mut expr = String::new();
-                let mut brace_depth = 0usize;
-                let mut paren_depth = 0usize;
-                let mut bracket_depth = 0usize;
-                while index < chars.len() {
-                    let ch = chars[index];
-                    match ch {
-                        '{' => {
-                            brace_depth += 1;
-                            expr.push(ch);
-                        }
-                        '}' if brace_depth == 0 && paren_depth == 0 && bracket_depth == 0 => {
-                            break;
-                        }
-                        '}' => {
-                            brace_depth = brace_depth.saturating_sub(1);
-                            expr.push(ch);
-                        }
-                        '(' => {
-                            paren_depth += 1;
-                            expr.push(ch);
-                        }
-                        ')' => {
-                            paren_depth = paren_depth.saturating_sub(1);
-                            expr.push(ch);
-                        }
-                        '[' => {
-                            bracket_depth += 1;
-                            expr.push(ch);
-                        }
-                        ']' => {
-                            bracket_depth = bracket_depth.saturating_sub(1);
-                            expr.push(ch);
-                        }
-                        _ => expr.push(ch),
+        for part in parts {
+            match part {
+                StringPart::Literal(text) => {
+                    if !text.is_empty() {
+                        let label = self.asm.data_label_with_bytes(text.as_bytes());
+                        self.emit_write_data(fd, label, text.len());
                     }
-                    index += 1;
                 }
-                if index >= chars.len() || chars[index] != '}' {
-                    return Err(Diagnostic::compile(span, "unterminated interpolation"));
+                StringPart::Interpolation(hole) => {
+                    let parsed =
+                        self.lower_interpolation_enums(rewrite_expression((**hole).clone()));
+                    self.emit_print_expr_fragment(fd, &parsed, span)?;
                 }
-                index += 1;
-                let normalized = strip_dynamic_cast(expr.trim());
-                let parsed =
-                    parse_inline_expression("<interpolation>", &normalized).map_err(|_| {
-                        Diagnostic::compile(span, "failed to parse interpolation expression")
-                    })?;
-                let parsed = self.lower_interpolation_enums(rewrite_expression(parsed));
-                self.emit_print_expr_fragment(fd, &parsed, span)?;
-            } else {
-                literal.push(chars[index]);
-                index += 1;
             }
-        }
-        if !literal.is_empty() {
-            let label = self.asm.data_label_with_bytes(literal.as_bytes());
-            self.emit_write_data(fd, label, literal.len());
         }
         Ok(())
     }
 
     fn emit_runtime_interpolated_string(
         &mut self,
-        value: &str,
+        parts: &[StringPart],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
         const RUNTIME_STRING_CAP: usize = 65_536;
         let data = self.asm.data_label_with_bytes(&vec![0; RUNTIME_STRING_CAP]);
         let len = self.asm.data_label_with_i64s(&[0]);
         let offset = self.asm.data_label_with_i64s(&[0]);
-        let chars = value.chars().collect::<Vec<_>>();
-        let mut literal = String::new();
-        let mut index = 0usize;
-        while index < chars.len() {
-            if chars[index] == '#' && chars.get(index + 1) == Some(&'{') {
-                if !literal.is_empty() {
-                    let label = self.asm.data_label_with_bytes(literal.as_bytes());
-                    let input = NativeStringRef {
-                        data: label,
-                        len: NativeStringLen::Immediate(literal.len()),
-                    };
-                    self.emit_append_native_string_to_runtime_buffer_offset_label(
-                        data,
-                        offset,
-                        input,
-                        span,
-                        "string interpolation result exceeds 65536 bytes",
-                    );
-                    literal.clear();
-                }
-                index += 2;
-                let mut expr = String::new();
-                let mut brace_depth = 0usize;
-                let mut paren_depth = 0usize;
-                let mut bracket_depth = 0usize;
-                while index < chars.len() {
-                    let ch = chars[index];
-                    match ch {
-                        '{' => {
-                            brace_depth += 1;
-                            expr.push(ch);
-                        }
-                        '}' if brace_depth == 0 && paren_depth == 0 && bracket_depth == 0 => {
-                            break;
-                        }
-                        '}' => {
-                            brace_depth = brace_depth.saturating_sub(1);
-                            expr.push(ch);
-                        }
-                        '(' => {
-                            paren_depth += 1;
-                            expr.push(ch);
-                        }
-                        ')' => {
-                            paren_depth = paren_depth.saturating_sub(1);
-                            expr.push(ch);
-                        }
-                        '[' => {
-                            bracket_depth += 1;
-                            expr.push(ch);
-                        }
-                        ']' => {
-                            bracket_depth = bracket_depth.saturating_sub(1);
-                            expr.push(ch);
-                        }
-                        _ => expr.push(ch),
+        for part in parts {
+            let hole = match part {
+                StringPart::Literal(text) => {
+                    if !text.is_empty() {
+                        let label = self.asm.data_label_with_bytes(text.as_bytes());
+                        let input = NativeStringRef {
+                            data: label,
+                            len: NativeStringLen::Immediate(text.len()),
+                        };
+                        self.emit_append_native_string_to_runtime_buffer_offset_label(
+                            data,
+                            offset,
+                            input,
+                            span,
+                            "string interpolation result exceeds 65536 bytes",
+                        );
                     }
-                    index += 1;
+                    continue;
                 }
-                if index >= chars.len() || chars[index] != '}' {
-                    return Err(Diagnostic::compile(span, "unterminated interpolation"));
-                }
-                index += 1;
-                let normalized = strip_dynamic_cast(expr.trim());
-                let parsed =
-                    parse_inline_expression("<interpolation>", &normalized).map_err(|_| {
-                        Diagnostic::compile(span, "failed to parse interpolation expression")
-                    })?;
-                let parsed = self.lower_interpolation_enums(rewrite_expression(parsed));
+                StringPart::Interpolation(hole) => hole,
+            };
+            {
+                let parsed = self.lower_interpolation_enums(rewrite_expression((**hole).clone()));
                 if let Some(fragment) = self.compile_collection_literal_display_runtime_string(
                     &parsed,
                     span,
@@ -33196,24 +33053,7 @@ impl NativeCodeGenerator {
                 } else {
                     return Err(unsupported(span, "native string interpolation"));
                 }
-            } else {
-                literal.push(chars[index]);
-                index += 1;
             }
-        }
-        if !literal.is_empty() {
-            let label = self.asm.data_label_with_bytes(literal.as_bytes());
-            let input = NativeStringRef {
-                data: label,
-                len: NativeStringLen::Immediate(literal.len()),
-            };
-            self.emit_append_native_string_to_runtime_buffer_offset_label(
-                data,
-                offset,
-                input,
-                span,
-                "string interpolation result exceeds 65536 bytes",
-            );
         }
         self.emit_store_runtime_string_len_from_offset(len, offset);
         Ok(NativeValue::RuntimeString { data, len })
@@ -38802,6 +38642,10 @@ fn expr_references_any_name_with_shadowing(
     shadowed: &HashSet<String>,
 ) -> bool {
     match expr {
+        Expr::StringInterpolation { parts, .. } => parts.iter().any(|part| {
+            matches!(part, StringPart::Interpolation(hole)
+                if expr_references_any_name_with_shadowing(hole, names, shadowed))
+        }),
         Expr::Identifier { name, .. } => names.contains(name) && !shadowed.contains(name),
         Expr::VarDecl { name, value, .. } => {
             if expr_references_any_name_with_shadowing(value, names, shadowed) {
@@ -39153,6 +38997,13 @@ fn collect_pattern_binding_names(pattern: &Pattern, names: &mut HashSet<String>)
 
 fn collect_assigned_names(expr: &Expr, names: &mut HashSet<String>) {
     match expr {
+        Expr::StringInterpolation { parts, .. } => {
+            for part in parts {
+                if let StringPart::Interpolation(hole) = part {
+                    collect_assigned_names(hole, names);
+                }
+            }
+        }
         Expr::Assign { name, value, .. } => {
             names.insert(name.clone());
             collect_assigned_names(value, names);
@@ -39273,6 +39124,10 @@ fn collect_assigned_names(expr: &Expr, names: &mut HashSet<String>) {
 
 fn static_expr_is_pure(expr: &Expr) -> bool {
     match expr {
+        Expr::StringInterpolation { parts, .. } => parts.iter().all(|part| match part {
+            StringPart::Literal(_) => true,
+            StringPart::Interpolation(hole) => static_expr_is_pure(hole),
+        }),
         Expr::Assign { .. } | Expr::While { .. } | Expr::Foreach { .. } | Expr::Cleanup { .. } => {
             false
         }
@@ -39454,6 +39309,10 @@ fn lookup_var_slot_in_scopes(scopes: &[HashMap<String, VarSlot>], name: &str) ->
 
 fn expr_contains_thread_call(expr: &Expr, thread_aliases: &HashSet<String>) -> bool {
     match expr {
+        Expr::StringInterpolation { parts, .. } => parts.iter().any(|part| {
+            matches!(part, StringPart::Interpolation(hole)
+                if expr_contains_thread_call(hole, thread_aliases))
+        }),
         Expr::Call {
             callee, arguments, ..
         } => {
@@ -40254,17 +40113,6 @@ fn format_static_double(bits: u64) -> String {
         format!("{value:.1}")
     } else {
         value.to_string()
-    }
-}
-
-fn strip_dynamic_cast(expression: &str) -> String {
-    let trimmed = expression.trim();
-    if let Some(prefix) = trimmed.strip_suffix(":> *") {
-        prefix.trim_end().to_string()
-    } else if let Some(prefix) = trimmed.strip_suffix(":>*") {
-        prefix.trim_end().to_string()
-    } else {
-        trimmed.to_string()
     }
 }
 
@@ -41104,7 +40952,7 @@ mod tests {
     /// directly.
     fn first_def_param_and_body(source: &str) -> (String, Expr) {
         let program =
-            super::parse_inline_expression("<test>", source).expect("source should parse");
+            klassic_syntax::parse_inline_expression("<test>", source).expect("source should parse");
         let expressions = match &program {
             Expr::Block { expressions, .. } => expressions.clone(),
             other => vec![other.clone()],

--- a/crates/klassic-rewrite/src/lib.rs
+++ b/crates/klassic-rewrite/src/lib.rs
@@ -1,4 +1,4 @@
-use klassic_syntax::Expr;
+use klassic_syntax::{Expr, StringPart};
 
 pub fn rewrite_expression(expr: Expr) -> Expr {
     finalize(expr)
@@ -271,6 +271,21 @@ fn rewrite(expr: Expr) -> Expr {
             expressions: expressions.into_iter().map(finalize).collect(),
             span,
         },
+        Expr::StringInterpolation { parts, span } => wrap_placeholders(
+            Expr::StringInterpolation {
+                parts: parts
+                    .into_iter()
+                    .map(|part| match part {
+                        StringPart::Literal(text) => StringPart::Literal(text),
+                        StringPart::Interpolation(hole) => {
+                            StringPart::Interpolation(Box::new(rewrite(*hole)))
+                        }
+                    })
+                    .collect(),
+                span,
+            },
+            span,
+        ),
         other => other,
     }
 }
@@ -502,6 +517,18 @@ fn replace_placeholders(expr: Expr, counter: &mut usize) -> Expr {
             expressions: expressions
                 .into_iter()
                 .map(|expression| replace_placeholders(expression, counter))
+                .collect(),
+            span,
+        },
+        Expr::StringInterpolation { parts, span } => Expr::StringInterpolation {
+            parts: parts
+                .into_iter()
+                .map(|part| match part {
+                    StringPart::Literal(text) => StringPart::Literal(text),
+                    StringPart::Interpolation(hole) => {
+                        StringPart::Interpolation(Box::new(replace_placeholders(*hole, counter)))
+                    }
+                })
                 .collect(),
             span,
         },

--- a/crates/klassic-syntax/src/lib.rs
+++ b/crates/klassic-syntax/src/lib.rs
@@ -151,6 +151,10 @@ pub enum Expr {
         value: String,
         span: Span,
     },
+    StringInterpolation {
+        parts: Vec<StringPart>,
+        span: Span,
+    },
     Null {
         span: Span,
     },
@@ -345,6 +349,14 @@ pub enum Expr {
     },
 }
 
+/// One piece of an interpolated string: either literal text or an
+/// expression hole (`#{ ... }`) parsed with the full grammar.
+#[derive(Clone, Debug, PartialEq)]
+pub enum StringPart {
+    Literal(String),
+    Interpolation(Box<Expr>),
+}
+
 impl Expr {
     pub fn span(&self) -> Span {
         match self {
@@ -352,6 +364,7 @@ impl Expr {
             | Self::Double { span, .. }
             | Self::Bool { span, .. }
             | Self::String { span, .. }
+            | Self::StringInterpolation { span, .. }
             | Self::Null { span }
             | Self::Unit { span }
             | Self::Identifier { span, .. }
@@ -399,6 +412,12 @@ enum TokenKind {
     Int(i64, IntLiteralKind),
     Double(f64, FloatLiteralKind),
     String(String),
+    // Interpolated string template pieces. A string with `#{...}` holes
+    // lexes as `StringStart(text)` ‹hole tokens› (`StringMid(text)` ‹hole›)*
+    // `StringEnd(text)`; the hole tokens are ordinary expression tokens.
+    StringStart(String),
+    StringMid(String),
+    StringEnd(String),
     Identifier(String),
     True,
     False,
@@ -475,9 +494,22 @@ pub fn parse_inline_expression(name: &str, text: &str) -> Result<Expr, Diagnosti
     parse_source(&source)
 }
 
+/// How a string segment ended while scanning literal content.
+enum SegmentEnd {
+    /// The closing `"` of the string literal.
+    Quote,
+    /// A `#{` opening an interpolation hole.
+    Interpolation,
+}
+
 struct Lexer<'a> {
     input: &'a str,
     position: usize,
+    /// Brace nesting depth for each currently-open `#{ ... }` hole. While
+    /// this is non-empty the lexer is inside an interpolation: `{`/`}`
+    /// adjust the top depth, and a `}` at depth 0 closes the hole and
+    /// resumes lexing the enclosing string literal.
+    interp_braces: Vec<usize>,
 }
 
 impl<'a> Lexer<'a> {
@@ -485,6 +517,7 @@ impl<'a> Lexer<'a> {
         Self {
             input: source.text(),
             position: 0,
+            interp_braces: Vec::new(),
         }
     }
 
@@ -544,10 +577,23 @@ impl<'a> Lexer<'a> {
             }
             Some('{') => {
                 self.bump_char();
+                if let Some(depth) = self.interp_braces.last_mut() {
+                    *depth += 1;
+                }
                 TokenKind::LBrace
             }
             Some('}') => {
+                if self.interp_braces.last() == Some(&0) {
+                    // Closes the innermost interpolation hole; resume the
+                    // enclosing string literal where the hole opened.
+                    self.bump_char();
+                    self.interp_braces.pop();
+                    return self.lex_string_resume(start);
+                }
                 self.bump_char();
+                if let Some(depth) = self.interp_braces.last_mut() {
+                    *depth -= 1;
+                }
                 TokenKind::RBrace
             }
             Some('+') => {
@@ -644,7 +690,7 @@ impl<'a> Lexer<'a> {
                 self.bump_char();
                 TokenKind::Caret
             }
-            Some('"') => return self.lex_string(),
+            Some('"') => return self.lex_string_open(),
             Some(ch) if ch.is_ascii_digit() => return self.lex_number(),
             Some(ch) if Self::is_identifier_start(ch) => return self.lex_identifier(),
             Some(ch) => {
@@ -772,11 +818,51 @@ impl<'a> Lexer<'a> {
         })
     }
 
-    fn lex_string(&mut self) -> Result<Token, Diagnostic> {
+    /// Lex a string literal beginning at the opening `"`. Produces a plain
+    /// `String` token, or — when the literal contains a `#{` hole —
+    /// `StringStart(text)`, pushing a fresh interpolation context whose
+    /// hole tokens are then lexed by the normal `next_token` loop.
+    fn lex_string_open(&mut self) -> Result<Token, Diagnostic> {
         let start = self.position;
-        self.bump_char();
-        let mut value = String::new();
+        self.bump_char(); // opening '"'
+        let (text, end) = self.read_string_segment(start)?;
+        let kind = match end {
+            SegmentEnd::Quote => TokenKind::String(text),
+            SegmentEnd::Interpolation => {
+                self.interp_braces.push(0);
+                TokenKind::StringStart(text)
+            }
+        };
+        Ok(Token {
+            kind,
+            span: Span::new(start, self.position),
+        })
+    }
 
+    /// Resume the enclosing string literal after a hole's closing `}` was
+    /// consumed. Produces `StringMid(text)` (another hole follows) or
+    /// `StringEnd(text)` (the literal closes). `start` is the position of
+    /// the `}` that closed the preceding hole.
+    fn lex_string_resume(&mut self, start: usize) -> Result<Token, Diagnostic> {
+        let (text, end) = self.read_string_segment(start)?;
+        let kind = match end {
+            SegmentEnd::Quote => TokenKind::StringEnd(text),
+            SegmentEnd::Interpolation => {
+                self.interp_braces.push(0);
+                TokenKind::StringMid(text)
+            }
+        };
+        Ok(Token {
+            kind,
+            span: Span::new(start, self.position),
+        })
+    }
+
+    /// Read string content (decoding escapes) up to and consuming either a
+    /// closing `"` or a `#{` hole opener. The opening `"` (or the prior
+    /// hole's `}`) must already have been consumed.
+    fn read_string_segment(&mut self, start: usize) -> Result<(String, SegmentEnd), Diagnostic> {
+        let mut value = String::new();
         loop {
             match self.peek_char() {
                 None => {
@@ -788,7 +874,12 @@ impl<'a> Lexer<'a> {
                 }
                 Some('"') => {
                     self.bump_char();
-                    break;
+                    return Ok((value, SegmentEnd::Quote));
+                }
+                Some('#') if self.peek_nth_char(1) == Some('{') => {
+                    self.bump_char(); // '#'
+                    self.bump_char(); // '{'
+                    return Ok((value, SegmentEnd::Interpolation));
                 }
                 Some('\\') => {
                     self.bump_char();
@@ -823,11 +914,6 @@ impl<'a> Lexer<'a> {
                 }
             }
         }
-
-        Ok(Token {
-            kind: TokenKind::String(value),
-            span: Span::new(start, self.position),
-        })
     }
 
     fn skip_trivia(&mut self) -> Result<(), Diagnostic> {
@@ -2542,6 +2628,44 @@ impl Parser {
         Ok(rewrap_span(lambda, start.merge(end)))
     }
 
+    /// Parse an interpolated string literal. The lexer has already split
+    /// it into `StringStart(text)` ‹hole tokens› (`StringMid(text)` ‹hole›)*
+    /// `StringEnd(text)`, so each hole is parsed with the full expression
+    /// grammar between the template tokens.
+    fn parse_string_interpolation(&mut self) -> Result<Expr, Diagnostic> {
+        let start = self.peek().span;
+        let TokenKind::StringStart(leading) = self.peek().kind.clone() else {
+            return Err(Diagnostic::parse(start, "expected a string interpolation"));
+        };
+        self.bump();
+        let mut parts = vec![StringPart::Literal(leading)];
+        loop {
+            let hole = self.parse_expression()?;
+            parts.push(StringPart::Interpolation(Box::new(hole)));
+            self.consume_separators();
+            match self.peek().kind.clone() {
+                TokenKind::StringMid(text) => {
+                    self.bump();
+                    parts.push(StringPart::Literal(text));
+                }
+                TokenKind::StringEnd(text) => {
+                    let end = self.bump().span;
+                    parts.push(StringPart::Literal(text));
+                    return Ok(Expr::StringInterpolation {
+                        parts,
+                        span: start.merge(end),
+                    });
+                }
+                _ => {
+                    return Err(Diagnostic::parse(
+                        self.peek().span,
+                        "expected `}` to close the string interpolation",
+                    ));
+                }
+            }
+        }
+    }
+
     fn parse_primary(&mut self) -> Result<Expr, Diagnostic> {
         match self.peek().kind.clone() {
             TokenKind::Int(value, kind) => {
@@ -2564,6 +2688,7 @@ impl Parser {
                 let token = self.bump().span;
                 Ok(Expr::String { value, span: token })
             }
+            TokenKind::StringStart(_) => self.parse_string_interpolation(),
             TokenKind::True => {
                 let token = self.bump().span;
                 Ok(Expr::Bool {
@@ -3311,6 +3436,10 @@ impl Parser {
                         | TokenKind::RParen
                         | TokenKind::RBracket
                         | TokenKind::RBrace
+                        // A cast that ends a `#{ ... }` hole is terminated by
+                        // the interpolation template token, e.g. `#{x :> *}`.
+                        | TokenKind::StringMid(_)
+                        | TokenKind::StringEnd(_)
                 ) && paren_depth == 0
                     && bracket_depth == 0
                     && brace_depth == 0
@@ -3800,6 +3929,9 @@ impl TokenMarker {
 
 fn token_text(kind: &TokenKind) -> String {
     match kind {
+        TokenKind::StringStart(value) => format!("\"{value}#{{"),
+        TokenKind::StringMid(value) => format!("}}{value}#{{"),
+        TokenKind::StringEnd(value) => format!("}}{value}\""),
         TokenKind::Int(value, kind) => match kind {
             IntLiteralKind::Byte => format!("{value}BY"),
             IntLiteralKind::Short => format!("{value}S"),
@@ -3918,6 +4050,7 @@ fn needs_spacing_between(previous: Option<&TokenKind>, next: Option<&TokenKind>)
 
 fn rewrap_span(expr: Expr, span: Span) -> Expr {
     match expr {
+        Expr::StringInterpolation { parts, .. } => Expr::StringInterpolation { parts, span },
         Expr::Int { value, kind, .. } => Expr::Int { value, kind, span },
         Expr::Double { value, kind, .. } => Expr::Double { value, kind, span },
         Expr::Bool { value, .. } => Expr::Bool { value, span },

--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -3,8 +3,8 @@ use std::collections::{HashMap, HashSet};
 
 use klassic_span::{Diagnostic, DiagnosticKind, Severity, Span};
 use klassic_syntax::{
-    Expr, FloatLiteralKind, IntLiteralKind, RecordField, TypeAnnotation, TypeClassConstraint,
-    TypeClassMethod,
+    Expr, FloatLiteralKind, IntLiteralKind, RecordField, StringPart, TypeAnnotation,
+    TypeClassConstraint, TypeClassMethod,
 };
 
 pub mod proof;
@@ -1394,6 +1394,17 @@ impl TypeChecker {
             }),
             Expr::Bool { .. } => Ok(Type::Bool),
             Expr::String { .. } => Ok(Type::String),
+            Expr::StringInterpolation { parts, .. } => {
+                // Type-check every hole so a type error inside `#{ ... }` is
+                // reported; any value is displayable, so the whole literal
+                // is a `String`.
+                for part in parts {
+                    if let StringPart::Interpolation(hole) = part {
+                        self.infer_expr(hole)?;
+                    }
+                }
+                Ok(Type::String)
+            }
             Expr::Null { .. } => Ok(Type::Null),
             Expr::Unit { .. } => Ok(Type::Unit),
             Expr::Identifier { name, span } => {
@@ -5810,6 +5821,18 @@ fn substitute_expr_identifiers(expr: &Expr, substitutions: &HashMap<String, Expr
         | Expr::EnumDeclaration { .. }
         | Expr::Match { .. }
         | Expr::PegRuleBlock { .. } => expr.clone(),
+        Expr::StringInterpolation { parts, span } => Expr::StringInterpolation {
+            parts: parts
+                .iter()
+                .map(|part| match part {
+                    StringPart::Literal(text) => StringPart::Literal(text.clone()),
+                    StringPart::Interpolation(hole) => StringPart::Interpolation(Box::new(
+                        substitute_expr_identifiers(hole, substitutions),
+                    )),
+                })
+                .collect(),
+            span: *span,
+        },
         Expr::Identifier { name, .. } => substitutions
             .get(name)
             .cloned()

--- a/crates/klassic-types/src/proof.rs
+++ b/crates/klassic-types/src/proof.rs
@@ -13,7 +13,7 @@
 use std::collections::{HashMap, HashSet};
 
 use klassic_span::{Diagnostic, Span};
-use klassic_syntax::Expr;
+use klassic_syntax::{Expr, StringPart};
 
 #[derive(Clone, Debug)]
 pub struct ProofDefinition {
@@ -260,6 +260,13 @@ fn collect_referenced_proof_names(
         | Expr::String { .. }
         | Expr::Null { .. }
         | Expr::Unit { .. } => {}
+        Expr::StringInterpolation { parts, .. } => {
+            for part in parts {
+                if let StringPart::Interpolation(hole) = part {
+                    collect_referenced_proof_names(hole, names, dependencies);
+                }
+            }
+        }
         Expr::InstanceDeclaration { methods, .. }
         | Expr::ExtensionDeclaration { methods, .. }
         | Expr::Block {

--- a/docs/book/src/tour/strings.md
+++ b/docs/book/src/tour/strings.md
@@ -22,7 +22,14 @@ println(greeting)   // Hello, Klassic!
 ```
 
 `#{...}` evaluates an arbitrary expression and splices its rendering
-into the surrounding string.
+into the surrounding string. A hole is parsed with the full expression
+grammar, so it may contain blocks, `match`, and even nested interpolated
+strings to any depth:
+
+```kl
+val x = 9
+println("outer #{ "inner #{x}" }")   // outer inner 9
+```
 
 ## Concatenation
 

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -637,6 +637,108 @@ fn record_literal_immediate_dot_access() {
     assert_eq!(String::from_utf8_lossy(&out.stdout), "1\n5\n()\n");
 }
 
+/// The interpolation lexer is stateful, so `#{ ... }` holes are parsed
+/// with the full grammar: blocks, `match`, records, `:> *` casts, and
+/// nested interpolated strings (`#{ "inner #{x}" }`) work to arbitrary
+/// depth. (The evaluator previously mis-scanned any `}` inside a hole.)
+#[test]
+fn string_interpolation_arbitrary_nesting() {
+    let cases = [
+        // Nested braces in an `if` — the evaluator's old scanner broke here.
+        (
+            "val c = true\nprintln(\"r=#{if(c) { 10 } else { 20 }}\")",
+            "r=10\n()\n",
+        ),
+        // A `match` (with a nested string in an arm) inside a hole.
+        (
+            "enum E { case A; case B }\nval x = A\nprintln(\"m=#{x match { case A => \"ay\"; case B => \"bee\" }}\")",
+            "m=ay\n()\n",
+        ),
+        // A nested interpolated string inside a hole.
+        (
+            "val x = 9\nprintln(\"o #{ \"in #{x}\" } e\")",
+            "o in 9 e\n()\n",
+        ),
+        // A `:> *` dynamic cast inside a hole.
+        ("val x = 5\nprintln(\"c=#{x :> *}\")", "c=5\n()\n"),
+        // Record-literal dot access inside a hole.
+        ("println(\"#{record { v: 7 }.v}\")", "7\n()\n"),
+        // Adjacent holes with an empty literal between them.
+        ("val a = 1\nval b = 2\nprintln(\"#{a}#{b}\")", "12\n()\n"),
+    ];
+    for (src, expected) in cases {
+        let out = Command::new(klassic_bin())
+            .args(["-e", src])
+            .output()
+            .expect("binary should run");
+        assert!(
+            out.status.success(),
+            "`{src}` should evaluate\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout),
+            expected,
+            "wrong output for `{src}`"
+        );
+    }
+}
+
+/// eval and native agree on interpolation with nested braces and a nested
+/// interpolated string — cases the old per-backend scanners handled
+/// inconsistently (the evaluator could not nest braces at all).
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_string_interpolation_nesting_matches_eval() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-interp-nesting-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-interp-nesting-{unique}"));
+    let program =
+        "val c = true\nval x = 9\nprintln(\"r=#{if(c) { 10 } else { 20 }} n=#{ \"in #{x}\" }\")\n";
+    fs::write(&source_path, program).expect("source should write");
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(
+        eval.status.success(),
+        "eval failed:\n{}",
+        String::from_utf8_lossy(&eval.stderr)
+    );
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(String::from_utf8_lossy(&eval.stdout), "r=10 n=in 9\n");
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&eval.stdout),
+        "native output must match eval"
+    );
+}
+
 /// Syntax errors for the parenthesization Klassic requires (and the
 /// `field: value` record syntax) carry a keyword-specific hint instead
 /// of the bare `expected (`, so users coming from Kotlin/Scala/Rust see
@@ -17407,13 +17509,13 @@ fn builds_native_executable_for_runtime_literal_display_fragments() {
 val runtime = FileInput#all(path)
 mutable hits = 0
 val listText = toString([{{ hits += 1; runtime }}, {{ hits += 1; "tail" }}])
-val listInterpolated = "list=#{{[{{ hits += 1; runtime }}, {{ hits += 1; \"tail\" }}]}}"
+val listInterpolated = "list=#{{[{{ hits += 1; runtime }}, {{ hits += 1; "tail" }}]}}"
 val listConcat = "list=" + [{{ hits += 1; runtime }}, {{ hits += 1; "tail" }}]
 val mapText = toString(%[{{ hits += 1; runtime }}: {{ hits += 1; "value" }}])
-val mapInterpolated = "map=#{{%[{{ hits += 1; runtime }}: {{ hits += 1; \"value\" }}]}}"
+val mapInterpolated = "map=#{{%[{{ hits += 1; runtime }}: {{ hits += 1; "value" }}]}}"
 val mapConcat = "map=" + %[{{ hits += 1; runtime }}: {{ hits += 1; "value" }}]
 val setText = toString(%({{ hits += 1; runtime }}, {{ hits += 1; "tail" }}, {{ hits += 1; runtime }}))
-val setInterpolated = "set=#{{%({{ hits += 1; runtime }}, {{ hits += 1; \"tail\" }}, {{ hits += 1; runtime }})}}"
+val setInterpolated = "set=#{{%({{ hits += 1; runtime }}, {{ hits += 1; "tail" }}, {{ hits += 1; runtime }})}}"
 val setConcat = "set=" + %({{ hits += 1; runtime }}, {{ hits += 1; "tail" }}, {{ hits += 1; runtime }})
 println(listText)
 println(listInterpolated)


### PR DESCRIPTION
## What

String interpolation was scanned ad-hoc from the raw string value in **four**
separate places (the evaluator and three native paths), each re-counting
delimiters and re-parsing the hole text. The copies diverged:

- the evaluator never tracked brace depth, so `"#{ if c { 1 } else { 0 } }"`
  mis-scanned at the first inner `}` (native handled it — a real eval/native
  parity gap);
- none understood nested string literals, so `"#{ "inner #{x}" }"` could not be
  written at all.

This replaces the scanners with an **interpolation-aware (stateful) lexer**. A
string with `#{` holes lexes as:

```
StringStart(text) ‹hole tokens› (StringMid(text) ‹hole›)* StringEnd(text)
```

The lexer keeps a per-hole brace-depth stack and re-enters string mode on a
nested `"`, so holes are tokenized with the normal grammar and nest to any
depth — blocks, `match`, records, and nested interpolated strings. The parser
builds a structured `Expr::StringInterpolation { parts }` node whose holes are
real sub-expressions, and every backend consumes that node directly.

## Consequences

- The evaluator brace-depth bug is fixed; eval and native agree byte-for-byte.
- Holes are now **type-checked** (previously a no-op) and go through the rewrite
  pass, so placeholder desugaring works inside `#{ ... }`.
- `:> *` is a normal parsed cast in a hole, so the `strip_dynamic_cast` string
  hack is deleted from both the evaluator and the native backend; the four
  ad-hoc scanners are removed (net −360 lines of scanning code).
- aarch64 and the C backend report a clean *unsupported* diagnostic for an
  interpolated string and still compile plain string literals.

### Migration note

A nested string inside a hole is now written with real quotes (`#{ "x" }`)
instead of the previous escaped form (`#{ \"x\" }`). The one test that used the
old form is migrated.

## Test plan

- New `string_interpolation_arbitrary_nesting` (eval) and
  `native_string_interpolation_nesting_matches_eval` (eval==native) tests cover
  nested braces, `match`, records, `:> *`, adjacent holes, and nested strings.
- A 12-case eval==native parity sweep passes; all existing interpolation tests
  (including `test-programs/string-interpolation.kl` and the native
  side-effect/GC/list-display tests) stay green.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
  and `cargo test` all green.
- Tour example in `strings.md` is execution-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)