### PR TITLE
fix: report the missing brace for an unclosed block

### DIFF
--- a/crates/klassic-syntax/src/lib.rs
+++ b/crates/klassic-syntax/src/lib.rs
@@ -1052,6 +1052,15 @@ impl Parser {
             if self.consume_separators() {
                 continue;
             }
+            // Reaching end-of-input here means a block's closing `}` is
+            // missing — the top-level caller ends on `Eof` and never gets
+            // here, so an `Eof` always implies an unclosed block.
+            if matches!(self.peek().kind, TokenKind::Eof) {
+                return Err(
+                    Diagnostic::parse(self.peek().span, "expected `}` to close the block")
+                        .with_incomplete_input(),
+                );
+            }
             return Err(Diagnostic::parse(
                 self.peek().span,
                 "expected a newline or `;` between expressions",

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -769,6 +769,39 @@ fn helpful_syntax_diagnostics() {
     }
 }
 
+/// A block that reaches end-of-input without its closing `}` reports the
+/// missing brace, instead of the misleading "expected a newline or `;`
+/// between expressions" — while a genuine missing separator still does.
+#[test]
+fn unclosed_block_reports_missing_brace() {
+    let unclosed = Command::new(klassic_bin())
+        .args(["-e", "val x = { 1 + 2"])
+        .output()
+        .expect("binary should run");
+    assert!(!unclosed.status.success(), "unclosed block should fail");
+    assert!(
+        String::from_utf8_lossy(&unclosed.stderr).contains("expected `}` to close the block"),
+        "expected a missing-brace hint, got:\n{}",
+        String::from_utf8_lossy(&unclosed.stderr)
+    );
+
+    // A real missing separator between two expressions keeps its own hint.
+    let no_separator = Command::new(klassic_bin())
+        .args(["-e", "{ 1 2 }"])
+        .output()
+        .expect("binary should run");
+    assert!(
+        !no_separator.status.success(),
+        "missing separator should fail"
+    );
+    assert!(
+        String::from_utf8_lossy(&no_separator.stderr)
+            .contains("expected a newline or `;` between expressions"),
+        "expected a separator hint, got:\n{}",
+        String::from_utf8_lossy(&no_separator.stderr)
+    );
+}
+
 /// CI guard: the direct Mach-O backend's binaries can only run on
 /// Apple Silicon, so every test that builds *and executes* that
 /// backend's output is `#[cfg(all(target_os = "macos", target_arch =


### PR DESCRIPTION
## What

A block that reached end-of-input before its closing `}` reported a misleading
error:

```kl
val x = { 1 + 2
// before: expected a newline or `;` between expressions
// after:  expected `}` to close the block
```

`parse_sequence_until` only ends on `Eof` for the top-level program, so reaching
its separator error with the current token at `Eof` always means a block's `}`
is missing. Report that (with the incomplete-input flag), and keep the separator
hint for a genuine missing separator (`{ 1 2 }`).

## Test plan

- New `unclosed_block_reports_missing_brace` cli_smoke test covers the
  unclosed-block and missing-separator cases.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
  `cargo test` all green. Parser diagnostic only; codegen/runtime unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)