### PR TITLE
fix: type-check list `.foldLeft` against the element type

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -4404,10 +4404,19 @@ impl TypeChecker {
                 // once) and `xs.foldLeft(init)(f)` (curried) — the
                 // latter partial-applies this type, and the runtime
                 // goes through apply_callable so the partial completes.
-                "foldLeft" => Some(Type::Function(
-                    vec![Type::Dynamic, Type::Dynamic],
-                    Box::new(Type::Dynamic),
-                )),
+                // `xs.foldLeft(init, f)` over a `List<a>` ties the folder to
+                // the element type: `init` and the result share an
+                // accumulator type `b`, and `f` is `(b, a) -> b`. This
+                // rejects, e.g., a folder that treats the `Int` element as a
+                // `String`, instead of typing every position as `Dynamic`.
+                "foldLeft" => {
+                    let acc = self.fresh_var();
+                    let folder = Type::Function(
+                        vec![acc.clone(), inner.as_ref().clone()],
+                        Box::new(acc.clone()),
+                    );
+                    Some(Type::Function(vec![acc.clone(), folder], Box::new(acc)))
+                }
                 _ => None,
             },
             Type::Map(key, value) => match field {

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -481,6 +481,44 @@ fn map_key_value_methods_are_typed() {
     }
 }
 
+/// `xs.foldLeft(init, f)` over a `List<a>` ties the folder to the element
+/// type — `init` and the result share an accumulator type and `f` is
+/// `(acc, a) -> acc` — so a valid numeric/string fold works but a folder
+/// that treats the `Int` element as a `String` is a type error.
+#[test]
+fn list_foldleft_is_element_typed() {
+    let good = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "println([1 2 3].foldLeft(0, (acc, x) => acc + x))\nprintln([\"a\" \"b\"].foldLeft(\"\", (acc, x) => acc + x))",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        good.status.success(),
+        "valid folds should evaluate\nstderr:\n{}",
+        String::from_utf8_lossy(&good.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&good.stdout), "6\nab\n()\n");
+
+    let bad = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "println([1 2 3].foldLeft(0, (acc, x) => acc + length(x)))",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        !bad.status.success(),
+        "treating an Int element as a String should be a type error"
+    );
+    assert!(
+        String::from_utf8_lossy(&bad.stderr).contains("String is not compatible with Int"),
+        "expected an element type error, got:\n{}",
+        String::from_utf8_lossy(&bad.stderr)
+    );
+}
+
 /// Regressions for three stdlib correctness bugs: `stdlibIsOdd` returned
 /// false for negative odd numbers, `sortBy`/`sort` reversed the relative
 /// order of equal-key elements (unstable sort), and `indent("")` produced


### PR DESCRIPTION
## What

`xs.foldLeft(init, f)` over a `List<a>` typed all three positions (accumulator,
element, result) as `Dynamic`, so an ill-typed folder was silently accepted and
only failed at run time:

```kl
[1 2 3].foldLeft(0, (acc, x) => acc + length(x))
// before: runtime "length expects a string" (x is an Int)
// after:  compile error: String is not compatible with Int
```

The method is now typed `(b, (b, a) -> b) -> b`: `init` and the result share a
fresh accumulator type `b`, and the folder takes the receiver's element type
`a`. Valid numeric/string folds keep working (`foldLeft(0, (a, x) => a + x)`,
`foldLeft("", (a, x) => a + x)`).

This continues the soundness series that typed `.map` (#454), `.contains`
(#455), and the Map key/value methods (#456).

## Test plan

- New `list_foldleft_is_element_typed` cli_smoke test: good Int/String folds
  evaluate; an element-type mismatch is rejected.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
  `cargo test` all green. eval and native agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)