### PR TITLE
fix: reject a negative index in std.list.at

### DIFF
--- a/stdlib/std/list.kl
+++ b/stdlib/std/list.kl
@@ -122,8 +122,10 @@ def slice(xs, from, to) = {
 // ---------- at --------------------------------------------------------------
 
 // Indexed access: the element at index `i` (zero-based). An out-of-range
-// index raises the existing head-on-empty error.
-def at(xs, i) = head(drop(xs, i))
+// index raises the existing head-on-empty error. A negative index is
+// out of range too (without the guard `drop` treats it as 0 and returns
+// the head).
+def at(xs, i) = if(i < 0) head([]) else head(drop(xs, i))
 
 // ---------- scanLeft --------------------------------------------------------
 

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -561,6 +561,40 @@ fn stdlib_correctness_regressions() {
     }
 }
 
+/// `std.list.at` treats a negative index as out of range — raising the
+/// same head-on-empty error as a too-large index — instead of silently
+/// returning the head element (`drop` treats a negative count as 0).
+#[test]
+fn list_at_rejects_negative_index() {
+    let good = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "import std.list.{at}\nprintln(at([10 20 30], 0))\nprintln(at([10 20 30], 2))",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        good.status.success(),
+        "in-range access should evaluate\nstderr:\n{}",
+        String::from_utf8_lossy(&good.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&good.stdout), "10\n30\n()\n");
+
+    let negative = Command::new(klassic_bin())
+        .args(["-e", "import std.list.{at}\nprintln(at([10 20 30], -1))"])
+        .output()
+        .expect("binary should run");
+    assert!(
+        !negative.status.success(),
+        "a negative index should be out of range"
+    );
+    assert!(
+        String::from_utf8_lossy(&negative.stderr).contains("head expects a non-empty list"),
+        "expected an out-of-range error, got:\n{}",
+        String::from_utf8_lossy(&negative.stderr)
+    );
+}
+
 /// A `->` (thin arrow) in a type annotation is accepted as an alias for
 /// `=>`, so `(Int) -> Int` parses as a function type (in `val` and
 /// parameter annotations, and curried) instead of an opaque Named type


### PR DESCRIPTION
## What

`at(xs, i)` is `head(drop(xs, i))`, and `drop` treats a negative count as 0, so
a negative index silently returned the head element instead of being out of
range:

```kl
import std.list.{at}
at([10 20 30], -1)   // before: 10   after: out-of-range error
at([10 20 30], 5)    // already: out-of-range error
```

The doc comment already states an out-of-range index raises the head-on-empty
error; guard `i < 0` so a negative index does too, matching a too-large index.

## Test plan

- New `list_at_rejects_negative_index` cli_smoke test: in-range access works, a
  negative index is rejected.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
  `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)