### PR TITLE
feat: accept trailing commas in calls, parameter lists, and lambdas

### DIFF
--- a/crates/klassic-syntax/src/lib.rs
+++ b/crates/klassic-syntax/src/lib.rs
@@ -2382,6 +2382,10 @@ impl Parser {
                         if matches!(self.peek().kind, TokenKind::Comma) {
                             self.bump();
                             self.consume_separators();
+                            // Allow a trailing comma, like collection literals.
+                            if matches!(self.peek().kind, TokenKind::RParen) {
+                                break;
+                            }
                             continue;
                         }
                         break;
@@ -2969,6 +2973,10 @@ impl Parser {
                 if matches!(self.peek().kind, TokenKind::Comma) {
                     self.bump();
                     self.consume_separators();
+                    // Allow a trailing comma in the parameter list.
+                    if matches!(self.peek().kind, TokenKind::RParen) {
+                        break;
+                    }
                     continue;
                 }
                 break;
@@ -3003,6 +3011,10 @@ impl Parser {
                 if matches!(self.peek().kind, TokenKind::Comma) {
                     self.bump();
                     self.consume_separators();
+                    // Allow a trailing comma in the parameter list.
+                    if matches!(self.peek().kind, TokenKind::RParen) {
+                        break;
+                    }
                     continue;
                 }
                 break;
@@ -3068,6 +3080,17 @@ impl Parser {
             match self.tokens.get(index).map(|token| &token.kind) {
                 Some(TokenKind::Comma) => {
                     index += 1;
+                    // A trailing comma before `)` still looks like a lambda.
+                    if matches!(
+                        self.tokens.get(index).map(|token| &token.kind),
+                        Some(TokenKind::RParen)
+                    ) {
+                        index += 1;
+                        return matches!(
+                            self.tokens.get(index).map(|token| &token.kind),
+                            Some(TokenKind::FatArrow)
+                        );
+                    }
                 }
                 Some(TokenKind::RParen) => {
                     index += 1;

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -874,6 +874,35 @@ fn unclosed_block_reports_missing_brace() {
     );
 }
 
+/// A trailing comma is accepted in function calls, parameter lists, and
+/// lambda parameters, matching the collection literals that already
+/// allow it — while an empty `(,)` is still a syntax error.
+#[test]
+fn trailing_comma_in_calls_params_and_lambdas() {
+    let good = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "def f(x, y,) = x + y\nval g = (a,) => a * 2\nprintln(f(1, 2,))\nprintln(g(5))",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        good.status.success(),
+        "trailing commas should parse\nstderr:\n{}",
+        String::from_utf8_lossy(&good.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&good.stdout), "3\n10\n()\n");
+
+    // An empty argument list with only a comma is still rejected.
+    for src in ["def f(x) = x\nf(,)", "val g = (,) => 1"] {
+        let bad = Command::new(klassic_bin())
+            .args(["-e", src])
+            .output()
+            .expect("binary should run");
+        assert!(!bad.status.success(), "`{src}` should be a syntax error");
+    }
+}
+
 /// CI guard: the direct Mach-O backend's binaries can only run on
 /// Apple Silicon, so every test that builds *and executes* that
 /// backend's output is `#[cfg(all(target_os = "macos", target_arch =


### PR DESCRIPTION
## What

Collection literals (`[1, 2, 3,]`, `%(1, 2,)`, `%["a": 1,]`) accepted a trailing
comma, but function calls, `def` parameter lists, and lambda parameters did not:

```kl
f(1, 2,)      // before: expected an expression
def f(x,) = x // before: expected an identifier
(x,) => x     // before: expected `)`
```

Mirror the collection-literal pattern: after consuming a comma, stop on the
closing `)`. `looks_like_lambda` is taught the same so `(x,) => x` is still
recognized as a lambda. An empty `f(,)` / `(,) => ...` remains a syntax error,
and the change only widens accepted input.

## Test plan

- New `trailing_comma_in_calls_params_and_lambdas` cli_smoke test covers calls,
  params, and lambda params, plus the rejected empty cases.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
  `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)