### PR TITLE
fix: drop the phantom trailing line from std.string.lines()

### DIFF
--- a/stdlib/std/string.kl
+++ b/stdlib/std/string.kl
@@ -8,7 +8,10 @@ module std.string
 extension (this: String) {
   def isEmpty() = isEmptyString(this)
   def nonEmpty() = if(isEmptyString(this)) false else true
-  def lines() = split(this, "\n")
+  def lines() = {
+    val parts = split(this, "\n")
+    if(isEmptyString(stdlibLast(parts))) stdlibTake(parts, size(parts) - 1) else parts
+  }
   def words() = stdlibFilter(split(this, " "), (w) => if(isEmptyString(w)) false else true)
   def lengthChars() = length(this)
   def reverseChars() = reverse(this)

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -595,6 +595,47 @@ fn list_at_rejects_negative_index() {
     );
 }
 
+/// `std.string.lines()` does not emit a phantom empty line for a trailing
+/// newline (or for the empty string), matching Python/Rust/Haskell.
+#[test]
+fn string_lines_drops_trailing_newline() {
+    let cases = [
+        // Empty string has zero lines.
+        ("import std.string\nprintln(size(\"\".lines()))", "0\n()\n"),
+        // A trailing newline does not add an empty line.
+        (
+            "import std.string\nprintln(\"a\\nb\\n\".lines())",
+            "[a, b]\n()\n",
+        ),
+        // No trailing newline: same result.
+        (
+            "import std.string\nprintln(\"a\\nb\".lines())",
+            "[a, b]\n()\n",
+        ),
+        // An interior blank line is preserved.
+        (
+            "import std.string\nprintln(size(\"a\\n\\nb\".lines()))",
+            "3\n()\n",
+        ),
+    ];
+    for (src, expected) in cases {
+        let out = Command::new(klassic_bin())
+            .args(["-e", src])
+            .output()
+            .expect("binary should run");
+        assert!(
+            out.status.success(),
+            "`{src}` should evaluate\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout),
+            expected,
+            "wrong output for `{src}`"
+        );
+    }
+}
+
 /// A `->` (thin arrow) in a type annotation is accepted as an alias for
 /// `=>`, so `(Int) -> Int` parses as a function type (in `val` and
 /// parameter annotations, and curried) instead of an opaque Named type


### PR DESCRIPTION
## What

`lines()` was `split(this, "\n")`, so a trailing newline produced a spurious
empty final element and the empty string produced `[""]`:

```kl
"a\nb\n".lines()   // before: ["a", "b", ""]   after: ["a", "b"]
"".lines()          // before: [""]             after: []
```

Drop a single trailing empty element, matching Python `splitlines`, Rust
`str::lines`, and Haskell `lines`. An interior blank line is preserved
(`"a\n\nb".lines()` -> `["a", "", "b"]`).

## Test plan

- New `string_lines_drops_trailing_newline` cli_smoke test.
- `cargo fmt --check`, `cargo clippy ... -D warnings`, `cargo test` all green.
  eval and native agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)