### PR TITLE
fix: name the offending type/field in three opaque diagnostics

### DIFF
--- a/crates/klassic-eval/src/lib.rs
+++ b/crates/klassic-eval/src/lib.rs
@@ -1253,7 +1253,12 @@ fn eval_expr_inner(
                         Ok(value)
                     }
                 }
-                _ => Err(Diagnostic::runtime(*span, "field access expects a record")),
+                _ => Err(Diagnostic::runtime(
+                    *span,
+                    format!(
+                        "no field `{field}` here; if `{field}` is a method, call it as `{field}()`"
+                    ),
+                )),
             }
         }
         Expr::Cleanup { body, cleanup, .. } => {

--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -551,8 +551,13 @@ impl TypeChecker {
                     return Err(type_error(
                         *span,
                         format!(
-                            "variant `{name}` expects {} fields but got {}",
+                            "variant `{name}` expects {} {} but got {}",
                             field_types.len(),
+                            if field_types.len() == 1 {
+                                "field"
+                            } else {
+                                "fields"
+                            },
                             args.len()
                         ),
                     ));
@@ -1901,7 +1906,13 @@ impl TypeChecker {
                                 Ok(Type::Var(id))
                             }
                             other if other.is_numeric() || other.is_dynamic_like() => Ok(other),
-                            _ => Err(type_error(*span, "arithmetic operator expects numbers")),
+                            other => Err(type_error(
+                                *span,
+                                format!(
+                                    "arithmetic operator requires a numeric type, but got {}",
+                                    display_type(&other)
+                                ),
+                            )),
                         }
                     }
                     BinaryOp::BitAnd | BinaryOp::BitOr | BinaryOp::BitXor => {
@@ -3777,8 +3788,13 @@ impl TypeChecker {
                 return Err(type_error(
                     span,
                     format!(
-                        "record `{name}` expects {} fields but got {}",
+                        "record `{name}` expects {} {} but got {}",
                         schema.fields.len(),
+                        if schema.fields.len() == 1 {
+                            "field"
+                        } else {
+                            "fields"
+                        },
                         arguments.len()
                     ),
                 ));

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -702,6 +702,37 @@ fn type_errors_use_readable_type_var_names() {
     );
 }
 
+/// Several diagnostics name the offending value/type instead of being
+/// opaque: arity messages use the singular "field", non-numeric
+/// arithmetic names the type, and a field access on a non-record names
+/// the field and hints at the method call.
+#[test]
+fn clearer_diagnostic_messages() {
+    let cases = [
+        (
+            "enum Box { case Box(v: Int) }\nval b = Box(1)\nb match { case Box(a, c) => a }",
+            "expects 1 field but got 2",
+        ),
+        ("true + false", "requires a numeric type, but got Boolean"),
+        (
+            "import std.string\n\"hello\".toUpperCase",
+            "if `toUpperCase` is a method, call it as `toUpperCase()`",
+        ),
+    ];
+    for (src, expected) in cases {
+        let out = Command::new(klassic_bin())
+            .args(["-e", src])
+            .output()
+            .expect("binary should run");
+        assert!(!out.status.success(), "`{src}` should fail");
+        assert!(
+            String::from_utf8_lossy(&out.stderr).contains(expected),
+            "`{src}` expected message containing {expected:?}, got:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}
+
 /// A match arm whose constructor an earlier unguarded, irrefutably-bound
 /// arm already matches is reported as unreachable — but a refutable
 /// earlier payload (`case S(1)`) does not close the variant, and guards


### PR DESCRIPTION
## What

Three diagnostics hid the information a reader needs:

- variant/record arity used **"1 fields"** → now agrees in number (`expects 1 field but got 2`).
- non-numeric arithmetic said **"arithmetic operator expects numbers"** → now names the type (`true + false` → `requires a numeric type, but got Boolean`).
- a field access on a non-record said **"field access expects a record"** → now names the field and hints at the method call (`"hello".toUpperCase` → `no field `toUpperCase` here; if `toUpperCase` is a method, call it as `toUpperCase()``).

## Test plan

- New `clearer_diagnostic_messages` cli_smoke test covers all three.
- `cargo fmt --check`, `cargo clippy ... -D warnings`, `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)