### PR TITLE
fix: say "constructor" in an enum constructor arity error

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -1945,17 +1945,19 @@ impl TypeChecker {
                 arguments,
                 span,
             } => {
+                let noun = self.call_target_noun(callee);
                 if let Expr::Identifier { name, .. } = callee.as_ref()
                     && let Some(binding) = self.lookup(name).cloned()
                     && !binding.constraints.is_empty()
                 {
                     let (callee_type, constraints) = self.instantiate_binding_signature(&binding);
-                    let result = self.infer_constrained_call(callee_type, arguments, *span)?;
+                    let result =
+                        self.infer_constrained_call(callee_type, arguments, *span, noun)?;
                     self.ensure_constraints_satisfied(&constraints, *span)?;
                     return Ok(result);
                 }
                 let callee_type = self.infer_expr(callee)?;
-                self.infer_call(callee_type, arguments, *span)
+                self.infer_call(callee_type, arguments, *span, noun)
             }
             Expr::FieldAccess {
                 target,
@@ -2123,11 +2125,24 @@ impl TypeChecker {
         }
     }
 
+    /// Whether a call target is an enum constructor, so arity diagnostics
+    /// can say "constructor" instead of the generic "function".
+    fn call_target_noun(&self, callee: &Expr) -> &'static str {
+        if let Expr::Identifier { name, .. } = callee
+            && self.enum_variant_schema(name).is_some()
+        {
+            "constructor"
+        } else {
+            "function"
+        }
+    }
+
     fn infer_call(
         &mut self,
         callee_type: Type,
         arguments: &[Expr],
         span: Span,
+        noun: &str,
     ) -> Result<Type, Diagnostic> {
         match self.resolve(&callee_type) {
             Type::Function(params, result) => {
@@ -2135,7 +2150,7 @@ impl TypeChecker {
                     return Err(type_error(
                         span,
                         format!(
-                            "function expects {} {} but got {}",
+                            "{noun} expects {} {} but got {}",
                             params.len(),
                             if params.len() == 1 {
                                 "argument"
@@ -2289,6 +2304,7 @@ impl TypeChecker {
         callee_type: Type,
         arguments: &[Expr],
         span: Span,
+        noun: &str,
     ) -> Result<Type, Diagnostic> {
         match self.resolve(&callee_type) {
             Type::Function(params, result) => {
@@ -2296,7 +2312,7 @@ impl TypeChecker {
                     return Err(type_error(
                         span,
                         format!(
-                            "function expects {} {} but got {}",
+                            "{noun} expects {} {} but got {}",
                             params.len(),
                             if params.len() == 1 {
                                 "argument"

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -733,6 +733,37 @@ fn clearer_diagnostic_messages() {
     }
 }
 
+/// An arity mismatch when applying an enum constructor says "constructor"
+/// rather than the generic "function", while a real function still says
+/// "function".
+#[test]
+fn constructor_arity_error_says_constructor() {
+    let ctor = Command::new(klassic_bin())
+        .args(["-e", "enum Shape { case Circle(r: Int) }\nCircle(1, 2)"])
+        .output()
+        .expect("binary should run");
+    assert!(
+        !ctor.status.success(),
+        "wrong constructor arity should fail"
+    );
+    assert!(
+        String::from_utf8_lossy(&ctor.stderr).contains("constructor expects 1 argument but got 2"),
+        "expected a constructor message, got:\n{}",
+        String::from_utf8_lossy(&ctor.stderr)
+    );
+
+    let func = Command::new(klassic_bin())
+        .args(["-e", "def f(x, y) = x + y\nf(1)"])
+        .output()
+        .expect("binary should run");
+    assert!(!func.status.success(), "wrong function arity should fail");
+    assert!(
+        String::from_utf8_lossy(&func.stderr).contains("function expects 2 arguments but got 1"),
+        "expected a function message, got:\n{}",
+        String::from_utf8_lossy(&func.stderr)
+    );
+}
+
 /// A match arm whose constructor an earlier unguarded, irrefutably-bound
 /// arm already matches is reported as unreachable — but a refutable
 /// earlier payload (`case S(1)`) does not close the variant, and guards


### PR DESCRIPTION
## What

Applying an enum constructor with the wrong number of arguments reported the
generic "function":

```kl
enum Shape { case Circle(r: Int) }
Circle(1, 2)   // before: function expects 1 argument but got 2
               // after:  constructor expects 1 argument but got 2
```

The call-inference arity check now takes a noun — "constructor" when the callee
is an identifier naming an enum variant, "function" otherwise.

## Test plan

- New `constructor_arity_error_says_constructor` cli_smoke test covers the
  constructor and function cases.
- `cargo fmt --check`, `cargo clippy ... -D warnings`, `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)