### PR TITLE
fix: point a binding annotation mismatch at the value, not the keyword

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -1662,7 +1662,9 @@ impl TypeChecker {
                 let final_type = if let Some(annotation) = annotation {
                     let mut named = HashMap::new();
                     let declared = self.parse_annotation_with_named_vars(annotation, &mut named);
-                    self.enforce_assignable(declared, value_type, *span)?
+                    // Point a declared-vs-value mismatch at the value, not at
+                    // the start of the `val`/`mutable` keyword.
+                    self.enforce_assignable(declared, value_type, value.span())?
                 } else {
                     value_type
                 };
@@ -1749,7 +1751,10 @@ impl TypeChecker {
                 let body_type = self.infer_expr(body)?;
                 self.pop_scope();
 
-                let resolved_return = self.enforce_assignable(return_type, body_type, *span)?;
+                // Point a return-type mismatch at the body expression, not at
+                // the start of the `def` keyword.
+                let resolved_return =
+                    self.enforce_assignable(return_type, body_type, body.span())?;
                 let resolved_params = param_types
                     .into_iter()
                     .map(|param| self.resolve(&param))

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -764,6 +764,35 @@ fn constructor_arity_error_says_constructor() {
     );
 }
 
+/// A type-annotation mismatch in a `val`/`def` binding points at the
+/// offending value or body expression, not at the start of the keyword.
+#[test]
+fn binding_annotation_mismatch_points_at_value() {
+    let val = Command::new(klassic_bin())
+        .args(["-e", "val x: String = 42"])
+        .output()
+        .expect("binary should run");
+    assert!(!val.status.success(), "the val mismatch should fail");
+    // `42` is at column 17; the `val` keyword is at column 1.
+    assert!(
+        String::from_utf8_lossy(&val.stderr).contains(":1:17:"),
+        "expected the span at the value, got:\n{}",
+        String::from_utf8_lossy(&val.stderr)
+    );
+
+    let def = Command::new(klassic_bin())
+        .args(["-e", "def f(x: String): Int = x"])
+        .output()
+        .expect("binary should run");
+    assert!(!def.status.success(), "the def mismatch should fail");
+    // The body `x` is at column 25; the `def` keyword is at column 1.
+    assert!(
+        String::from_utf8_lossy(&def.stderr).contains(":1:25:"),
+        "expected the span at the body, got:\n{}",
+        String::from_utf8_lossy(&def.stderr)
+    );
+}
+
 /// A match arm whose constructor an earlier unguarded, irrefutably-bound
 /// arm already matches is reported as unreachable — but a refutable
 /// earlier payload (`case S(1)`) does not close the variant, and guards


### PR DESCRIPTION
## What

A type-annotation mismatch in a `val`/`def` binding reported its span at column 1
(the start of the keyword) instead of the offending expression:

```
val x: String = 42          // before: 1:1  after: 1:17 (the `42`)
def f(x: String): Int = x   // before: 1:1  after: 1:25 (the body `x`)
```

Enforce the annotation against the value/body using that expression's span.

## Test plan

- New `binding_annotation_mismatch_points_at_value` cli_smoke test asserts the
  spans land on the value/body.
- `cargo fmt --check`, `cargo clippy ... -D warnings`, `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)