### PR TITLE
fix: resolve stdlib enum type annotations to the imported enum

### DIFF
--- a/crates/klassic-eval/src/lib.rs
+++ b/crates/klassic-eval/src/lib.rs
@@ -1802,6 +1802,7 @@ fn clear_user_modules() {
 fn clear_user_records() {
     USER_RECORDS.with(|records| records.borrow_mut().clear());
     klassic_types::clear_user_record_schemas();
+    klassic_types::clear_user_enum_schemas();
 }
 
 #[cfg(test)]

--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -174,6 +174,7 @@ type ModuleTypeExports = HashMap<String, StoredType>;
 thread_local! {
     static USER_MODULE_TYPES: RefCell<HashMap<String, ModuleTypeExports>> = RefCell::new(HashMap::new());
     static USER_RECORD_SCHEMAS: RefCell<HashMap<String, RecordSchema>> = RefCell::new(HashMap::new());
+    static USER_ENUM_SCHEMAS: RefCell<HashMap<String, EnumSchema>> = RefCell::new(HashMap::new());
     static USER_BINDING_TYPES: RefCell<HashMap<String, StoredType>> = RefCell::new(HashMap::new());
     static USER_TYPECLASS_INFOS: RefCell<HashMap<String, TypeClassInfo>> = RefCell::new(HashMap::new());
     static USER_INSTANCE_INFOS: RefCell<Vec<InstanceInfo>> = const { RefCell::new(Vec::new()) };
@@ -261,6 +262,7 @@ where
     checker.push_scope();
     checker.install_builtins();
     checker.record_schemas.extend(resolve_user_record_schemas());
+    checker.enum_schemas.extend(resolve_user_enum_schemas());
     checker.typeclasses.extend(resolve_user_typeclass_infos());
     checker.instances.extend(resolve_user_instance_types());
     for (name, stored) in resolve_user_binding_types() {
@@ -284,6 +286,7 @@ where
         .map(|ty| display_type(&checker.resolve(&ty)));
     if result.is_ok() {
         export_user_record_schemas(checker.user_record_schemas());
+        export_user_enum_schemas(checker.user_enum_schemas());
         export_user_typeclass_infos(checker.user_typeclass_infos());
         export_user_instance_types(checker.user_instance_types());
         // Module-scoped translation units export their root bindings
@@ -321,6 +324,10 @@ pub fn clear_user_module_types() {
 
 pub fn clear_user_record_schemas() {
     USER_RECORD_SCHEMAS.with(|schemas| schemas.borrow_mut().clear());
+}
+
+pub fn clear_user_enum_schemas() {
+    USER_ENUM_SCHEMAS.with(|schemas| schemas.borrow_mut().clear());
 }
 
 pub fn clear_user_binding_types() {
@@ -490,6 +497,10 @@ impl TypeChecker {
             .filter(|(name, _)| name.as_str() != "Point")
             .map(|(name, schema)| (name.clone(), schema.clone()))
             .collect()
+    }
+
+    fn user_enum_schemas(&self) -> HashMap<String, EnumSchema> {
+        self.enum_schemas.clone()
     }
 
     fn user_typeclass_infos(&self) -> HashMap<String, TypeClassInfo> {
@@ -4563,6 +4574,13 @@ fn export_user_record_schemas(schemas: HashMap<String, RecordSchema>) {
     });
 }
 
+fn export_user_enum_schemas(schemas: HashMap<String, EnumSchema>) {
+    USER_ENUM_SCHEMAS.with(|known| {
+        let mut known = known.borrow_mut();
+        known.extend(schemas);
+    });
+}
+
 fn export_user_binding_types(bindings: HashMap<String, StoredType>) {
     USER_BINDING_TYPES.with(|known| {
         let mut known = known.borrow_mut();
@@ -4586,6 +4604,10 @@ fn export_user_instance_types(instances: Vec<InstanceInfo>) {
 
 fn resolve_user_record_schemas() -> HashMap<String, RecordSchema> {
     USER_RECORD_SCHEMAS.with(|schemas| schemas.borrow().clone())
+}
+
+fn resolve_user_enum_schemas() -> HashMap<String, EnumSchema> {
+    USER_ENUM_SCHEMAS.with(|schemas| schemas.borrow().clone())
 }
 
 fn resolve_user_binding_types() -> HashMap<String, StoredType> {

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -793,6 +793,41 @@ fn binding_annotation_mismatch_points_at_value() {
     );
 }
 
+/// Type annotations that name a stdlib enum (`Option<T>`, `Result<T, E>`)
+/// resolve to the same nominal type the constructors produce, so a `val`,
+/// parameter, or return annotation type-checks — while a genuine element
+/// mismatch is still reported.
+#[test]
+fn stdlib_enum_type_annotations_resolve() {
+    let good = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "import std.option.{some, getOrElse}\nval o: Option<Int> = some(5)\ndef unwrap(p: Option<Int>): Int = getOrElse(p, 0)\nprintln(unwrap(o))",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        good.status.success(),
+        "stdlib enum annotations should type-check\nstderr:\n{}",
+        String::from_utf8_lossy(&good.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&good.stdout), "5\n()\n");
+
+    let bad = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "import std.option.{some}\nval o: Option<Int> = some(\"x\")",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(!bad.status.success(), "an element mismatch should fail");
+    assert!(
+        String::from_utf8_lossy(&bad.stderr).contains("Int is not compatible with String"),
+        "expected an element type error, got:\n{}",
+        String::from_utf8_lossy(&bad.stderr)
+    );
+}
+
 /// A match arm whose constructor an earlier unguarded, irrefutably-bound
 /// arm already matches is reported as unreachable — but a refutable
 /// earlier payload (`case S(1)`) does not close the variant, and guards


### PR DESCRIPTION
## What

A type annotation naming a stdlib enum failed with a misleading error:

```kl
import std.option.{some}
val o: Option<Int> = some(5)
// before: type mismatch: Option<Int> is not compatible with Option<Int>
// after:  ok
```

Record schemas were shared across modules via a thread-local, but enum schemas
were not, so the importing checker did not know `Option` was an enum and left
the annotation an opaque applied `Named` type that could not unify with the
nominal `Enum` the constructors return.

Mirror the record-schema sharing for enums: export each checked unit's
`enum_schemas` into a `USER_ENUM_SCHEMAS` thread-local and load them into each
new checker (clearing them alongside the record schemas). `val`, parameter, and
return annotations referencing `Option<T>` / `Result<T, E>` now type-check.

## Test plan

- New `stdlib_enum_type_annotations_resolve` cli_smoke test: a `val`, parameter,
  and return annotation type-check, and `Option<Int> = some("x")` is still
  reported as `Int is not compatible with String`.
- `cargo fmt --check`, `cargo clippy ... -D warnings`, `cargo test` all green.
  eval and native agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)