### PR TITLE
fix: reject an unknown constructor in a match arm

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -553,6 +553,15 @@ impl TypeChecker {
                 // keep the legacy Dynamic bindings.
                 let Some((enum_name, type_params, field_types)) = self.enum_variant_schema(name)
                 else {
+                    // An unknown constructor matched against a concrete enum
+                    // scrutinee is a mistake (e.g. a typo). Only fall back to
+                    // Dynamic bindings when the scrutinee's enum isn't known.
+                    if let Type::Enum(scrutinee_enum, _) = self.resolve(scrutinee_type) {
+                        return Err(type_error(
+                            *span,
+                            format!("`{name}` is not a constructor of `{scrutinee_enum}`"),
+                        ));
+                    }
                     for arg in args {
                         self.declare_pattern_bindings(arg, &Type::Dynamic)?;
                     }

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -879,6 +879,41 @@ fn duplicate_match_constructor_is_unreachable() {
     }
 }
 
+/// A match arm naming a constructor that does not belong to the scrutinee's
+/// enum (a typo) is a compile-time error instead of being silently accepted.
+#[test]
+fn unknown_match_constructor_is_rejected() {
+    let bad = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "enum Color { case Red; case Blue }\nRed match { case Nonexistent => 0; case Red => 1; case Blue => 2 }",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(!bad.status.success(), "an unknown constructor should fail");
+    assert!(
+        String::from_utf8_lossy(&bad.stderr)
+            .contains("`Nonexistent` is not a constructor of `Color`"),
+        "expected an unknown-constructor error, got:\n{}",
+        String::from_utf8_lossy(&bad.stderr)
+    );
+
+    // Real constructors, variables, and wildcards still type-check.
+    let good = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "enum Color { case Red; case Blue }\nprintln(Red match { case Red => 1; case _ => 2 })",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        good.status.success(),
+        "a valid match should evaluate\nstderr:\n{}",
+        String::from_utf8_lossy(&good.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&good.stdout), "1\n()\n");
+}
+
 /// A structural record literal can be dot-accessed immediately
 /// (`record { x: 1 }.x`), including chained access, instead of requiring
 /// a `val` binding first.


### PR DESCRIPTION
## What

A `match` arm naming a constructor that belongs to no enum (a typo) was silently
accepted:

```kl
enum Color { case Red; case Blue }
Red match { case Nonexistent => 0; case Red => 1; case Blue => 2 }
// before: evaluates to 1, no diagnostic
// after:  `Nonexistent` is not a constructor of `Color`
```

`declare_pattern_bindings` fell back to `Dynamic` sub-pattern bindings for an
unknown constructor. Now, when the scrutinee resolves to a concrete enum, an
unknown constructor is a compile-time error; the `Dynamic` fallback is kept only
when the scrutinee's enum is not statically known, so variable/wildcard arms and
matches on dynamic values are unaffected. (A wrong-enum constructor was already
caught by scrutinee unification; this closes the truly-unknown-name gap.)

## Test plan

- New `unknown_match_constructor_is_rejected` cli_smoke test: the typo fails, a
  valid match with a real constructor + wildcard still evaluates.
- `cargo fmt --check`, `cargo clippy ... -D warnings`, `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)