### PR TITLE
fix: report a nonexistent std.* import as an unknown module

### DIFF
--- a/crates/klassic-types/Cargo.toml
+++ b/crates/klassic-types/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 klassic-span = { path = "../klassic-span" }
 klassic-syntax = { path = "../klassic-syntax" }
+klassic-runtime = { path = "../klassic-runtime" }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -3515,7 +3515,12 @@ impl TypeChecker {
                     "wildcard imports are not supported; list the members explicitly, \
                      e.g. `import {module}.{{a, b}}`"
                 )
-            } else if path.starts_with("std.") {
+            } else if klassic_runtime::STDLIB_MODULES
+                .iter()
+                .any(|module| module.path == path)
+            {
+                // A real stdlib module that resolved here only because it is
+                // not inlined by the current backend (e.g. `std.json` natively).
                 format!(
                     "module `{path}` is part of the standard library but is not yet \
                      available in native builds. Run the program with the evaluator \

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -914,6 +914,29 @@ fn unknown_match_constructor_is_rejected() {
     assert_eq!(String::from_utf8_lossy(&good.stdout), "1\n()\n");
 }
 
+/// Importing a `std.*` module that does not exist reports "unknown module"
+/// rather than the "part of the standard library / not yet available in
+/// native builds" message reserved for real but not-yet-inlined modules.
+#[test]
+fn nonexistent_std_module_says_unknown() {
+    for path in ["std.nonexistent", "std.collections"] {
+        let out = Command::new(klassic_bin())
+            .args(["-e", &format!("import {path}.{{foo}}\n1")])
+            .output()
+            .expect("binary should run");
+        assert!(!out.status.success(), "`{path}` should fail to import");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains(&format!("unknown module `{path}`")),
+            "expected `unknown module` for `{path}`, got:\n{stderr}"
+        );
+        assert!(
+            !stderr.contains("part of the standard library"),
+            "should not claim a nonexistent module is part of the stdlib:\n{stderr}"
+        );
+    }
+}
+
 /// A structural record literal can be dot-accessed immediately
 /// (`record { x: 1 }.x`), including chained access, instead of requiring
 /// a `val` binding first.


### PR DESCRIPTION
## What

Importing any `std.*` path that failed to resolve reported the native-builds
message, even for a path that does not exist:

```kl
import std.nonexistent.{foo}
// before: module `std.nonexistent` is part of the standard library but is not
//         yet available in native builds. Run the program with the evaluator …
// after:  unknown module `std.nonexistent`
```

Gate that message on membership in the real bundled stdlib set
(`klassic_runtime::STDLIB_MODULES`): a genuinely native-unsupported module like
`std.json` keeps it (verified: native build of `import std.json` still reports
it), while an unknown `std.*` path falls through to `unknown module`.

## Test plan

- New `nonexistent_std_module_says_unknown` cli_smoke test.
- Verified `std.list` (real) imports still work and `std.json` native build keeps
  its message.
- `cargo fmt --check`, `cargo clippy ... -D warnings`, `cargo test` all green.
  (`klassic-runtime` is a new dep of `klassic-types`; no cycle.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)