### PR TITLE
fix: refuse native enum equality instead of comparing heap identity

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -6226,6 +6226,17 @@ impl NativeCodeGenerator {
                 .mov_imm64(Reg::Rax, u64::from(equal == (op == BinaryOp::Equal)));
             return Ok(NativeValue::Bool);
         }
+        // A heap value (e.g. an enum constructor) reaching this fallthrough
+        // for `==`/`!=` would be compared by heap identity — two freshly
+        // built copies of the same value have different addresses, so the
+        // result is wrong. Refuse it cleanly instead of silently
+        // miscompiling; structural enum equality is a future feature
+        // (the evaluator already compares them structurally).
+        if matches!(op, BinaryOp::Equal | BinaryOp::NotEqual)
+            && matches!(lhs_value, NativeValue::HeapPointer)
+        {
+            return Err(unsupported(span, "equality of heap values such as enums"));
+        }
         if !matches!(lhs_value, NativeValue::Int | NativeValue::HeapPointer) {
             return Err(unsupported(span, "native binary operation for non-Int lhs"));
         }

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -1059,6 +1059,56 @@ fn native_string_interpolation_nesting_matches_eval() {
     );
 }
 
+/// Native equality of enum values used to silently compare heap identity
+/// (so `Red == Red` returned `false`); it is now refused with a clean
+/// diagnostic rather than miscompiled. The evaluator compares structurally
+/// (the oracle answer is `true`).
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_enum_equality_is_refused_not_miscompiled() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-enum-eq-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-enum-eq-{unique}"));
+    fs::write(
+        &source_path,
+        "enum Color { case Red; case Green }\nprintln(Red == Red)\n",
+    )
+    .expect("source should write");
+
+    // The evaluator (oracle) compares structurally: Red == Red is true.
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(eval.status.success());
+    assert_eq!(String::from_utf8_lossy(&eval.stdout), "true\n");
+
+    // The native build refuses rather than silently returning false.
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+    assert!(
+        !build.status.success(),
+        "native enum equality should be refused, not miscompiled"
+    );
+    assert!(
+        String::from_utf8_lossy(&build.stderr).contains("equality of heap values such as enums"),
+        "expected a clean unsupported diagnostic, got:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+}
+
 /// Syntax errors for the parenthesization Klassic requires (and the
 /// `field: value` record syntax) carry a keyword-specific hint instead
 /// of the bare `expected (`, so users coming from Kotlin/Scala/Rust see


### PR DESCRIPTION
## What

`==` / `!=` on enum values **silently miscompiled** in native builds. Enum values
are `HeapPointer`s, and the binary-op fallthrough compared them with a raw 64-bit
`cmp` — heap identity. Two freshly-built copies of the same value have different
addresses, so the program was accepted and run with the **wrong answer**:

```kl
enum Color { case Red; case Green }
println(Red == Red)        // eval: true   native: false  (WRONG)
// Box(5) == Box(5) -> native false; if (s == Active) -> wrong branch
```

This refuses heap-value equality with a clean "not supported by the native
compiler yet" diagnostic instead of the silent miscompile. The evaluator still
compares structurally (the oracle answer is `true`); native structural enum
equality is a follow-up feature. `Int`/`String`/list/record equality are
unaffected — they take dedicated branches before this fallthrough.

## Test plan

- New Linux-gated `native_enum_equality_is_refused_not_miscompiled` test: eval
  returns `true` for `Red == Red`, the native build refuses with the diagnostic.
- Verified `Int`/`String`/`[..]` equality and enum `match` still work natively.
- `cargo fmt --check`, `cargo clippy ... -D warnings`, `cargo test` all green
  (no test/stdlib relied on native enum `==`).

Found by a fourth-pass quality hunt re-covering the eval/native parity dimension
that rate-limited out of the third pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)