### PR TITLE
fix: clearer parser errors for `import foo.*` and `;` in variant fields

### DIFF
--- a/crates/klassic-syntax/src/lib.rs
+++ b/crates/klassic-syntax/src/lib.rs
@@ -1618,6 +1618,10 @@ impl Parser {
                     self.bump();
                 }
                 TokenKind::Comma if paren_depth == 0 && angle_depth == 0 => break,
+                // A `;` does not separate variant fields (use `,`); stop here
+                // so it surfaces as a clean parse error instead of being
+                // swallowed into a garbled type name like `Int;y:Int`.
+                TokenKind::Semicolon if paren_depth == 0 && angle_depth == 0 => break,
                 TokenKind::Less => {
                     angle_depth += 1;
                     self.bump();
@@ -1980,6 +1984,25 @@ impl Parser {
         } else {
             None
         };
+        // `import foo.*` is a wildcard attempt — `*` is not an identifier, so
+        // without this it would leave a stray `*` and report "expected a
+        // newline". Give the same hint as the `import foo._` form.
+        if matches!(self.peek().kind, TokenKind::Dot)
+            && matches!(
+                self.tokens.get(self.index + 1).map(|token| &token.kind),
+                Some(TokenKind::Star)
+            )
+        {
+            self.bump();
+            let star = self.bump().span;
+            return Err(Diagnostic::parse(
+                star,
+                format!(
+                    "wildcard imports are not supported; list the members explicitly, \
+                     e.g. `import {path}.{{a, b}}`"
+                ),
+            ));
+        }
         let (members, excludes) = if matches!(self.peek().kind, TokenKind::Dot)
             && matches!(
                 self.tokens.get(self.index + 1).map(|token| &token.kind),

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -1124,6 +1124,7 @@ fn helpful_syntax_diagnostics() {
             "record literals use `field: value`",
         ),
         ("import std.list._", "wildcard imports are not supported"),
+        ("import std.list.*", "wildcard imports are not supported"),
     ];
     for (src, expected) in cases {
         let output = Command::new(klassic_bin())
@@ -1137,6 +1138,37 @@ fn helpful_syntax_diagnostics() {
             String::from_utf8_lossy(&output.stderr)
         );
     }
+}
+
+/// A `;` between enum variant fields (where a `,` is required) is a clean
+/// parse error rather than being swallowed into a garbled type name like
+/// `Int;y:Int`. Comma-separated and multi-line variants still parse.
+#[test]
+fn enum_variant_semicolon_is_a_clean_error() {
+    let bad = Command::new(klassic_bin())
+        .args(["-e", "enum P { case Pt(x: Int; y: Int) }\nPt(1, 2)"])
+        .output()
+        .expect("binary should run");
+    assert!(!bad.status.success(), "a `;` field separator should fail");
+    let stderr = String::from_utf8_lossy(&bad.stderr);
+    assert!(
+        stderr.contains("expected `)`") && !stderr.contains("Int;y"),
+        "expected a clean parse error, not a garbled type, got:\n{stderr}"
+    );
+
+    let good = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "enum P {\n  case Pt(x: Int, y: Int)\n}\nprintln(Pt(1, 2))",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        good.status.success(),
+        "comma-separated variant fields should parse\nstderr:\n{}",
+        String::from_utf8_lossy(&good.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&good.stdout), "Pt(1, 2)\n()\n");
 }
 
 /// A block that reaches end-of-input without its closing `}` reports the


### PR DESCRIPTION
## What

Two parser papercuts surfaced confusing errors:

- `import foo.*` left a stray `*` and reported "expected a newline or `;` between
  expressions". It now gives the same wildcard hint as `import foo._`.
- A `;` between enum variant fields (where `,` is required) was swallowed by the
  greedy variant-field-type scanner into a garbled type name like `Int;y:Int`,
  producing a nonsense "constructor expects 1 argument" downstream. The scanner
  now stops at a top-level `;`, surfacing a clean "expected `)`".

Comma-separated and multi-line variant declarations are unaffected.

## Test plan

- `helpful_syntax_diagnostics` extended with `import std.list.*`.
- New `enum_variant_semicolon_is_a_clean_error` test (clean error, no garbled
  type; comma/multi-line forms still parse).
- `cargo fmt --check`, `cargo clippy ... -D warnings`, `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)