### PR TITLE
fix: support enum .toString() method in the evaluator

### DIFF
--- a/crates/klassic-eval/src/builtin_registry.rs
+++ b/crates/klassic-eval/src/builtin_registry.rs
@@ -159,6 +159,7 @@ pub(crate) fn value_method_builtin_name(value: &Value, field: &str) -> Option<&'
         | Value::Double(_)
         | Value::Bool(_)
         | Value::Unit
+        | Value::Enum { .. }
         | Value::Record { .. } => match field {
             "toString" => Some("toString"),
             _ => None,

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -914,6 +914,26 @@ fn unknown_match_constructor_is_rejected() {
     assert_eq!(String::from_utf8_lossy(&good.stdout), "1\n()\n");
 }
 
+/// `enumValue.toString()` works in the evaluator (it returns the variant
+/// rendering, matching `toString(enumValue)` and the native backend),
+/// rather than type-checking and then failing at run time.
+#[test]
+fn enum_tostring_method_works() {
+    let out = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "enum O { case Red; case S(v: Int) }\nprintln(Red.toString())\nprintln(S(7).toString())\nval s: String = Red.toString()\nprintln(s)",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        out.status.success(),
+        "enum .toString() should evaluate\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "Red\nS(7)\nRed\n()\n");
+}
+
 /// Importing a `std.*` module that does not exist reports "unknown module"
 /// rather than the "part of the standard library / not yet available in
 /// native builds" message reserved for real but not-yet-inlined modules.


### PR DESCRIPTION
## What

`enumValue.toString()` type-checked but failed at run time:

```kl
enum Color { case Red }
println(Red.toString())
// before: no field `toString` here …   (but toString(Red) and native both work)
// after:  Red
```

`value_method_builtin_name` mapped `.toString()` to the builtin for
Int/Bool/Unit/Record but omitted enum values, so the method dispatch fell
through to field access. The native backend already handled it (an eval/native
parity gap). Add `Value::Enum` to that arm so `Red.toString()` returns the
variant rendering, matching `toString(Red)` and native byte-for-byte.

## Test plan

- New `enum_tostring_method_works` cli_smoke test (`Red.toString()`,
  `S(7).toString()`, annotated binding).
- Verified eval now matches native for all forms.
- `cargo fmt --check`, `cargo clippy ... -D warnings`, `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)