### PR TITLE
fix: reset the native interpolation buffer offset per call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ dependencies = [
 name = "klassic-types"
 version = "0.1.0"
 dependencies = [
+ "klassic-runtime",
  "klassic-span",
  "klassic-syntax",
 ]

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -32921,6 +32921,10 @@ impl NativeCodeGenerator {
         let data = self.asm.data_label_with_bytes(&vec![0; RUNTIME_STRING_CAP]);
         let len = self.asm.data_label_with_i64s(&[0]);
         let offset = self.asm.data_label_with_i64s(&[0]);
+        // The offset cell is a static data slot: reset it to 0 on every
+        // call, otherwise a second invocation appends after the first
+        // call's content (the sibling runtime-string helpers all do this).
+        self.emit_reset_runtime_buffer_offset_label(offset);
         for part in parts {
             let hole = match part {
                 StringPart::Literal(text) => {

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -1079,6 +1079,63 @@ fn native_string_interpolation_nesting_matches_eval() {
     );
 }
 
+/// A runtime string interpolation (a hole that is not statically foldable,
+/// e.g. an enum payload bound in a match arm) used to accumulate previous
+/// calls' output in native because the shared buffer offset was never
+/// reset per call. Each call now returns only its own interpolation.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_runtime_interpolation_does_not_accumulate_across_calls() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-interp-accum-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-interp-accum-{unique}"));
+    fs::write(
+        &source_path,
+        "enum E { case EA(n: Int) }\ndef greet(e: E): String = e match { case EA(n) => \"val: #{n}\" }\nprintln(greet(EA(10)))\nprintln(greet(EA(20)))\nprintln(greet(EA(30)))\n",
+    )
+    .expect("source should write");
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(eval.status.success());
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(
+        String::from_utf8_lossy(&eval.stdout),
+        "val: 10\nval: 20\nval: 30\n"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&eval.stdout),
+        "native interpolation must not accumulate across calls"
+    );
+}
+
 /// Native equality of enum values used to silently compare heap identity
 /// (so `Red == Red` returned `false`); it is now refused with a clean
 /// diagnostic rather than miscompiled. The evaluator compares structurally


### PR DESCRIPTION
## What

A runtime string interpolation — a hole that is **not statically foldable**, e.g.
an enum payload bound in a `match` arm — silently accumulated previous calls'
output in native builds:

```kl
enum E { case EA(n: Int) }
def greet(e: E): String = e match { case EA(n) => "val: #{n}" }
println(greet(EA(10)))   // native: val: 10
println(greet(EA(20)))   // native: val: 10val: 20   (eval: val: 20)
println(greet(EA(30)))   // native: val: 10val: 20val: 30
```

`emit_runtime_interpolated_string` allocates a static data-section `offset` cell
but never reset it at call time, so a second invocation appended after the first
call's content. Emit a buffer-offset reset at the start of the runtime build,
mirroring every sibling runtime-string helper. eval and native now agree.

(Also syncs `Cargo.lock` for the `klassic-runtime` dependency added to
`klassic-types` in #476.)

## Test plan

- New Linux-gated `native_runtime_interpolation_does_not_accumulate_across_calls`
  test builds and runs the multi-call enum-match interpolation reproducer and
  asserts native matches eval (`val: 10\nval: 20\nval: 30\n`).
- `cargo fmt --check`, `cargo clippy ... -D warnings`, `cargo test` all green.

Found by a fifth-pass quality hunt focused on native miscompiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)