### PR TITLE
fix: collapse duplicate map-literal keys (last value wins)

### DIFF
--- a/crates/klassic-eval/src/lib.rs
+++ b/crates/klassic-eval/src/lib.rs
@@ -1312,17 +1312,22 @@ fn eval_expr_inner(
                 .map(|element| eval_expr(element, environment, state))
                 .collect::<Result<Vec<_>, _>>()?,
         )),
-        Expr::MapLiteral { entries, .. } => Ok(Value::Map(
-            entries
-                .iter()
-                .map(|(key, value)| {
-                    Ok((
-                        eval_expr(key, environment, state)?,
-                        eval_expr(value, environment, state)?,
-                    ))
-                })
-                .collect::<Result<Vec<_>, Diagnostic>>()?,
-        )),
+        Expr::MapLiteral { entries, .. } => {
+            // A duplicate key keeps a single entry with the last value
+            // written (last-wins), so `size`/`get` stay consistent — the
+            // same way the set literal collapses duplicate elements.
+            let mut pairs: Vec<(Value, Value)> = Vec::new();
+            for (key, value) in entries {
+                let key = eval_expr(key, environment, state)?;
+                let value = eval_expr(value, environment, state)?;
+                if let Some(slot) = pairs.iter_mut().find(|(existing, _)| *existing == key) {
+                    slot.1 = value;
+                } else {
+                    pairs.push((key, value));
+                }
+            }
+            Ok(Value::Map(pairs))
+        }
         Expr::SetLiteral { elements, .. } => {
             let mut values = Vec::new();
             for element in elements {

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -24556,7 +24556,7 @@ impl NativeCodeGenerator {
         entries: &[(Expr, Expr)],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
-        let mut static_entries = Vec::with_capacity(entries.len());
+        let mut static_entries: Vec<(StaticValue, StaticValue)> = Vec::with_capacity(entries.len());
         for (key, value) in entries {
             let key = self.static_value_from_argument_preserving_effects(
                 key,
@@ -24568,7 +24568,16 @@ impl NativeCodeGenerator {
                 span,
                 "native map value with non-static value",
             )?;
-            static_entries.push((key, value));
+            // A duplicate key keeps a single entry with the last value
+            // (last-wins), matching the evaluator and the set literal.
+            if let Some(slot) = static_entries
+                .iter_mut()
+                .find(|(existing, _)| self.static_value_equal_user(existing, &key))
+            {
+                slot.1 = value;
+            } else {
+                static_entries.push((key, value));
+            }
         }
         let label = self.intern_static_map(static_entries);
         Ok(NativeValue::StaticMap { label })

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -481,6 +481,27 @@ fn map_key_value_methods_are_typed() {
     }
 }
 
+/// A map literal with a duplicate key keeps one entry with the last value
+/// (last-wins), so `size`/`get` stay consistent — matching how the set
+/// literal collapses duplicate elements.
+#[test]
+fn map_literal_duplicate_key_is_last_wins() {
+    let out = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "val m = %[\"a\": 1 \"a\": 2 \"b\": 3]\nprintln(Map#size(m))\nprintln(m.get(\"a\"))\nprintln(m.get(\"b\"))",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        out.status.success(),
+        "the map literal should evaluate\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Two distinct keys; `a` keeps the last value `2`.
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "2\n2\n3\n()\n");
+}
+
 /// `xs.foldLeft(init, f)` over a `List<a>` ties the folder to the element
 /// type — `init` and the result share an accumulator type and `f` is
 /// `(acc, a) -> acc` — so a valid numeric/string fold works but a folder


### PR DESCRIPTION
## What

A map literal with a repeated key kept both entries:

```kl
val m = %["a": 1 "a": 2]
Map#size(m)   // before: 2    after: 1
m.get("a")    // before: 1    after: 2  (last-wins)
```

`size` 2 with `get` returning the first value is an inconsistent map. The set
literal already collapses duplicates; do the same for map keys in both the
evaluator and the native backend, keeping the last value written.

## Test plan

- New `map_literal_duplicate_key_is_last_wins` cli_smoke test
  (`%["a":1 "a":2 "b":3]` → size 2, `get("a")`=2, `get("b")`=3).
- Verified eval and native agree (both for the duplicate and the no-duplicate
  cases).
- `cargo fmt --check`, `cargo clippy ... -D warnings`, `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)