### PR TITLE
fix: materialize console-writing print concats/interpolations in native

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -32725,6 +32725,17 @@ impl NativeCodeGenerator {
             span: string_span,
         } = expr
         {
+            // A hole that performs its own console output must run before the
+            // surrounding string is printed, so materialize the whole value
+            // first instead of streaming each fragment to the fd in order.
+            if parts.iter().any(|part| {
+                matches!(part, StringPart::Interpolation(hole)
+                    if self.expr_writes_console_output(hole))
+            }) {
+                let value = self.emit_runtime_interpolated_string(parts, *string_span)?;
+                self.emit_print_value_fragment(fd, value);
+                return Ok(());
+            }
             return self.emit_print_interpolated_string(fd, parts, *string_span);
         }
 
@@ -32735,6 +32746,12 @@ impl NativeCodeGenerator {
             ..
         } = expr
             && self.is_print_concat_expr(expr)
+            // The split path emits each operand straight to the fd in source
+            // order. That only matches the evaluator when no operand performs
+            // its own console output: a nested `println` must run before the
+            // surrounding text (its value is the Unit result), so a concat
+            // that writes to the console is materialized first instead.
+            && !self.expr_writes_console_output(expr)
         {
             self.emit_print_expr_fragment(fd, lhs, span)?;
             self.emit_print_expr_fragment(fd, rhs, span)?;
@@ -32919,6 +32936,142 @@ impl NativeCodeGenerator {
             }
         }
         Ok(())
+    }
+
+    /// True when evaluating `expr` can itself write to stdout/stderr (it
+    /// reaches a `println`/`printlnError` call, including transitively
+    /// through user functions it calls). The print-concat and
+    /// print-interpolation fast paths emit each fragment straight to the fd
+    /// in source order; that only matches the evaluator when no fragment
+    /// performs its own console output, since a nested `println`'s text must
+    /// land *before* the surrounding string (its value is the Unit result).
+    fn expr_writes_console_output(&self, expr: &Expr) -> bool {
+        let mut visiting = HashSet::new();
+        self.expr_writes_console_output_visiting(expr, &mut visiting)
+    }
+
+    fn expr_writes_console_output_visiting(
+        &self,
+        expr: &Expr,
+        visiting: &mut HashSet<String>,
+    ) -> bool {
+        let recur = |s: &Self, e: &Expr, v: &mut HashSet<String>| {
+            s.expr_writes_console_output_visiting(e, v)
+        };
+        match expr {
+            Expr::Call {
+                callee, arguments, ..
+            } => {
+                if let Expr::Identifier { name, .. } = callee.as_ref() {
+                    let resolved = self.builtin_name_for_identifier(name);
+                    if matches!(resolved.as_str(), "println" | "printlnError") {
+                        return true;
+                    }
+                    // Follow a call into a user-defined function body once,
+                    // so a hole like `#{emit()}` whose `emit` prints is also
+                    // recognised. The visiting set breaks recursion cycles.
+                    if let Some(function) = self.functions.get(name.as_str())
+                        && !visiting.contains(name)
+                    {
+                        visiting.insert(name.clone());
+                        let writes = recur(self, &function.body, visiting);
+                        visiting.remove(name);
+                        if writes {
+                            return true;
+                        }
+                    }
+                }
+                recur(self, callee, visiting)
+                    || arguments
+                        .iter()
+                        .any(|argument| recur(self, argument, visiting))
+            }
+            Expr::StringInterpolation { parts, .. } => parts.iter().any(|part| {
+                matches!(part, StringPart::Interpolation(hole)
+                    if recur(self, hole, visiting))
+            }),
+            Expr::Unary { expr, .. } | Expr::FieldAccess { target: expr, .. } => {
+                recur(self, expr, visiting)
+            }
+            Expr::Binary { lhs, rhs, .. } => {
+                recur(self, lhs, visiting) || recur(self, rhs, visiting)
+            }
+            Expr::If {
+                condition,
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                recur(self, condition, visiting)
+                    || recur(self, then_branch, visiting)
+                    || else_branch
+                        .as_deref()
+                        .is_some_and(|branch| recur(self, branch, visiting))
+            }
+            Expr::While {
+                condition, body, ..
+            } => recur(self, condition, visiting) || recur(self, body, visiting),
+            Expr::Foreach { iterable, body, .. } => {
+                recur(self, iterable, visiting) || recur(self, body, visiting)
+            }
+            Expr::Block { expressions, .. } => expressions
+                .iter()
+                .any(|expression| recur(self, expression, visiting)),
+            Expr::Cleanup { body, cleanup, .. } => {
+                recur(self, body, visiting) || recur(self, cleanup, visiting)
+            }
+            Expr::Lambda { body, .. }
+            | Expr::DefDecl { body, .. }
+            | Expr::TheoremDeclaration { body, .. } => recur(self, body, visiting),
+            Expr::InstanceDeclaration { methods, .. } => {
+                methods.iter().any(|method| recur(self, method, visiting))
+            }
+            Expr::RecordConstructor { arguments, .. }
+            | Expr::ListLiteral {
+                elements: arguments,
+                ..
+            } => arguments
+                .iter()
+                .any(|argument| recur(self, argument, visiting)),
+            Expr::RecordLiteral { fields, .. } => {
+                fields.iter().any(|(_, value)| recur(self, value, visiting))
+            }
+            Expr::MapLiteral { entries, .. } => entries
+                .iter()
+                .any(|(key, value)| recur(self, key, visiting) || recur(self, value, visiting)),
+            Expr::SetLiteral { elements, .. } => elements
+                .iter()
+                .any(|element| recur(self, element, visiting)),
+            Expr::VarDecl { value, .. } | Expr::Assign { value, .. } => {
+                recur(self, value, visiting)
+            }
+            Expr::AxiomDeclaration { proposition, .. } => recur(self, proposition, visiting),
+            Expr::Match {
+                scrutinee, arms, ..
+            } => {
+                recur(self, scrutinee, visiting)
+                    || arms.iter().any(|arm| {
+                        arm.guard
+                            .as_ref()
+                            .is_some_and(|guard| recur(self, guard, visiting))
+                            || recur(self, &arm.body, visiting)
+                    })
+            }
+            Expr::Int { .. }
+            | Expr::Double { .. }
+            | Expr::Bool { .. }
+            | Expr::String { .. }
+            | Expr::Null { .. }
+            | Expr::Unit { .. }
+            | Expr::Identifier { .. }
+            | Expr::ModuleHeader { .. }
+            | Expr::Import { .. }
+            | Expr::RecordDeclaration { .. }
+            | Expr::TypeClassDeclaration { .. }
+            | Expr::ExtensionDeclaration { .. }
+            | Expr::EnumDeclaration { .. }
+            | Expr::PegRuleBlock { .. } => false,
+        }
     }
 
     fn emit_runtime_interpolated_string(

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -126,7 +126,11 @@ cargo run -- -e "1 + 2"
   threads, whose stacks live at unrelated addresses.
   `println` / `printlnError` stream simple
   string-concatenation and interpolation expressions directly until a heap string
-  runtime is added. Interpolated strings can also be folded into static native
+  runtime is added. That streaming fast path is skipped when a fragment performs
+  its own console output (a `println` reached directly or transitively through a
+  called function): such concats / interpolations are materialized first so the
+  nested output lands before the surrounding text, matching the evaluator instead
+  of interleaving it. Interpolated strings can also be folded into static native
   values when all fragments resolve through immutable static bindings, including
   fragments with mutable block prefixes when their final values remain
   recoverable. Interpolation fragments that resolve to native runtime strings,

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -1157,6 +1157,74 @@ fn native_runtime_interpolation_does_not_accumulate_across_calls() {
     );
 }
 
+/// A `println` nested inside a string concatenation or interpolation hole
+/// must run before the surrounding text is printed (its value is the Unit
+/// result). The native print-concat / print-interpolation fast paths used to
+/// stream each fragment straight to the fd, interleaving the inner output;
+/// they now materialize the value first when a fragment writes to the
+/// console, matching the evaluator. The check follows a call into a user
+/// function so transitive output (`emit()`) is recognised too.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_print_with_nested_console_output_matches_eval() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-print-nested-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-print-nested-{unique}"));
+    let program = concat!(
+        "def emit(): Int = { println(\"side\"); 9 }\n",
+        "println(\"A\" + println(\"B\") + \"C\")\n",
+        "println(\"a#{println(\"b\")}c\")\n",
+        "println(\"n=#{emit()}!\")\n",
+        "val x = 7\n",
+        "println(\"keep=#{x} fast\")\n",
+    );
+    fs::write(&source_path, program).expect("source should write");
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(
+        eval.status.success(),
+        "eval failed:\n{}",
+        String::from_utf8_lossy(&eval.stderr)
+    );
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(
+        String::from_utf8_lossy(&eval.stdout),
+        "B\nA()C\nb\na()c\nside\nn=9!\nkeep=7 fast\n"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&eval.stdout),
+        "native print must not interleave nested console output"
+    );
+}
+
 /// Native equality of enum values used to silently compare heap identity
 /// (so `Red == Red` returned `false`); it is now refused with a clean
 /// diagnostic rather than miscompiled. The evaluator compares structurally


### PR DESCRIPTION
## Problem (silent native miscompile, HIGH)

A `println` nested inside a string concatenation or interpolation hole must run **before** the surrounding text is printed — the concatenation's value uses the inner `println`'s `Unit` result, not its output. The native `println` fast paths streamed each fragment straight to the fd in source order, interleaving the nested output:

| program | eval (oracle) | native (before) |
|---|---|---|
| `println("A" + println("B") + "C")` | `B⏎A()C` | `AB⏎()C` |
| `println("A#{println("B")}C")` | `B⏎A()C` | `AB⏎()C` |
| `println("n=#{emit()}!")` where `emit` prints | `side⏎n=9!` | `n=side⏎9!` |

## Fix

Both the print-concat split and the print-interpolation streaming path now skip the fast path and **materialize the value first** when any fragment writes to the console. A new `expr_writes_console_output` walker detects a `println`/`printlnError` reached directly **or transitively through a called user function** (with a cycle guard, looking the body up in the function registry).

Pure fragments keep the fast path, so `someStringCall() + "!"` — a runtime-string concat the native backend cannot *materialize* — still prints by streaming each operand. (An earlier `||`→`&&` attempt broke exactly that case; the regression test `builds_native_executable_for_conditional_runtime_return_calls` caught it.)

## Verification

- eval == native on direct nested `println`, two nested holes, transitive 2-level user functions, recursive pure functions (cycle guard), and pure `toString`/arithmetic holes.
- New regression test `native_print_with_nested_console_output_matches_eval` (Linux-gated).
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 476 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)