### PR TITLE
fix: reject native selective imports of non-member names

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -664,6 +664,9 @@ struct InlineImport {
     // `import a.{x, y}` / `import a.{x => _}` when resolving a reference.
     members: Option<Vec<String>>,
     excludes: Vec<String>,
+    // Source span of the `import`, so a selective import of a name the
+    // module does not export can be rejected where the evaluator does.
+    span: Span,
 }
 
 fn collect_inlinable_imports(
@@ -677,6 +680,7 @@ fn collect_inlinable_imports(
             alias,
             members,
             excludes,
+            span,
             ..
         } if stdlib_module_is_inlinable(path)
             || user_modules.iter().any(|module| module.path == *path) =>
@@ -686,6 +690,7 @@ fn collect_inlinable_imports(
                 alias: alias.clone(),
                 members: members.clone(),
                 excludes: excludes.clone(),
+                span: *span,
             });
         }
         Expr::Block { expressions, .. } => {
@@ -730,6 +735,33 @@ fn module_free_def_names(parsed: &Expr) -> Vec<String> {
     fn collect(expr: &Expr, out: &mut Vec<String>) {
         match expr {
             Expr::DefDecl { name, .. } => out.push(name.clone()),
+            Expr::Block { expressions, .. } => {
+                for sub in expressions {
+                    collect(sub, out);
+                }
+            }
+            _ => {}
+        }
+    }
+    let mut out = Vec::new();
+    collect(parsed, &mut out);
+    out
+}
+
+/// Every bare name a module exports for a selective `import`, matching the
+/// evaluator's root value bindings: free `def`s, top-level `val` / `mutable`
+/// bindings, and enum constructors. Type names and extension methods are not
+/// value bindings, so they are not importable. Used only to validate
+/// `import a.{x}` members — mangling still keys off free defs alone.
+fn module_member_names(parsed: &Expr) -> Vec<String> {
+    fn collect(expr: &Expr, out: &mut Vec<String>) {
+        match expr {
+            Expr::DefDecl { name, .. } | Expr::VarDecl { name, .. } => out.push(name.clone()),
+            Expr::EnumDeclaration { variants, .. } => {
+                for variant in variants {
+                    out.push(variant.name.clone());
+                }
+            }
             Expr::Block { expressions, .. } => {
                 for sub in expressions {
                     collect(sub, out);
@@ -1337,6 +1369,35 @@ fn inline_module_imports(
     let mut mangled_modules: HashMap<String, Vec<String>> = HashMap::new();
     for (path, parsed) in &parsed_by_path {
         mangled_modules.insert(path.clone(), module_free_def_names(parsed));
+    }
+
+    // Reject a selective import of a name the target module does not export.
+    // Without this the rename scope silently drops the unknown member, so
+    // native accepted programs the evaluator rejects with `module `p` has no
+    // member `m``. The export set mirrors the evaluator's root value bindings
+    // (free defs, top-level vals, enum constructors), not just the free defs
+    // mangling keys off. Only inlined modules are checked.
+    let module_members: HashMap<&str, Vec<String>> = parsed_by_path
+        .iter()
+        .map(|(path, parsed)| (path.as_str(), module_member_names(parsed)))
+        .collect();
+    for import in main_imports.iter().chain(module_imports.values().flatten()) {
+        let (Some(members), Some(exports)) =
+            (&import.members, module_members.get(import.path.as_str()))
+        else {
+            continue;
+        };
+        for member in members {
+            if import.excludes.contains(member) {
+                continue;
+            }
+            if !exports.contains(member) {
+                return Err(Diagnostic::compile(
+                    import.span,
+                    format!("module `{}` has no member `{}`", import.path, member),
+                ));
+            }
+        }
     }
 
     let mut module_decls = Vec::new();

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -721,7 +721,12 @@ cargo run -- -e "1 + 2"
   differently-typed free functions across modules — user or `std.*` —
   no longer collide (#449). Selective and bulk imports resolve to the
   mangled name; aliased imports (`import std.x as M`) collapse their
-  `M.func` access to the target module's mangled name. The ADT-backed
+  `M.func` access to the target module's mangled name. A selective
+  `import a.{x}` of a name the module does not export is rejected before
+  splicing with the same `module `a` has no member `x`` diagnostic the
+  evaluator gives — the export set mirrors the evaluator's root value
+  bindings (free defs, top-level `val`s, enum constructors), so the unknown
+  member is no longer silently dropped into an accepted build. The ADT-backed
   modules (`std.option` / `std.result`)
   now inline as well, on top of the generic-enum specialization above:
   their constructors (`some` / `ok`), consumers (`getOrElse` / `unwrapOr`

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -22983,6 +22983,80 @@ fn native_build_inlines_adt_stdlib_modules() {
     );
 }
 
+/// A selective import of a name a module does not export is rejected by the
+/// native build with the same `module `p` has no member `m`` diagnostic the
+/// evaluator gives, instead of silently dropping the unknown member and
+/// accepting a program eval refuses. The exported set mirrors the
+/// evaluator's value bindings (free defs, top-level vals, enum
+/// constructors), so a real member still builds.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_build_rejects_nonexistent_selective_import_member() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let bad_path = std::env::temp_dir().join(format!("klassic_native_badimport_{stamp}.kl"));
+    let good_path = std::env::temp_dir().join(format!("klassic_native_goodimport_{stamp}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic_native_import_{stamp}.bin"));
+
+    // `abs` is not a free def in std.math (only the `absValue` extension
+    // method exists), so eval rejects it; native must too.
+    fs::write(&bad_path, "import std.math.{abs}\nprintln(5)\n").expect("temp source should write");
+    let bad_build = Command::new(klassic_bin())
+        .args([
+            "build",
+            bad_path.to_str().expect("path should be utf-8"),
+            "-o",
+            output_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        !bad_build.status.success(),
+        "native build must reject an import of a non-member"
+    );
+    assert!(
+        String::from_utf8_lossy(&bad_build.stderr)
+            .contains("module `std.math` has no member `abs`"),
+        "expected the evaluator's member diagnostic, got:\n{}",
+        String::from_utf8_lossy(&bad_build.stderr)
+    );
+
+    // A val (`none`), an enum constructor (`Some`), and a free def
+    // (`getOrElse`) are all real members and still build + run.
+    fs::write(
+        &good_path,
+        "import std.option.{Some, none, getOrElse}\n\
+         println(getOrElse(Some(7), 0))\n\
+         println(getOrElse(none, 42))\n",
+    )
+    .expect("temp source should write");
+    let good_build = Command::new(klassic_bin())
+        .args([
+            "build",
+            good_path.to_str().expect("path should be utf-8"),
+            "-o",
+            output_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        good_build.status.success(),
+        "real members (val / constructor / def) must build\nstderr:\n{}",
+        String::from_utf8_lossy(&good_build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("compiled binary should run");
+
+    let _ = fs::remove_file(&bad_path);
+    let _ = fs::remove_file(&good_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "7\n42\n");
+}
+
 /// A generic-enum value freshly built on each arm of a `match` (so its
 /// shape is produced inside control flow) now carries a merged shape past
 /// the join (M6), so `map` / `flatMap` / `orElse` results can be matched


### PR DESCRIPTION
## Problem (eval/native accept-reject parity gap)

`import std.math.{abs}` builds and runs under the native compiler, printing its result, even though `abs` is **not** a member of `std.math` (only the `absValue` extension method exists). The evaluator rejects it:

```
module `std.math` has no member `abs`
```

So native silently accepted a program the evaluator refuses. The cause: the namespacing rewrite filtered an import's members against the module's free defs and **silently dropped** any it didn't recognise, never validating them.

## Fix

Validate selective import members in `inline_module_imports` before splicing, emitting the evaluator's exact diagnostic (and span) for an unknown member.

The tricky part is the **export set**. The evaluator exports a module's root *value* bindings (`environment.root_exports()`), which is broader than free defs: it also includes top-level `val`/`mutable` bindings and enum constructors. A first cut that validated against free defs alone wrongly rejected `std.option.{none}` (a `val`) and `{Some}` (a constructor) and broke 4 inlining tests. A new `module_member_names` collects defs + vals + enum constructors (type names and extension methods are not value bindings, so they stay non-importable, matching eval). Mangling still keys off free defs alone.

| import | eval | native (before) | native (after) |
|---|---|---|---|
| `std.math.{abs}` | reject | **accept** | reject |
| `std.option.{absValue}` (ext method) | reject | accept | reject |
| `std.option.{Some, none, getOrElse}` | accept | accept | accept |
| `std.math.{min}` | accept | accept | accept |

## Verification

- eval == native on non-member, extension-method-as-member, real `val`/constructor/`def` members, multi-member with one bad name, and user-module members.
- New regression test `native_build_rejects_nonexistent_selective_import_member` (Linux-gated).
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 477 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)