### PR TITLE
fix: capture a shadowed lambda param by value in returned closures

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -3870,6 +3870,13 @@ struct NativeCodeGenerator {
     scope_gc_root_counts: Vec<usize>,
     scopes: Vec<HashMap<String, VarSlot>>,
     static_scopes: Vec<HashMap<String, StaticValue>>,
+    /// Names of enclosing-lambda parameters currently bound to a static
+    /// constant during inline-call lowering. Such a param is immutable and
+    /// its static value is authoritative, so an inner lambda must NOT capture
+    /// it via a (frame-relative, escape-unsafe) runtime slot that would
+    /// shadow the static value — that made a returned closure read an outer
+    /// `val` shadowed by the param. Saved/restored around each inline body.
+    inline_static_params: Vec<String>,
     scope_base_offsets: Vec<i32>,
     next_stack_offset: i32,
     next_var_slot_id: usize,
@@ -4088,6 +4095,7 @@ impl NativeCodeGenerator {
             scope_gc_root_counts: vec![0],
             scopes: vec![HashMap::new()],
             static_scopes: vec![HashMap::new()],
+            inline_static_params: Vec::new(),
             scope_base_offsets: vec![0],
             next_stack_offset: 0,
             next_var_slot_id: 0,
@@ -5607,7 +5615,7 @@ impl NativeCodeGenerator {
                     params.clone(),
                     body.as_ref().clone(),
                     self.current_static_captures(),
-                    self.current_runtime_captures(),
+                    self.closure_runtime_captures(),
                     None,
                     expr_contains_thread_call(body, &thread_aliases),
                 );
@@ -8534,6 +8542,7 @@ impl NativeCodeGenerator {
             ));
         }
         self.push_scope();
+        let saved_inline_params = self.inline_static_params.len();
         let result = (|| {
             for (param, argument) in params.iter().zip(arguments) {
                 let static_argument = self.static_value_from_pure_expr(argument);
@@ -8547,6 +8556,7 @@ impl NativeCodeGenerator {
                         self.asm.store_rbp_slot(slot.offset, Reg::Rax);
                         if let Some(value) = static_argument {
                             self.bind_static_value(param.clone(), value);
+                            self.inline_static_params.push(param.clone());
                         }
                     }
                     NativeValue::Null
@@ -8572,6 +8582,7 @@ impl NativeCodeGenerator {
             }
             self.compile_expr(body)
         })();
+        self.inline_static_params.truncate(saved_inline_params);
         match result {
             Ok(value) => {
                 if self.native_value_captures_current_scope(value)
@@ -26184,6 +26195,7 @@ impl NativeCodeGenerator {
             ));
         }
         self.push_scope();
+        let saved_inline_params = self.inline_static_params.len();
         let result = (|| {
             let assigned_captures = assigned_names_in_expr(&lambda.body);
             self.bind_static_lambda_runtime_captures(&lambda);
@@ -26207,6 +26219,7 @@ impl NativeCodeGenerator {
                         self.asm.store_rbp_slot(slot.offset, Reg::Rax);
                         if let Some(value) = static_argument {
                             self.bind_static_value(param.clone(), value);
+                            self.inline_static_params.push(param.clone());
                         }
                     }
                     NativeValue::Null
@@ -26232,6 +26245,7 @@ impl NativeCodeGenerator {
             }
             self.compile_expr(&lambda.body)
         })();
+        self.inline_static_params.truncate(saved_inline_params);
         match result {
             Ok(value) => {
                 if self.native_value_captures_current_scope(value)
@@ -26986,12 +27000,23 @@ impl NativeCodeGenerator {
                 for (name, value) in bindings {
                     captures.insert((*name).to_string(), value.clone());
                 }
+                // A statically-substituted binding (an enclosing lambda's
+                // parameter) is authoritative for that name. If an outer
+                // `val` of the same name was materialized into a runtime slot
+                // (e.g. while binding the enclosing lambda's captures), that
+                // slot must NOT be captured here — at call time a runtime
+                // capture shadows the static one, so the inner closure would
+                // read the outer val instead of the shadowing parameter.
+                let mut runtime_captures = self.current_runtime_captures();
+                for (name, _) in bindings {
+                    runtime_captures.remove(*name);
+                }
                 let thread_aliases = self.current_thread_aliases_with_static_bindings(bindings);
                 let label = self.intern_static_lambda(
                     params.clone(),
                     body.as_ref().clone(),
                     captures,
-                    self.current_runtime_captures(),
+                    runtime_captures,
                     None,
                     expr_contains_thread_call(body, &thread_aliases),
                 );
@@ -28497,6 +28522,20 @@ impl NativeCodeGenerator {
             for (name, slot) in scope {
                 captures.insert(name.clone(), *slot);
             }
+        }
+        captures
+    }
+
+    /// Runtime captures for a lambda being interned, with statically-bound
+    /// enclosing-lambda parameters removed. Those params are immutable and
+    /// carry an authoritative static-constant value; a runtime slot for them
+    /// is a frame-relative stack offset that does not survive the closure
+    /// escaping its defining frame, and (being present in `runtime_captures`)
+    /// would shadow the correct static value at call time.
+    fn closure_runtime_captures(&self) -> HashMap<String, VarSlot> {
+        let mut captures = self.current_runtime_captures();
+        for name in &self.inline_static_params {
+            captures.remove(name);
         }
         captures
     }

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -369,6 +369,13 @@ cargo run -- -e "1 + 2"
   be bound and called when captures and arguments are statically recoverable;
   unannotated functions that return runtime-capturing lambdas are inlined at the
   call site so their captured local slots stay alive after the function returns.
+  When an enclosing lambda parameter is bound to a static constant during such
+  inline lowering, an inner returned closure captures it by that static value
+  rather than a frame-relative runtime slot: the parameter is immutable, and a
+  runtime capture would both fail to survive the closure escaping its frame and
+  shadow the correct value, so a parameter shadowing an outer `val` of the same
+  name no longer makes the closure read the outer binding. Mutable captures keep
+  their live runtime slot.
   Static `if` values, static binary folds, and
   static call folds use the same purity gate before native folding, and
   dynamic-control assignments invalidate static facts for runtime integer/boolean

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -3431,6 +3431,71 @@ fn builds_native_executable_for_top_level_lambda_bindings() {
     assert!(run.stderr.is_empty());
 }
 
+/// A returned inner closure that captures an enclosing lambda parameter must
+/// see the parameter, not an outer `val` of the same name it shadows. Native
+/// used to capture the shadowed parameter through a frame-relative runtime
+/// slot that lost out to the outer val's value, so `f(3)(4)` printed `14`
+/// (outer `x = 10`) instead of the evaluator's `7`. Mutable captures, which
+/// genuinely need the live runtime slot, must keep working.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn builds_native_executable_for_shadowed_param_in_returned_closure() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-native-shadow-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-native-shadow-{unique}"));
+    fs::write(
+        &source_path,
+        // 1: param `x` shadows outer val `x`; 2: same plus a real captured
+        // val `k`; 3: distinct shadow values; 4: control with no collision;
+        // 5: escaping mutable closure still reads the live value.
+        "val x = 10\n\
+         val f = (x: Int) => (y: Int) => x + y\n\
+         println(f(3)(4))\n\
+         val k = 1000\n\
+         val g = (x: Int) => (y: Int) => k + x + y\n\
+         println(g(3)(4))\n\
+         val h = (x: Int) => (y: Int) => x + y\n\
+         println(h(100)(1))\n\
+         val z = 5\n\
+         val noClash = (x: Int) => (y: Int) => x + y\n\
+         println(noClash(3)(4))\n\
+         mutable c = 0\n\
+         val read = () => c\n\
+         c = 9\n\
+         println(read())\n",
+    )
+    .expect("source should write");
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("klassic build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let run = Command::new(&output_path)
+        .output()
+        .expect("generated executable should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert!(run.status.success());
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "7\n1007\n101\n7\n9\n");
+    assert!(run.stderr.is_empty());
+}
+
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[test]
 fn builds_native_executable_for_functions_capturing_top_level_bindings() {


### PR DESCRIPTION
## Problem (silent native miscompile, HIGH)

A returned inner closure that captures an **enclosing lambda parameter** read an outer `val` of the same name instead of the parameter that shadows it:

```kl
val x = 10
val f = (x: Int) => (y: Int) => x + y
println(f(3)(4))   // eval 7, native 14  (used outer val 10, + 4)
```

A distinct-value variant (`val x = 100`) gave native `104`, confirming native picked the outer `val` rather than the shadowing parameter. Found by the native-miscompile hunt and reproduced independently.

## Root cause

When the inner lambda `(y) => x + y` is interned it records the parameter `x` both as a **static constant** (3, correct) and as a **runtime capture** pointing at the enclosing frame's slot. At call time a runtime capture shadows the static one (`static_capture_shadowed_by_runtime`), and that frame-relative stack slot — which doesn't survive the closure escaping its defining frame — resolved to the outer `val` (10) instead of the parameter (3).

## Fix

A statically-bound enclosing-lambda parameter is immutable and its static value is authoritative, so it must not be captured through a runtime slot. The lowering now tracks such parameters (`inline_static_params`, saved/restored around each inline body) and drops them from a returned closure's runtime captures (`closure_runtime_captures`), alongside the existing binding-substitution path for statically folded bodies.

Only **immutable parameters** are tracked, so **mutable captures keep their live runtime slot** — `mutable c = 0; val f = () => c; c = 5; f()` still prints `5`.

| case | eval | native before | native after |
|---|---|---|---|
| param shadows outer val | 7 | **14** | 7 |
| + real captured val `k` | 1007 | **1014** | 1007 |
| distinct values (100/3/4) | 7 | **104** | 7 |
| no name collision (control) | 7 | 7 | 7 |
| escaping mutable closure | 5 | 5 | 5 |

## Verification

- eval == native on shadow-only, shadow + legit capture, distinct values, HOF-passed closures, repeated distinct calls, and live mutable captures.
- New regression test `builds_native_executable_for_shadowed_param_in_returned_closure` (Linux-gated).
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 478 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)