### PR TITLE
fix: reset the native bool->string buffer offset per call

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -36595,6 +36595,11 @@ impl NativeCodeGenerator {
         let data = self.asm.data_label_with_bytes(&vec![0; RUNTIME_STRING_CAP]);
         let len = self.asm.data_label_with_i64s(&[0]);
         let offset = self.asm.data_label_with_i64s(&[0]);
+        // Reset the static offset cell per call, like the Int sibling
+        // (emit_i64_rax_to_runtime_string_ref): without this a second
+        // bool->string conversion appends after the first call's content,
+        // so `"" + b` over two calls produced "true" then "truefalse".
+        self.emit_reset_runtime_buffer_offset_label(offset);
         self.emit_append_bool_rax_to_runtime_buffer_offset_label(
             data,
             offset,

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -1157,6 +1157,65 @@ fn native_runtime_interpolation_does_not_accumulate_across_calls() {
     );
 }
 
+/// Converting a Boolean to a string via `+` concatenation (e.g. an enum
+/// payload `"" + b`) used to reuse a static runtime buffer whose offset was
+/// never reset per call, so a second call appended after the first's content
+/// (`true`, then `truefalse`). The Int sibling already reset its offset; now
+/// the Boolean path does too, matching the evaluator.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_bool_concat_does_not_accumulate_across_calls() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-bool-accum-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-bool-accum-{unique}"));
+    fs::write(
+        &source_path,
+        "enum W { case B(b: Boolean) }\n\
+         def show(w: W): String = w match { case B(b) => \"\" + b }\n\
+         println(show(B(true)))\n\
+         println(show(B(false)))\n\
+         println(show(B(true)))\n",
+    )
+    .expect("source should write");
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(eval.status.success());
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(String::from_utf8_lossy(&eval.stdout), "true\nfalse\ntrue\n");
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&eval.stdout),
+        "native bool concatenation must not accumulate across calls"
+    );
+}
+
 /// A `println` nested inside a string concatenation or interpolation hole
 /// must run before the surrounding text is printed (its value is the Unit
 /// result). The native print-concat / print-interpolation fast paths used to


### PR DESCRIPTION
## Problem (silent native miscompile, HIGH)

Converting a Boolean to a string via `+` concatenation reused a static `.data` runtime buffer whose offset cell was never reset, so a second conversion appended after the first call's content:

```kl
enum W { case B(b: Boolean) }
def show(w: W): String = w match { case B(b) => "" + b }
println(show(B(true)))    // true
println(show(B(false)))   // eval: false, native: truefalse
```

A 3-call test confirmed monotonic accumulation (`true`, `truefalse`, `truefalsetrue`).

## Fix

`emit_bool_rax_to_runtime_string_ref` was missing the `emit_reset_runtime_buffer_offset_label(offset)` call that its Int sibling `emit_i64_rax_to_runtime_string_ref` already makes. Adding it makes each conversion start at offset 0, matching the evaluator. This is the same class as #480 (interpolation buffer accumulation).

Only the Boolean `+`-concat path was affected: interpolation `#{b}` uses a different codegen path and Int payloads were already correct.

## Verification

- eval == native on `"" + b` and `b + ""`, across 2 and 3 calls, plus interpolation and Int-payload controls.
- New regression test `native_bool_concat_does_not_accumulate_across_calls` (Linux-gated).
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 479 passed).

Found by the native-miscompile hunt (dimension `enums-match`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)