### PR TITLE
fix: refuse recursive capture of a mutable global instead of miscompiling

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -3901,6 +3901,11 @@ struct NativeCodeGenerator {
     virtual_dirs: HashSet<String>,
     unknown_virtual_paths: HashSet<String>,
     queued_threads: Vec<QueuedThread>,
+    /// Names of top-level `mutable` bindings. An out-of-line (self-recursive)
+    /// function cannot address the top-level frame's slot for one of these,
+    /// so capturing a mutable global there is refused rather than silently
+    /// snapshotting a stale copy into the callee frame.
+    top_level_mutable_names: HashSet<String>,
     dynamic_control_depth: usize,
     mergeable_dynamic_branch_depth: usize,
     /// Monomorphic enums lowered to `__gc_record` shape by
@@ -4120,6 +4125,7 @@ impl NativeCodeGenerator {
             virtual_dirs: HashSet::new(),
             unknown_virtual_paths: HashSet::new(),
             queued_threads: Vec::new(),
+            top_level_mutable_names: HashSet::new(),
             dynamic_control_depth: 0,
             mergeable_dynamic_branch_depth: 0,
             lowered_enum_names: HashSet::new(),
@@ -4730,6 +4736,7 @@ impl NativeCodeGenerator {
         };
         let thread_aliases = top_level_thread_aliases(expressions);
         let top_level_value_names = top_level_value_names(expressions);
+        self.top_level_mutable_names = top_level_mutable_names(expressions);
         for expression in expressions {
             match expression {
                 Expr::DefDecl {
@@ -37328,6 +37335,19 @@ impl NativeCodeGenerator {
             if self.lookup_var(name).is_some() {
                 continue;
             }
+            // A top-level `mutable` global lives in the top-level frame's
+            // stack slot, which this out-of-line function cannot address.
+            // Snapshotting it into a callee-frame local would read a stale
+            // value and discard any write when the frame dies (a silent
+            // miscompile), so refuse instead. Non-recursive functions that
+            // touch a mutable global are inlined at the call site and reach
+            // the real slot, so this only affects self-recursive ones.
+            if self.top_level_mutable_names.contains(name) {
+                return Err(unsupported(
+                    function.body.span(),
+                    "native recursive function capturing a mutable top-level binding",
+                ));
+            }
             if let Some(value) = lookup_static_value_in_scopes(&saved_static_scopes, name) {
                 self.bind_static_runtime_value(name.clone(), value);
                 continue;
@@ -39556,6 +39576,20 @@ fn top_level_value_names(expressions: &[Expr]) -> HashSet<String> {
         .iter()
         .filter_map(|expression| match expression {
             Expr::VarDecl { name, .. } => Some(name.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn top_level_mutable_names(expressions: &[Expr]) -> HashSet<String> {
+    expressions
+        .iter()
+        .filter_map(|expression| match expression {
+            Expr::VarDecl {
+                name,
+                mutable: true,
+                ..
+            } => Some(name.clone()),
             _ => None,
         })
         .collect()

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -356,7 +356,12 @@ cargo run -- -e "1 + 2"
   are call-site inlined; recursive `def` declarations can still capture immutable
   static top-level values, builtin aliases, static lambda values, and immutable
   runtime string / line-list / selected-length runtime-list / runtime-record
-  bindings by rebinding them inside the emitted function frame. Direct calls and value aliases for
+  bindings by rebinding them inside the emitted function frame. Capturing a
+  top-level `mutable` binding from a recursive (out-of-line) function is refused
+  with a clean diagnostic rather than compiled: such a global lives in the
+  top-level frame's slot, which the callee frame cannot address, so rebinding it
+  would snapshot a stale value and discard writes. The non-recursive case is
+  inlined and reaches the real slot, so it keeps working. Direct calls and value aliases for
   user-defined functions shadow same-named native builtins.
   Immutable aliases to curried helpers such as `assertResult`, `cons`, `map`,
   and `foldLeft` resolve through the same native special-call paths as direct

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -3136,6 +3136,70 @@ fn builds_native_executable_for_recursive_function_static_top_level_capture() {
     assert!(run.stderr.is_empty());
 }
 
+/// A self-recursive function is compiled out of line, so it cannot address
+/// the top-level frame's slot for a `mutable` global it captures. Native used
+/// to snapshot the global's value into a callee-frame local, reading a stale
+/// value and discarding writes when the frame dies — a silent miscompile
+/// (`mutable c = 0; def f(n){ c = 1; ... }; f(0); println(c)` printed `0`
+/// instead of the evaluator's `1`). It is now refused with a clean diagnostic
+/// rather than miscompiled. A self-recursive capture of an *immutable* val is
+/// still snapshotted correctly (see the test above), and a non-recursive
+/// function mutating a global is inlined and reaches the real slot.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_refuses_recursive_capture_of_mutable_global() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-native-recmut-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-native-recmut-{unique}"));
+    fs::write(
+        &source_path,
+        "mutable c = 0\n\
+         def f(n: Int): Int = {\n\
+         \x20 c = 1\n\
+         \x20 if(n <= 0) 0 else f(n - 1)\n\
+         }\n\
+         val r = f(0)\n\
+         println(c)\n",
+    )
+    .expect("source should write");
+
+    // The evaluator (oracle) accepts it and prints 1.
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(eval.status.success());
+    assert_eq!(String::from_utf8_lossy(&eval.stdout), "1\n");
+
+    // Native refuses rather than silently printing 0.
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("klassic build should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert!(
+        !build.status.success(),
+        "native must refuse a recursive capture of a mutable global, not miscompile it"
+    );
+    assert!(
+        String::from_utf8_lossy(&build.stderr)
+            .contains("recursive function capturing a mutable top-level binding"),
+        "expected a clean unsupported diagnostic, got:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+}
+
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[test]
 fn builds_native_executable_for_static_folded_recursive_list_function() {


### PR DESCRIPTION
## Problem (silent native miscompile, HIGH)

A self-recursive function is compiled out of line, so it cannot address the top-level frame's slot for a `mutable` global it captures:

```kl
mutable c = 0
def f(n: Int): Int = { c = 1; if(n <= 0) 0 else f(n - 1) }
val r = f(0)
println(c)        // eval 1, native 0
```

The out-of-line prologue rebound the captured global by snapshotting its compile-time value into a fresh callee-frame local (`bind_static_runtime_value`), so `c = ...` wrote a stack slot discarded when the frame died and the real global never changed. It triggers on **syntactic** self-recursion even when the recursive branch is never taken (`n = 0` above), and accumulating variants printed `0` instead of the running total. Found by the native-miscompile hunt across the `control-flow` / `side-effects` dimensions (8 of the hunt's findings collapse to this one root cause).

## Fix

Compiling this correctly needs mutable top-level bindings allocated as real shared globals (`.data`/`.bss`) that every frame loads/stores through — a broad change to the variable model that also touches the static-fold tracking, GC roots, and the inline path. For now, **refuse the capture with a clean diagnostic** rather than miscompiling it (`native recursive function capturing a mutable top-level binding is not supported`), matching how native already refuses other unrepresentable constructs (e.g. #477 enum equality).

Narrowly scoped — only `mutable` captures from out-of-line (self-recursive) functions are refused:
- a self-recursive capture of an **immutable** top-level `val` is still snapshotted correctly (`val one = 1; def fact(n) = ... fact(n - one)` → 120);
- a **non-recursive** function mutating a global is inlined and reaches the real slot, so it keeps working.

## Verification

- The miscompiling programs now emit a clean diagnostic; immutable-capture recursion, non-recursive global mutation, pure recursion, and top-level-only mutation all still build and match eval.
- New regression test `native_refuses_recursive_capture_of_mutable_global` (Linux-gated).
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 480 passed).

The proper fix (real shared globals for mutable top-level bindings) is left as a documented follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)