### PR TITLE
fix: resolve a nominal record annotation to its record type

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -651,12 +651,26 @@ impl TypeChecker {
                     Type::Enum(name, head_args) if head_args.is_empty() => {
                         return Type::Enum(name.clone(), args);
                     }
+                    Type::Named(name) if self.record_schemas.contains_key(name) => {
+                        return Type::Record(name.clone(), args);
+                    }
+                    Type::Record(name, head_args) if head_args.is_empty() => {
+                        return Type::Record(name.clone(), args);
+                    }
                     _ => {}
                 }
                 Type::Applied(Box::new(head), args)
             }
             Type::Named(name) if self.enum_schemas.contains_key(name) => {
                 Type::Enum(name.clone(), Vec::new())
+            }
+            // Annotations parse a nominal record name as `Named`; normalize
+            // it to the nominal record type so a `p: Point` annotation
+            // unifies with a `#Point(...)` constructor (which is already a
+            // `Type::Record`). Without this the annotation stayed `Named` and
+            // failed to unify (`Point is not compatible with #Point`).
+            Type::Named(name) if self.record_schemas.contains_key(name) => {
+                Type::Record(name.clone(), Vec::new())
             }
             Type::Record(name, args) => Type::Record(
                 name.clone(),

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -3200,6 +3200,72 @@ fn native_refuses_recursive_capture_of_mutable_global() {
     );
 }
 
+/// A nominal record type annotation (`p: Point`) accepts the corresponding
+/// `#Point(...)` constructor. The annotation used to stay a `Named` type
+/// while the constructor produced a `Record` type, so they failed to unify
+/// (`Point is not compatible with #Point`), making annotated record params
+/// and returns unusable. Native must match the evaluator on the now-accepted
+/// program.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn builds_native_executable_for_annotated_nominal_record() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-native-recordann-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-native-recordann-{unique}"));
+    fs::write(
+        &source_path,
+        "record Point { x: Int; y: Int }\n\
+         def sum(p: Point): Int = p.x + p.y\n\
+         def mk(a: Int): Point = #Point(a, a + 1)\n\
+         val q: Point = #Point(10, 20)\n\
+         println(sum(#Point(3, 4)))\n\
+         println(sum(mk(5)))\n\
+         println(q.y)\n",
+    )
+    .expect("source should write");
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(
+        eval.status.success(),
+        "eval failed:\n{}",
+        String::from_utf8_lossy(&eval.stderr)
+    );
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("klassic build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(String::from_utf8_lossy(&eval.stdout), "7\n11\n20\n");
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&eval.stdout),
+        "native output must match eval for annotated nominal records"
+    );
+}
+
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[test]
 fn builds_native_executable_for_static_folded_recursive_list_function() {

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -423,6 +423,36 @@ fn record_specs_are_covered_more_directly() {
     )
     .expect_err("record field mismatch should fail");
     assert!(field_error.to_string().contains("type mismatch"));
+
+    // A nominal record type annotation accepts the corresponding `#Name(...)`
+    // constructor: the annotation `p: Point` and the constructed value
+    // `#Point(...)` must unify. Both used to be different type
+    // representations (`Named` vs `Record`), so the annotation was rejected
+    // with `Point is not compatible with #Point`.
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "record Point {\n  x: Int\n  y: Int\n}\ndef sum(p: Point): Int = p.x + p.y\nsum(#Point(3, 4))",
+        )
+        .unwrap(),
+        Value::Int(7)
+    );
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "record Point {\n  x: Int\n  y: Int\n}\nval q: Point = #Point(1, 2)\nq.y",
+        )
+        .unwrap(),
+        Value::Int(2)
+    );
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "record Point {\n  x: Int\n  y: Int\n}\ndef mk(a: Int): Point = #Point(a, a + 1)\nmk(5).y",
+        )
+        .unwrap(),
+        Value::Int(6)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem (type-checker soundness/usability)

A nominal record type annotation was rejected against the matching constructor, making annotated record parameters, returns, and `val` bindings unusable:

```kl
record Point { x: Int; y: Int }
def sum(p: Point): Int = p.x + p.y
sum(#Point(3, 4))   // type mismatch: Point is not compatible with #Point

val q: Point = #Point(1, 2)   // also rejected
```

## Root cause

The checker's `resolve` normalizes a bare enum name (`Type::Named`) to its nominal `Type::Enum`, but had **no matching arm for records**. So a `Point` annotation stayed `Type::Named("Point")` (displays as `Point`) while the `#Point(...)` constructor produced `Type::Record("Point", [])` (displays as `#Point`). The two type constructors never unified — hence `Point is not compatible with #Point`.

`normalize_constraint_type` already mapped `Named` records to `Type::Record` for constraints, but general annotation resolution missed it.

## Fix

Add the record arms to `resolve` — both the zero-argument and the applied (parameterized) cases — mirroring the existing enum normalization. A record annotation now resolves to the nominal record type and unifies with its constructor. The `#Name` display and the previously-working `#Point` annotation form are unaffected.

## Verification

- eval == native on annotated record params, returns, `val` bindings, equality, nesting, and lists of records.
- New regression tests: `record_specs_are_covered_more_directly` (evaluator, in `language_regressions`) and `builds_native_executable_for_annotated_nominal_record` (eval==native, Linux-gated).
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 481 passed).

Found manually while probing record handling alongside the native-miscompile hunt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)