### PR TITLE
fix: allow structural-record width subtyping in assignability

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -1162,7 +1162,14 @@ impl TypeChecker {
                 let row = self.enforce_assignable(*left, *right, span)?;
                 Ok(Type::StructuralRecord(Box::new(row)))
             }
-            (Type::RowEmpty, Type::RowEmpty) => Ok(Type::RowEmpty),
+            // Width subtyping (assignability only): once the expected row has
+            // no more required fields, the actual record may still carry extra
+            // fields (or an open tail). A wider record is assignable to the
+            // narrower expected type, so the extras are ignored — the
+            // documented row-polymorphic behavior where a function "looks for
+            // the fields it mentions and ignores the rest". This is sound only
+            // for the directional assignability check, not for `unify`.
+            (Type::RowEmpty, actual) if is_row_type(&actual) => Ok(actual),
             (Type::RowExtend(label, field, rest), row) if is_row_type(&row) => {
                 let (other_field, other_rest) = self.rewrite_row(row, &label, span)?;
                 let unified_field = self.enforce_assignable(*field, other_field, span)?;

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -3266,6 +3266,68 @@ fn builds_native_executable_for_annotated_nominal_record() {
     );
 }
 
+/// Structural-record width subtyping: a function whose parameter type
+/// mentions a subset of fields accepts a richer record, ignoring the extra
+/// fields (the documented row-polymorphic behavior). The explicit annotation
+/// `{ x: Int }` used to be treated as a closed row, so passing a record with
+/// extra fields was rejected. Native must match the evaluator.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn builds_native_executable_for_record_width_subtyping() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-native-rowwidth-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-native-rowwidth-{unique}"));
+    fs::write(
+        &source_path,
+        "def name_of(o: { name: String }): String = o.name\n\
+         def add(r: { a: Int; b: Int }): Int = r.a + r.b\n\
+         println(name_of(record { name: \"Klassic\"; age: 7 }))\n\
+         println(add(record { a: 1; b: 2; c: 3; d: 4 }))\n",
+    )
+    .expect("source should write");
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(
+        eval.status.success(),
+        "eval failed:\n{}",
+        String::from_utf8_lossy(&eval.stderr)
+    );
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("klassic build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(String::from_utf8_lossy(&eval.stdout), "Klassic\n3\n");
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&eval.stdout),
+        "native output must match eval for record width subtyping"
+    );
+}
+
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[test]
 fn builds_native_executable_for_static_folded_recursive_list_function() {

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -453,6 +453,37 @@ fn record_specs_are_covered_more_directly() {
         .unwrap(),
         Value::Int(6)
     );
+
+    // Structural-record width subtyping: a function whose parameter mentions
+    // a subset of fields accepts a richer record (the documented
+    // "looks for the fields it mentions and ignores the rest" behavior).
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "def name_of(o: { name: String }): String = o.name\nname_of(record { name: \"Klassic\"; age: 7 })",
+        )
+        .unwrap(),
+        Value::String("Klassic".to_string())
+    );
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "def add(r: { a: Int; b: Int }): Int = r.a + r.b\nadd(record { a: 1; b: 2; c: 3; d: 4 })",
+        )
+        .unwrap(),
+        Value::Int(3)
+    );
+    // A missing required field is still rejected (narrowing is not allowed).
+    let missing = evaluate_text(
+        "<expr>",
+        "def need_x(r: { x: Int }): Int = r.x\nneed_x(record { y: 2 })",
+    )
+    .expect_err("a record missing a required field should be rejected");
+    assert!(
+        missing
+            .to_string()
+            .contains("is not available on this record")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem (type-checker / documentation mismatch)

The book documents structural-record width subtyping — *"the expected-type-driven check looks for the fields the function mentions and ignores the rest, so you can pass richer records freely"* (`docs/book/src/tour/records.md`) — but it didn't work:

```kl
def name_of(o: { name: String }): String = o.name
name_of(record { name: "Klassic"; age: 7 })
// field `age` is not available on this record
```

Row polymorphism is a headline feature (`introduction.md`), and the **inferred** case works (`def idr(r) = r.name` accepts any record with `name`). But an **explicit** structural-record annotation `{ name: String }` parsed to a *closed* row ending in `RowEmpty`, so passing a record with extra fields was rejected.

## Root cause

In `enforce_assignable`, once the expected row is exhausted (`RowEmpty`) and the actual still has fields, the `(RowEmpty, RowExtend)` pair fell through to the generic row case, which tried to rewrite the empty expected row to find the extra label and failed.

## Fix

Generalize the assignability row terminator from `(RowEmpty, RowEmpty)` to `(RowEmpty, actual) if is_row_type(&actual)`: once the expected row has no more required fields, any extra fields (or an open tail) the actual record carries are ignored. This is the documented behavior and is sound for the **directional** assignability check only — **`unify` is left unchanged**, so inference still treats `{x}` and `{x, y}` as distinct types.

Still correctly rejected: a record missing a required field (narrowing), or a field of the wrong type. Nested width subtyping works.

## Verification

- eval == native on width subtyping (single/multi field, nested), with narrowing and wrong-field-type still rejected.
- New regression tests: `record_specs_are_covered_more_directly` (evaluator) and `builds_native_executable_for_record_width_subtyping` (eval==native, Linux-gated).
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 482 passed).

Found manually while probing the type system against the documented language surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)