### PR TITLE
fix: treat a bare record type parameter as a type variable

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -4065,7 +4065,16 @@ impl TypeChecker {
                         .annotation
                         .as_ref()
                         .map(|annotation| {
-                            parse_schema_type_annotation(&annotation.text, type_params)
+                            // Mirror the enum path: a bare type-parameter name
+                            // (`record Box<a> { v: a }`) parses to `Named("a")`,
+                            // so generify it to `Generic("a")` like enums do.
+                            // Without this only the `'a` form became a type
+                            // variable and `<a>` was treated as a concrete type,
+                            // so `#Box(5)` failed to unify.
+                            generify_named_params(
+                                parse_schema_type_annotation(&annotation.text, type_params),
+                                type_params,
+                            )
                         })
                         .unwrap_or(Type::Dynamic);
                     (field.name.clone(), ty)

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -484,6 +484,23 @@ fn record_specs_are_covered_more_directly() {
             .to_string()
             .contains("is not available on this record")
     );
+
+    // A bare lowercase record type parameter (`record Box<a>`) is a type
+    // variable, consistent with enums (`enum Option<a>`). It used to be
+    // treated as a concrete type, so `#Box(5)` failed to unify; only the
+    // `'a` form worked.
+    assert_eq!(
+        evaluate_text("<expr>", "record Box<a> {\n  v: a\n}\nval b = #Box(5)\nb.v",).unwrap(),
+        Value::Int(5)
+    );
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "record Pair<a, b> {\n  fst: a\n  snd: b\n}\nval p = #Pair(1, \"two\")\np.snd",
+        )
+        .unwrap(),
+        Value::String("two".to_string())
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem (type-checker consistency)

A bare lowercase record type parameter was treated as a concrete type instead of a type variable, so a generic record could not be constructed:

```kl
record Box<a> { v: a }
val b = #Box(5)        // type mismatch: a is not compatible with Int
```

Enums already accept a bare `<a>` type parameter — `enum Option<a>` is the canonical form (CLAUDE.md) and the generic-enum machinery treats it as a type variable. Only the `'a` form worked for records, so enums and records were inconsistent for the same syntax.

## Root cause

`record_schema_from_fields` parsed each field type with `parse_schema_type_annotation` (which only generifies the `'a` form) but omitted the `generify_named_params` pass that `register_enum_declaration` applies — turning a bare `Named("a")` whose name is in `type_params` into `Generic("a")`.

## Fix

Apply the same `generify_named_params` wrap to record field types, mirroring the enum path. A bare `<a>` record parameter is now a type variable.

## Verification

- `record Box<a> { v: a }; #Box(5)` works; multi-parameter `record Pair<a, b>` works; use through an annotated function works; the `'a` form still works.
- Concrete field types are still type-checked (`#P("str")` for `record P { x: Int }` is rejected).
- New regression cases in `record_specs_are_covered_more_directly`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 482 passed).

Found while probing the type system for feature-syntax inconsistencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)