### PR TITLE
fix: treat a bare def type parameter as a type variable

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -1733,7 +1733,7 @@ impl TypeChecker {
             }
             Expr::DefDecl {
                 name,
-                type_params: _,
+                type_params,
                 constraints,
                 params,
                 param_annotations,
@@ -1742,6 +1742,16 @@ impl TypeChecker {
                 span,
             } => {
                 let mut named = HashMap::new();
+                // Seed the annotation parser with the explicit type
+                // parameters so a bare `<a>` name is a type variable, like
+                // enums/records/extensions. Without this only the `'a` form
+                // became a variable and `def id<a>(x: a): a` treated `a` as a
+                // concrete type, so `id(5)` failed to unify.
+                for type_param in type_params {
+                    named
+                        .entry(type_param.clone())
+                        .or_insert_with(|| self.fresh_var());
+                }
                 // Reuse the block-level predeclaration's variables when
                 // one exists, so forward calls already checked against
                 // them constrain this definition.

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -224,6 +224,27 @@ fn typechecker_specs_are_covered_more_directly() {
             .to_string()
             .contains("function expects 2 arguments but got 1")
     );
+
+    // A bare lowercase `def` type parameter (`def id<a>(x: a): a`) is a type
+    // variable, consistent with enums/records/extensions. It used to be
+    // treated as a concrete type, so even `id(5)` failed to unify; only the
+    // `'a` form worked.
+    assert_eq!(
+        evaluate_text("<expr>", "def id<a>(x: a): a = x\nid(5)").unwrap(),
+        Value::Int(5)
+    );
+    assert_eq!(
+        evaluate_text("<expr>", "def id<a>(x: a): a = x\nid(id(5))").unwrap(),
+        Value::Int(5)
+    );
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "def const<a, b>(x: a, y: b): a = x\nconst(1, \"ignored\")",
+        )
+        .unwrap(),
+        Value::Int(1)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem (type-checker consistency)

A bare lowercase `def` type parameter was treated as a concrete type instead of a type variable, so even a single call failed:

```kl
def id<a>(x: a): a = x
id(5)          // type mismatch: a is not compatible with Int
```

Enums (`enum Option<a>`), records (#489), and extension methods (`extension <a>(this: List<a>)`) already accept a bare `<a>` type parameter; only `def` did not, and only the `'a` form (`def id<'a>`) worked for it. This was the last of the four declaration forms to be inconsistent.

## Root cause

The `DefDecl` inference ignored its `type_params` entirely (`type_params: _`), and the annotation parser only treats an apostrophe-prefixed `'a` as a variable — a bare name is looked up in the `named` map and otherwise becomes a concrete `Named` type. The extension-method path seeds `named` with its type parameters (which is why it works); `def` did not.

## Fix

Seed `named` with the def's explicit type parameters before parsing its annotations, exactly as the extension-method path already does, so a bare `<a>` name resolves to a fresh type variable. The forward-reference predeclaration already skips generic defs, so it needs no change.

## Verification

- `def id<a>(x: a): a = x` works for `id(5)`, `id(id(5))`, and at two types (`id(5)`/`id("hi")`); `def const<a, b>` works; the `'a` form still works.
- A type variable constrained by the body (`def bad<a>(x: a): Int = x`) is still soundly monomorphized.
- New regression cases in `typechecker_specs_are_covered_more_directly`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 482 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)