### PR TITLE
fix: treat a bare typeclass type parameter as a type variable

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -3627,7 +3627,14 @@ impl TypeChecker {
                 .iter()
                 .map(|method| TypeClassMethodInfo {
                     name: method.name.clone(),
-                    ty: parse_schema_type_annotation(&method.annotation.text, type_params),
+                    // Mirror the enum/record path: a bare class type
+                    // parameter (`typeclass Show<a> where { show: (a) => ... }`)
+                    // parses to `Named("a")`, so generify it to a type
+                    // variable like the `'a` form already is.
+                    ty: generify_named_params(
+                        parse_schema_type_annotation(&method.annotation.text, type_params),
+                        type_params,
+                    ),
                 })
                 .collect(),
         }

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -619,6 +619,33 @@ fn typeclass_simple_specs_are_covered() {
 }
 
 #[test]
+fn typeclass_bare_type_param_specs_are_covered() {
+    // A bare lowercase class type parameter (`typeclass Show<a>`) is a type
+    // variable, consistent with enums/records/defs/extensions. It used to be
+    // treated as a concrete type, so the method signature `(a) => String` did
+    // not match the `Int` instance and `show(42)` failed.
+    let program = r#"
+        typeclass Show<a> where {
+          show: (a) => String
+        }
+
+        instance Show<Int> where {
+          def show(x: Int): String = "I" + x
+        }
+
+        instance Show<Boolean> where {
+          def show(b: Boolean): String = if(b) "Y" else "N"
+        }
+
+        show(42) + ", " + show(true)
+    "#;
+    assert_eq!(
+        evaluate_text("<expr>", program).unwrap(),
+        Value::String("I42, Y".to_string())
+    );
+}
+
+#[test]
 fn higher_kinded_typeclass_specs_are_covered() {
     let program = r#"
         typeclass Functor<'f: * => *> where {


### PR DESCRIPTION
## Problem (type-checker consistency)

A bare lowercase class type parameter was treated as a concrete type, so the method signature did not match its instances:

```kl
typeclass Show<a> where { show: (a) => String }
instance Show<Int> where { def show(x: Int): String = "I" + x }
show(42)        // type mismatch: a is not compatible with Int
```

Enums (`enum Option<a>`), records (#489), defs (#490), and extension methods already accept a bare `<a>` type parameter; only typeclass declarations still treated it as a concrete type, and only the `'a` form worked. This is the last declaration kind to gain bare-`<a>` support.

## Root cause

`build_typeclass_info` parsed each method signature with `parse_schema_type_annotation` but omitted the `generify_named_params` pass that the enum/record paths apply — turning a bare `Named("a")` whose name is in `type_params` into a type variable.

## Fix

Apply the same `generify_named_params` wrap to typeclass method signatures, mirroring the enum/record fix. A bare `typeclass Show<a>` now resolves its method types over a type variable.

## Verification

- `typeclass Show<a>` with direct calls (`show(42)`, `show(true)`) works; the `'a` form still works; the cumulative book `type-classes.md` examples still pass.
- New regression test `typeclass_bare_type_param_specs_are_covered`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 482 passed).

Note: a bare `where Show<a>` constraint still fails at runtime instance-dictionary dispatch (the type checker accepts it); that is a separate, deeper evaluator issue and is left as a follow-up. The documented `'a` form is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)