### PR TITLE
fix: check receiver type arguments in extension-method dispatch

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -2034,7 +2034,9 @@ impl TypeChecker {
                 if let Some(method_type) = self.builtin_value_method_type(&target_type, field) {
                     return Ok(method_type);
                 }
-                if let Some(method_type) = self.user_extension_method_type(&target_type, field) {
+                if let Some(method_type) =
+                    self.user_extension_method_type(&target_type, field, *span)
+                {
                     return Ok(method_type);
                 }
                 match self.resolve(&target_type) {
@@ -4413,18 +4415,29 @@ impl TypeChecker {
         Ok(Type::Unit)
     }
 
-    fn user_extension_method_type(&mut self, target: &Type, field: &str) -> Option<Type> {
+    fn user_extension_method_type(
+        &mut self,
+        target: &Type,
+        field: &str,
+        span: Span,
+    ) -> Option<Type> {
         let resolved = self.resolve(target);
         let key = dispatch_key_for_type(&resolved)?;
         let stored = resolve_user_extension_method_type(&key, field)?;
         let adopted = self.adopt_stored_type(&stored);
         let instantiated = self.instantiate_stored_type(&adopted);
         match instantiated {
-            // Drop the leading `this` parameter — dispatch already
-            // supplies the receiver, so the user-visible method type
-            // only carries any extra arguments.
             Type::Function(mut params, ret) if !params.is_empty() => {
-                params.remove(0);
+                // Unify the receiver against the declared `this` type before
+                // dropping it, so the receiver's concrete type arguments flow
+                // into the method's type variables (and a concrete receiver
+                // mismatch is rejected). `dispatch_key_for_type` keys only on
+                // the type constructor, so without this an
+                // `extension (this: List<Int>)` applied to a `List<String>`
+                // kept `Int` and silently accepted ill-typed arguments, and a
+                // generic `extension <a>(this: Box<a>)` left `a` free.
+                let this_param = params.remove(0);
+                self.unify(this_param, resolved, span).ok()?;
                 Some(Type::Function(params, ret))
             }
             other => Some(other),

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -22343,6 +22343,78 @@ fn extension_methods_dispatch_on_list_int() {
     assert_eq!(String::from_utf8_lossy(&output.stdout), "15\n()\n");
 }
 
+/// Extension-method dispatch unifies the receiver against the declared
+/// `this` type, so the receiver's concrete type arguments are honoured.
+/// A concrete `extension (this: List<Int>)` no longer applies to a
+/// `List<String>`, and a generic `extension <a>(this: Box<a>)` binds `a`
+/// to the receiver's element type — so an ill-typed argument is rejected
+/// instead of being silently accepted (the result used to be typed at the
+/// wrong argument, e.g. `Option<Int>.getOrElse("x")` returning a String).
+#[test]
+fn extension_method_dispatch_checks_receiver_type_arguments() {
+    // A concrete `List<Int>` extension does not apply to a `List<String>`.
+    let wrong_element = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "extension (this: List<Int>) { def headInt(): Int = head(this) }\n\
+             val strs: List<String> = [\"hello\"]\n\
+             val n: Int = strs.headInt()\n\
+             println(n + 100)",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        !wrong_element.status.success(),
+        "a List<Int> extension must not apply to a List<String>"
+    );
+    assert!(
+        String::from_utf8_lossy(&wrong_element.stderr).contains("headInt"),
+        "expected a no-such-method diagnostic, got:\n{}",
+        String::from_utf8_lossy(&wrong_element.stderr)
+    );
+
+    // A generic extension binds `a` to the receiver's element type, so a
+    // wrong-typed argument is a type error.
+    let wrong_arg = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "enum Box<a> { case Full(v: a); case Empty }\n\
+             extension <a>(this: Box<a>) { def getOr(v: a): a = this match { case Full(x) => x; case Empty => v } }\n\
+             val b: Box<Int> = Empty\n\
+             println(b.getOr(\"STR\"))",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        !wrong_arg.status.success(),
+        "Box<Int>.getOr must reject a String argument"
+    );
+    assert!(
+        String::from_utf8_lossy(&wrong_arg.stderr).contains("not compatible"),
+        "expected a type-mismatch diagnostic, got:\n{}",
+        String::from_utf8_lossy(&wrong_arg.stderr)
+    );
+
+    // Correct usage still compiles and runs: the matching concrete receiver
+    // and the generic extension at its real element type both work.
+    let correct = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "enum Box<a> { case Full(v: a); case Empty }\n\
+             extension <a>(this: Box<a>) { def getOr(v: a): a = this match { case Full(x) => x; case Empty => v } }\n\
+             val b: Box<Int> = Full(7)\n\
+             println(b.getOr(0))",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        correct.status.success(),
+        "correct extension usage must still work\nstderr:\n{}",
+        String::from_utf8_lossy(&correct.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&correct.stdout), "7\n()\n");
+}
+
 /// Native build now supports extension methods on built-in types by
 /// desugaring `extension (this: T) { def m() = ... }` into a
 /// mangled top-level def `__ext_T_m(this) = ...` and rewriting


### PR DESCRIPTION
## Problem (type soundness hole, HIGH)

User extension-method dispatch ignored the receiver's type arguments, accepting ill-typed programs:

```kl
extension (this: List<Int>) { def headInt(): Int = head(this) }
val strs: List<String> = ["hello"]
val n: Int = strs.headInt()    // accepted; n actually holds the String "hello"
println(n + 100)               // prints "hello100"

val o: Option<Int> = some(42)
val r = o.getOrElse("WRONG")   // accepted; r is typed/used as String
```

The free-function form (`getOrElse(o, "WRONG")`) was correctly rejected, so only the dot-method dispatch path was unsound. Found by the type-soundness hunt — 7 of its confirmed findings collapse to this one root cause (Option/Result/Box/List extension methods, several HIGH).

## Root cause

`user_extension_method_type` keyed dispatch on the type constructor alone (`dispatch_key_for_type` discards type arguments), instantiated the stored method type with fresh variables, and dropped the leading `this` parameter **without ever unifying it against the actual receiver**. So a concrete `List<Int>` receiver type never met a `List<String>` value, and a generic `extension <a>(this: Box<a>)` left `a` free, accepting any argument.

## Fix

Unify the receiver against the instantiated `this` parameter before dropping it (threading the call-site span for the diagnostic). The receiver's concrete type arguments now flow into the method's type variables — a generic extension binds its parameter to the element type — and a concrete receiver-type mismatch no longer resolves the method.

## Verification

- The three unsound cases (`List<Int>` ext on `List<String>`, `Option<Int>.getOrElse(String)`, `Box<Int>.getOr(String)`) are now rejected.
- Correct usage is unaffected: matching concrete receiver, generic extension at its real element type, method chains (`some(10).map(...).getOrElse(0)`), and use inside generic functions.
- New regression test `extension_method_dispatch_checks_receiver_type_arguments`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 483 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)