### PR TITLE
fix: carry typeclass constraints through indirect binding references

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -1455,25 +1455,23 @@ impl TypeChecker {
             Expr::Unit { .. } => Ok(Type::Unit),
             Expr::Identifier { name, span } => {
                 if let Some(binding) = self.lookup(name).cloned() {
-                    if binding
-                        .constraints
-                        .iter()
-                        .any(|c| matches!(c.class_name.as_str(), "Num" | "Plus"))
-                    {
-                        // Referencing an operator-constrained binding
-                        // indirectly (a val, a higher-order argument, ...)
-                        // must carry its Num/Plus constraints, or a bad
-                        // instantiation would type-check and crash at run
-                        // time. Instantiate type + constraints with shared
-                        // fresh variables and record the operator ones so the
+                    if !binding.constraints.is_empty() {
+                        // Referencing a constrained binding indirectly (a val,
+                        // a higher-order argument, ...) must carry its
+                        // constraints, or a bad instantiation would type-check
+                        // and crash at run time. Instantiate type + constraints
+                        // with shared fresh variables and record them so the
                         // enclosing generalization (or the program-end settle)
-                        // checks them. User constraints keep their existing
-                        // direct-call-only behaviour.
+                        // checks them — e.g. `val f: (Boolean) => String =
+                        // display` (where `display` needs `Show`) now reports
+                        // the missing `Show<Boolean>` instance instead of
+                        // dropping the constraint and failing at runtime. A
+                        // still-free constraint variable is generalized rather
+                        // than rejected, so storing a polymorphic constrained
+                        // function in a `val` and calling it later still works.
                         let (ty, constraints) = self.instantiate_binding_signature(&binding);
                         for constraint in constraints {
-                            if matches!(constraint.class_name.as_str(), "Num" | "Plus")
-                                && !self.inferred_constraints.contains(&constraint)
-                            {
+                            if !self.inferred_constraints.contains(&constraint) {
                                 self.inferred_constraints.push(constraint);
                             }
                         }

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -646,6 +646,58 @@ fn typeclass_bare_type_param_specs_are_covered() {
 }
 
 #[test]
+fn constrained_binding_indirect_reference_carries_constraint() {
+    // Assigning a class-constrained generic function to a concrete function
+    // type discharges its constraint at that type: `display` needs `Show`, so
+    // binding it at `(Boolean) => String` reports the missing `Show<Boolean>`
+    // instance instead of dropping the constraint and crashing at runtime.
+    let no_instance = evaluate_text(
+        "<expr>",
+        "typeclass Show<'a> where { show: ('a) => String }\n\
+         instance Show<Int> where { def show(x: Int): String = \"n:\" + x }\n\
+         def display<Show 'a>(x: 'a): String = show(x)\n\
+         val f: (Boolean) => String = display\n\
+         f(true)",
+    )
+    .expect_err("a constrained binding bound at a type without an instance should fail");
+    assert!(
+        no_instance
+            .to_string()
+            .contains("missing instance for Show"),
+        "expected a missing-instance error, got: {no_instance}"
+    );
+
+    // Binding it at a type that does have an instance still works.
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "typeclass Show<'a> where { show: ('a) => String }\n\
+             instance Show<Int> where { def show(x: Int): String = \"n:\" + x }\n\
+             def display<Show 'a>(x: 'a): String = show(x)\n\
+             val f: (Int) => String = display\n\
+             f(5)",
+        )
+        .unwrap(),
+        Value::String("n:5".to_string())
+    );
+
+    // Storing the polymorphic constrained function in a `val` and calling it
+    // later at a concrete type still works (the free constraint generalizes).
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "typeclass Show<'a> where { show: ('a) => String }\n\
+             instance Show<Int> where { def show(x: Int): String = \"i\" + x }\n\
+             def display<Show 'a>(x: 'a): String = show(x)\n\
+             val g = display\n\
+             g(5)",
+        )
+        .unwrap(),
+        Value::String("i5".to_string())
+    );
+}
+
+#[test]
 fn higher_kinded_typeclass_specs_are_covered() {
     let program = r#"
         typeclass Functor<'f: * => *> where {


### PR DESCRIPTION
## Problem (type soundness hole)

Assigning a class-constrained generic function to a concrete function type dropped its constraint, accepting an ill-typed program that crashed at runtime:

```kl
typeclass Show<'a> where { show: ('a) => String }
instance Show<Int> where { def show(x: Int): String = "n:" + x }
def display<Show 'a>(x: 'a): String = show(x)

val f: (Boolean) => String = display    // accepted (no Show<Boolean> instance!)
f(true)                                  // runtime: no matching instance dictionary
```

The direct-call form (`display(true)`) is correctly rejected at compile time. Found by the type-soundness hunt.

## Root cause

When an identifier references a constrained binding indirectly (a `val`, a higher-order argument), only operator (`Num`/`Plus`) constraints were recorded into the inferred-constraint set; user typeclass constraints were deliberately left to "direct-call-only" behaviour (per the in-code comment). So the missing instance was never reported on the assignment path.

## Fix

Record **every** constraint of an indirectly-referenced binding, not just the operator ones, so it is discharged by the enclosing generalization or the program-end settle. A still-free constraint variable generalizes rather than erroring, so the conservative "direct-call-only" limitation turned out to be unnecessary.

## Verification

- `val f: (Boolean) => String = display` is now rejected at compile time with `missing instance for Show<Boolean>`.
- Legitimate uses still work: binding at a type that has an instance (`val f: (Int) => String = display`), storing the polymorphic function in a `val` and calling it later (`val g = display; g(5)`), passing it as a higher-order argument, and operator-constrained vals (`val f = add; f(2, 3)`).
- New regression test `constrained_binding_indirect_reference_carries_constraint`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 483 passed) — no existing typeclass test regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)