### PR TITLE
fix: keep distinct type variables for two constraints on one class

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -3714,10 +3714,24 @@ impl TypeChecker {
                 .zip(constraint.arguments.iter().cloned())
                 .collect();
             for method in &info.methods {
-                self.declare_mono(
+                // Declare the class method polymorphically over the
+                // constraint's type variables with the constraint attached,
+                // rather than monomorphically tied to one constraint's
+                // argument. Each use then instantiates fresh and records the
+                // constraint at its concrete type. This lets two constraints
+                // on the same class with different type variables
+                // (`def pair<Show 'a, Show 'b>`) both reach `show` without
+                // unifying `'a` and `'b` — the old `declare_mono` overwrote
+                // the method with the last constraint's type, forcing the two
+                // variables equal and spuriously rejecting mixed-type calls.
+                let ty = substitute_generics(&method.ty, &substitutions);
+                let generalized = free_vars(&ty);
+                self.declare(
                     method.name.clone(),
                     false,
-                    substitute_generics(&method.ty, &substitutions),
+                    ty,
+                    generalized,
+                    vec![constraint.clone()],
                 );
             }
         }

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -646,6 +646,40 @@ fn typeclass_bare_type_param_specs_are_covered() {
 }
 
 #[test]
+fn two_constraints_on_same_class_use_distinct_type_variables() {
+    // `def pair<Show 'a, Show 'b>` has two constraints on the same class with
+    // different type variables. The class method `show` must be usable at both
+    // `'a` and `'b` without forcing them equal, so a mixed-type call is
+    // accepted. The method declaration used to be overwritten by the last
+    // constraint, unifying `'a` and `'b` and spuriously rejecting `pair(1, "x")`.
+    let program = r#"
+        typeclass Show<'a> where { show: ('a) => String }
+        instance Show<Int> where { def show(x: Int): String = "i" }
+        instance Show<String> where { def show(x: String): String = "s" }
+        def pair<Show 'a, Show 'b>(x: 'a, y: 'b): String = show(x) + show(y)
+        pair(1, "two")
+    "#;
+    assert_eq!(
+        evaluate_text("<expr>", program).unwrap(),
+        Value::String("is".to_string())
+    );
+
+    // A missing instance for either type variable is still rejected.
+    let missing = evaluate_text(
+        "<expr>",
+        "typeclass Show<'a> where { show: ('a) => String }\n\
+         instance Show<Int> where { def show(x: Int): String = \"i\" }\n\
+         def pair<Show 'a, Show 'b>(x: 'a, y: 'b): String = show(x) + show(y)\n\
+         pair(1, true)",
+    )
+    .expect_err("a missing instance for one constraint should fail");
+    assert!(
+        missing.to_string().contains("missing instance for Show"),
+        "expected a missing-instance error, got: {missing}"
+    );
+}
+
+#[test]
 fn constrained_binding_indirect_reference_carries_constraint() {
     // Assigning a class-constrained generic function to a concrete function
     // type discharges its constraint at that type: `display` needs `Show`, so


### PR DESCRIPTION
## Problem (type-checker spurious rejection)

Two constraints on the same class with different type variables wrongly unified those variables, rejecting valid mixed-type calls:

```kl
typeclass Show<'a> where { show: ('a) => String }
instance Show<Int> where { def show(x: Int): String = "i" }
instance Show<String> where { def show(x: String): String = "s" }
def pair<Show 'a, Show 'b>(x: 'a, y: 'b): String = show(x) + show(y)
pair(1, "two")    // type mismatch: Int is not compatible with String
```

Found by the type-soundness hunt.

## Root cause

`declare_constraint_methods` declared each class method monomorphically, tied to one constraint's argument. Processing `Show<'a>` then `Show<'b>` overwrote `show` with `('b) => String`, so both `show(x)` and `show(y)` used `'b`, forcing `'a = 'b`.

## Fix

Declare the class method polymorphically over the constraint's type variables with the constraint attached, so each use instantiates fresh and records the constraint at its concrete type. `show` becomes `forall 't. Show<'t> => ('t) => String` — identical whether declared from `Show<'a>` or `Show<'b>`, so the overwrite is harmless and both `'a` and `'b` reach it independently. (Builds on #493, which records such constraints on every reference.)

## Verification

- `pair(1, "two")` now type-checks and evaluates to `"is"`.
- Soundness preserved: a missing instance for either variable is still rejected (`pair(1, true)` and `display(true)` → `missing instance for Show<Boolean>`).
- Single-constraint, combined-class (`<Show 'a, Eq 'a>`), where-clause, and higher-kinded usage are unaffected.
- New regression test `two_constraints_on_same_class_use_distinct_type_variables`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 483 passed) — no existing typeclass test regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)