### PR TITLE
fix: type-check over-application of curried functions

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -2202,7 +2202,7 @@ impl TypeChecker {
     ) -> Result<Type, Diagnostic> {
         match self.resolve(&callee_type) {
             Type::Function(params, result) => {
-                if arguments.len() != params.len() {
+                if arguments.len() < params.len() {
                     return Err(type_error(
                         span,
                         format!(
@@ -2217,10 +2217,34 @@ impl TypeChecker {
                         ),
                     ));
                 }
+                let arity = params.len();
                 for (expected, argument) in params.into_iter().zip(arguments.iter()) {
                     self.check_call_argument(expected, argument)?;
                 }
-                Ok(self.resolve(&result))
+                let result = self.resolve(&result);
+                if arguments.len() > arity {
+                    // Over-application: a curried function applied to more
+                    // arguments than its first arity. Feed the remaining
+                    // arguments to the returned function, matching the runtime
+                    // (which curries via `apply_callable`), so e.g.
+                    // `map(xs, f)` type-checks like `map(xs)(f)`. Only when the
+                    // result is itself a function — otherwise this is a genuine
+                    // too-many-arguments error (e.g. a constructor or a
+                    // scalar-returning function), reported as such.
+                    if matches!(result, Type::Function(_, _)) {
+                        return self.infer_call(result, &arguments[arity..], span, noun);
+                    }
+                    return Err(type_error(
+                        span,
+                        format!(
+                            "{noun} expects {} {} but got {}",
+                            arity,
+                            if arity == 1 { "argument" } else { "arguments" },
+                            arguments.len()
+                        ),
+                    ));
+                }
+                Ok(result)
             }
             Type::Var(id) => {
                 // The callee is an unresolved type variable — typically a
@@ -2364,7 +2388,7 @@ impl TypeChecker {
     ) -> Result<Type, Diagnostic> {
         match self.resolve(&callee_type) {
             Type::Function(params, result) => {
-                if arguments.len() != params.len() {
+                if arguments.len() < params.len() {
                     return Err(type_error(
                         span,
                         format!(
@@ -2379,10 +2403,34 @@ impl TypeChecker {
                         ),
                     ));
                 }
+                let arity = params.len();
                 for (expected, argument) in params.into_iter().zip(arguments.iter()) {
                     self.check_call_argument(expected, argument)?;
                 }
-                Ok(self.resolve(&result))
+                let result = self.resolve(&result);
+                if arguments.len() > arity {
+                    // Over-application: a curried function applied to more
+                    // arguments than its first arity. Feed the remaining
+                    // arguments to the returned function, matching the runtime
+                    // (which curries via `apply_callable`), so e.g.
+                    // `map(xs, f)` type-checks like `map(xs)(f)`. Only when the
+                    // result is itself a function — otherwise this is a genuine
+                    // too-many-arguments error (e.g. a constructor or a
+                    // scalar-returning function), reported as such.
+                    if matches!(result, Type::Function(_, _)) {
+                        return self.infer_call(result, &arguments[arity..], span, noun);
+                    }
+                    return Err(type_error(
+                        span,
+                        format!(
+                            "{noun} expects {} {} but got {}",
+                            arity,
+                            if arity == 1 { "argument" } else { "arguments" },
+                            arguments.len()
+                        ),
+                    ));
+                }
+                Ok(result)
             }
             Type::Var(id) => {
                 // The callee is an unresolved type variable — typically a

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -245,6 +245,32 @@ fn typechecker_specs_are_covered_more_directly() {
         .unwrap(),
         Value::Int(1)
     );
+
+    // Over-application: a curried function applied to more arguments than its
+    // first arity feeds the rest to the returned function, like the runtime.
+    // `map(xs, f)` used to be rejected ("expects 1 argument but got 2") even
+    // though it ran; it now type-checks like `map(xs)(f)`.
+    assert_eq!(
+        evaluate_text("<expr>", "map([1 2 3], (x) => x + 1)").unwrap(),
+        Value::List(vec![Value::Int(2), Value::Int(3), Value::Int(4)])
+    );
+    // A genuine too-many-arguments error (a non-function result) is still
+    // reported as an arity error, not silently over-applied.
+    let too_many = evaluate_text("<expr>", "def f(x: Int): Int = x\nf(1, 2)")
+        .expect_err("calling a scalar-returning function with extra args should fail");
+    assert!(
+        too_many
+            .to_string()
+            .contains("expects 1 argument but got 2")
+    );
+    // Partial application (too few arguments) is still rejected.
+    let too_few = evaluate_text("<expr>", "def g(x, y) = x + y\ng(1)")
+        .expect_err("partial application should fail");
+    assert!(
+        too_few
+            .to_string()
+            .contains("expects 2 arguments but got 1")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem (type-checker spurious rejection)

A curried function applied to more arguments than its first arity was rejected by the type checker even though the runtime curries it:

```kl
map([1 2 3], (x) => x + 1)   // function expects 1 argument but got 2
```

`map` is `(List<a>) => ((a) => b) => List<b>`, so `map(xs, f)` passes two arguments to a one-argument function. The runtime applies `xs`, then applies `f` to the returned function (via `apply_callable`), so the call runs — but `infer_call` required an exact arity match and rejected it. (The `.foldLeft(init, f)` method form was already special-cased to two args; this generalizes the same idea.)

## Fix

When a call supplies more arguments than the callee's arity **and the result is itself a function**, feed the remaining arguments to that result, matching the runtime. Guards preserved:
- too-few arguments (partial application) is still rejected;
- a too-many-arguments call whose result is **not** a function (a constructor like `Circle(1, 2)`, a scalar-returning function like `f(1, 2)`) still reports the arity error rather than being silently over-applied.

## Verification

- `map([1 2 3], (x) => x + 1)` type-checks and evaluates to `[2, 3, 4]`; eval==native for the in-`def` form (top-level over-applied `map` gets a clean native diagnostic, not a miscompile).
- `Circle(1, 2)` → `constructor expects 1 argument but got 2`; `f(1, 2)` → `function expects 1 argument but got 2`; `g(1)` (partial) → `function expects 2 arguments but got 1`.
- New regression cases in `typechecker_specs_are_covered_more_directly`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 483 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)