### PR TITLE
fix: type-check instance method bodies against their return type

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -1523,10 +1523,57 @@ impl TypeChecker {
                 class_name,
                 for_type_annotation,
                 constraints,
+                methods,
                 span,
                 ..
             } => {
                 self.register_instance(class_name, for_type_annotation, constraints, *span)?;
+                // Type-check each instance method body against its declared
+                // return type, so a body that disagrees with its signature
+                // (`def compute(x: Boolean): Int = "not an int"`) is rejected
+                // at compile time instead of crashing at runtime. The method
+                // name itself is deliberately NOT declared in the scratch
+                // scope: a class method called inside the body (e.g.
+                // `show(p.name)`) must dispatch through the polymorphic class
+                // method, not recurse into this instance's own monomorphic
+                // definition.
+                for method in methods {
+                    let Expr::DefDecl {
+                        params,
+                        param_annotations,
+                        return_annotation,
+                        body,
+                        ..
+                    } = method
+                    else {
+                        continue;
+                    };
+                    self.push_scope();
+                    let result = (|| {
+                        let mut named = HashMap::new();
+                        for (index, param) in params.iter().enumerate() {
+                            let ty = param_annotations
+                                .get(index)
+                                .and_then(|annotation| annotation.as_ref())
+                                .map(|annotation| {
+                                    self.parse_annotation_with_named_vars(annotation, &mut named)
+                                })
+                                .unwrap_or_else(|| self.fresh_var());
+                            self.declare(param.clone(), false, ty, Vec::new(), Vec::new());
+                        }
+                        let return_type = return_annotation
+                            .as_ref()
+                            .map(|annotation| {
+                                self.parse_annotation_with_named_vars(annotation, &mut named)
+                            })
+                            .unwrap_or_else(|| self.fresh_var());
+                        let body_type = self.infer_expr(body)?;
+                        self.enforce_assignable(return_type, body_type, body.span())?;
+                        Ok(())
+                    })();
+                    self.pop_scope();
+                    result?;
+                }
                 Ok(Type::Unit)
             }
             Expr::TheoremDeclaration {

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -672,6 +672,39 @@ fn typeclass_bare_type_param_specs_are_covered() {
 }
 
 #[test]
+fn instance_method_body_is_checked_against_its_return_type() {
+    // An instance method whose body disagrees with its declared return type is
+    // rejected at compile time instead of crashing at runtime. The body used
+    // to be unchecked entirely.
+    let wrong_return = evaluate_text(
+        "<expr>",
+        "typeclass Compute<'a> where { compute: ('a) => Int }\n\
+         instance Compute<Boolean> where { def compute(x: Boolean): Int = \"not an int\" }\n\
+         compute(true)",
+    )
+    .expect_err("an instance body that returns the wrong type should fail");
+    assert!(
+        wrong_return.to_string().contains("type mismatch"),
+        "expected a type-mismatch error, got: {wrong_return}"
+    );
+
+    // A class method called inside an instance body dispatches through the
+    // polymorphic class method (here `show` on a `String` field), so a
+    // correct instance that references other instances still type-checks.
+    let valid = evaluate_text(
+        "<expr>",
+        "typeclass Show<'a> where { show: ('a) => String }\n\
+         instance Show<Int> where { def show(x: Int): String = \"i\" + x }\n\
+         instance Show<String> where { def show(x: String): String = x }\n\
+         record Person { name: String; age: Int }\n\
+         instance Show<Person> where { def show(p: Person): String = show(p.name) + \"/\" + show(p.age) }\n\
+         show(#Person(\"a\", 7))",
+    )
+    .unwrap();
+    assert_eq!(valid, Value::String("a/i7".to_string()));
+}
+
+#[test]
 fn two_constraints_on_same_class_use_distinct_type_variables() {
     // `def pair<Show 'a, Show 'b>` has two constraints on the same class with
     // different type variables. The class method `show` must be usable at both


### PR DESCRIPTION
## Problem (type soundness hole, HIGH)

A typeclass instance method body was never type-checked, so a body that disagreed with its declared signature was accepted and crashed at runtime:

```kl
typeclass Compute<'a> where { compute: ('a) => Int }
instance Compute<Boolean> where { def compute(x: Boolean): Int = "not an int" }
compute(true)        // ran, printed "not an int"
```

The `InstanceDeclaration` handler ignored the `methods` field entirely. Found by the type-soundness hunt.

## Fix

Check each instance method's body against its declared return type. Two subtleties, both essential (each was a failed earlier attempt):

1. **The method's own name is not declared while checking.** A class method called inside the body — e.g. `show(p.name)` in a `Show<Person>` instance — must dispatch through the polymorphic class method (`show` on a `String` field), not recurse into this instance's monomorphic `show: (Person) => String`. Declaring the name shadowed the class method and spuriously rejected valid instances.
2. **Parameters are declared from their annotations** so the body checks in the right context, and over-application (`map(xs, f)` in a `Show<List<'a>>` body) goes through the same call inference as everywhere else (now supported, #495).

## Verification

- `def compute(x: Boolean): Int = "not an int"` is now rejected with a type mismatch; an arithmetic mismatch in a body (`def f(x: Boolean): Int = x + 1`) is caught too.
- Valid instances still type-check: multiple dispatching instances, a generic `Show<List<'a>>`, and a `Show<Person>` whose body calls `show` on its fields.
- New regression test `instance_method_body_is_checked_against_its_return_type`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 483 passed) — including the advanced typeclass-dictionary example.

Note: an instance method's *parameter* type still isn't checked against the class signature instantiated at the instance type (`instance Compute<String> { def compute(x: Int) ... }`); that signature-vs-class check is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)