### PR TITLE
fix: check instance method signatures against the class

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -1528,21 +1528,27 @@ impl TypeChecker {
                 ..
             } => {
                 self.register_instance(class_name, for_type_annotation, constraints, *span)?;
-                // Type-check each instance method body against its declared
-                // return type, so a body that disagrees with its signature
-                // (`def compute(x: Boolean): Int = "not an int"`) is rejected
-                // at compile time instead of crashing at runtime. The method
-                // name itself is deliberately NOT declared in the scratch
-                // scope: a class method called inside the body (e.g.
-                // `show(p.name)`) must dispatch through the polymorphic class
-                // method, not recurse into this instance's own monomorphic
-                // definition.
+                // Type-check each instance method against the class. Two checks:
+                // (1) its body must match its declared return type, and (2) its
+                // declared signature must match the class method signature
+                // instantiated at the instance type — so an instance whose
+                // method returns the wrong type
+                // (`def compute(x: Boolean): Int = "not an int"`) or takes the
+                // wrong type (`instance Compute<String> { def compute(x: Int) }`)
+                // is rejected at compile time instead of crashing at runtime.
+                // The method name itself is deliberately NOT declared in the
+                // scratch scope: a class method called inside the body
+                // (`show(p.name)`) must dispatch through the polymorphic class
+                // method, not recurse into this instance's monomorphic one.
+                let class_info = self.typeclasses.get(class_name).cloned();
                 for method in methods {
                     let Expr::DefDecl {
+                        name: method_name,
                         params,
                         param_annotations,
                         return_annotation,
                         body,
+                        span: method_span,
                         ..
                     } = method
                     else {
@@ -1551,6 +1557,7 @@ impl TypeChecker {
                     self.push_scope();
                     let result = (|| {
                         let mut named = HashMap::new();
+                        let mut param_types = Vec::with_capacity(params.len());
                         for (index, param) in params.iter().enumerate() {
                             let ty = param_annotations
                                 .get(index)
@@ -1559,7 +1566,8 @@ impl TypeChecker {
                                     self.parse_annotation_with_named_vars(annotation, &mut named)
                                 })
                                 .unwrap_or_else(|| self.fresh_var());
-                            self.declare(param.clone(), false, ty, Vec::new(), Vec::new());
+                            self.declare(param.clone(), false, ty.clone(), Vec::new(), Vec::new());
+                            param_types.push(ty);
                         }
                         let return_type = return_annotation
                             .as_ref()
@@ -1567,6 +1575,37 @@ impl TypeChecker {
                                 self.parse_annotation_with_named_vars(annotation, &mut named)
                             })
                             .unwrap_or_else(|| self.fresh_var());
+
+                        // (2) signature vs class method instantiated at the
+                        // instance type. Single-parameter classes only; the
+                        // shared `named` map keeps a generic instance's type
+                        // variable (`Show<List<'a>>`) consistent between the
+                        // instance type and the method signature.
+                        if let Some(info) = &class_info
+                            && info.type_params.len() == 1
+                            && let Some(class_method) =
+                                info.methods.iter().find(|m| &m.name == method_name)
+                        {
+                            let instance_type = self
+                                .parse_annotation_with_named_vars(for_type_annotation, &mut named);
+                            let instance_type = self.normalize_constraint_type(instance_type);
+                            let substitutions: HashMap<String, Type> =
+                                std::iter::once((info.type_params[0].clone(), instance_type))
+                                    .collect();
+                            let expected = substitute_generics(&class_method.ty, &substitutions);
+                            // Only compare when the class declares the member
+                            // as a function; a non-function member type is a
+                            // loose placeholder, not a signature to match.
+                            if matches!(self.resolve(&expected), Type::Function(_, _)) {
+                                let actual = Type::Function(
+                                    param_types.clone(),
+                                    Box::new(return_type.clone()),
+                                );
+                                self.unify(expected, actual, *method_span)?;
+                            }
+                        }
+
+                        // (1) body vs declared return type.
                         let body_type = self.infer_expr(body)?;
                         self.enforce_assignable(return_type, body_type, body.span())?;
                         Ok(())

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -705,6 +705,48 @@ fn instance_method_body_is_checked_against_its_return_type() {
 }
 
 #[test]
+fn instance_method_signature_is_checked_against_the_class() {
+    // An instance method whose parameter type does not match the class
+    // method instantiated at the instance type is rejected. `Compute<String>`
+    // requires `compute: (String) => Int`, so a `(Int) => Int` method is a
+    // type error instead of crashing at runtime when the String is used.
+    let wrong_param = evaluate_text(
+        "<expr>",
+        "typeclass Compute<'a> where { compute: ('a) => Int }\n\
+         instance Compute<String> where { def compute(x: Int): Int = x - 1 }\n\
+         compute(\"hello\")",
+    )
+    .expect_err("an instance method with the wrong parameter type should fail");
+    assert!(
+        wrong_param.to_string().contains("type mismatch"),
+        "expected a type-mismatch error, got: {wrong_param}"
+    );
+
+    // A multi-argument class method is checked position by position.
+    let wrong_second = evaluate_text(
+        "<expr>",
+        "typeclass Eq<'a> where { equals: ('a, 'a) => Boolean }\n\
+         instance Eq<Int> where { def equals(x: Int, y: String): Boolean = true }\n\
+         equals(1, 2)",
+    )
+    .expect_err("a mismatched second parameter should fail");
+    assert!(wrong_second.to_string().contains("type mismatch"));
+
+    // A correct generic instance still type-checks.
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "typeclass Show<'a> where { show: ('a) => String }\n\
+             instance Show<Int> where { def show(x: Int): String = \"i\" }\n\
+             instance Show<List<'a>> where Show<'a> { def show(xs: List<'a>): String = \"L\" }\n\
+             show([1 2 3])",
+        )
+        .unwrap(),
+        Value::String("L".to_string())
+    );
+}
+
+#[test]
 fn two_constraints_on_same_class_use_distinct_type_variables() {
     // `def pair<Show 'a, Show 'b>` has two constraints on the same class with
     // different type variables. The class method `show` must be usable at both


### PR DESCRIPTION
## Problem (type soundness hole)

An instance method whose parameter type disagreed with the class method instantiated at the instance type was accepted, then crashed at runtime:

```kl
typeclass Compute<'a> where { compute: ('a) => Int }
instance Compute<String> where { def compute(x: Int): Int = x - 1 }
compute("hello")     // ran, "`-` expects numbers" at runtime
```

`Compute<String>` requires `compute: (String) => Int`, but the instance declared `(Int) => Int`. Only the body (against its own return type, #496) was checked — never the declared signature against the class. Found by the type-soundness hunt.

## Fix

Unify each instance method's declared signature with the class method signature instantiated at the instance type. A single shared `named` map keeps a generic instance's type variable (`Show<List<'a>>`) consistent between the instance type and the method signature.

Scoped conservatively: single-parameter classes only, and only when the class declares the member as a function — so a non-function placeholder member (`map: Int` in `functor-basic.kl`) is left alone.

## Verification

- `instance Compute<String> { def compute(x: Int) ... }` is now rejected; a mismatched second parameter (`Eq` with `def equals(x: Int, y: String)`) is caught position-by-position.
- Correct instances still type-check: multi-argument methods, generic `Show<List<'a>>`, and record instances.
- New regression test `instance_method_signature_is_checked_against_the_class`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 483 passed).

With this, all four typeclass-machinery findings from the soundness hunt (#493, #494, #496, this) are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)