### PR TITLE
fix: check non-lambda call arguments before lambda arguments

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -2304,8 +2304,22 @@ impl TypeChecker {
                     ));
                 }
                 let arity = params.len();
-                for (expected, argument) in params.into_iter().zip(arguments.iter()) {
-                    self.check_call_argument(expected, argument)?;
+                // Check non-lambda arguments before lambda arguments: a
+                // lambda whose body dispatches on its parameter (e.g.
+                // `(lst) => lst.size()`) would otherwise commit that
+                // parameter's still-free type variable to a structural-record
+                // shape before a sibling argument pins it to the real type, so
+                // `hof((lst) => lst.size(), [1,2,3])` would spuriously fail.
+                let pairs: Vec<(Type, &Expr)> = params.into_iter().zip(arguments.iter()).collect();
+                for (expected, argument) in &pairs {
+                    if !matches!(argument, Expr::Lambda { .. }) {
+                        self.check_call_argument(expected.clone(), argument)?;
+                    }
+                }
+                for (expected, argument) in &pairs {
+                    if matches!(argument, Expr::Lambda { .. }) {
+                        self.check_call_argument(expected.clone(), argument)?;
+                    }
                 }
                 let result = self.resolve(&result);
                 if arguments.len() > arity {
@@ -2490,8 +2504,22 @@ impl TypeChecker {
                     ));
                 }
                 let arity = params.len();
-                for (expected, argument) in params.into_iter().zip(arguments.iter()) {
-                    self.check_call_argument(expected, argument)?;
+                // Check non-lambda arguments before lambda arguments: a
+                // lambda whose body dispatches on its parameter (e.g.
+                // `(lst) => lst.size()`) would otherwise commit that
+                // parameter's still-free type variable to a structural-record
+                // shape before a sibling argument pins it to the real type, so
+                // `hof((lst) => lst.size(), [1,2,3])` would spuriously fail.
+                let pairs: Vec<(Type, &Expr)> = params.into_iter().zip(arguments.iter()).collect();
+                for (expected, argument) in &pairs {
+                    if !matches!(argument, Expr::Lambda { .. }) {
+                        self.check_call_argument(expected.clone(), argument)?;
+                    }
+                }
+                for (expected, argument) in &pairs {
+                    if matches!(argument, Expr::Lambda { .. }) {
+                        self.check_call_argument(expected.clone(), argument)?;
+                    }
                 }
                 let result = self.resolve(&result);
                 if arguments.len() > arity {

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -271,6 +271,19 @@ fn typechecker_specs_are_covered_more_directly() {
             .to_string()
             .contains("expects 2 arguments but got 1")
     );
+
+    // Non-lambda arguments are checked before lambda arguments, so a lambda
+    // whose body dispatches a method on its parameter (`(lst) => lst.size()`)
+    // sees the parameter's type pinned by the sibling argument. This used to
+    // commit the parameter to a structural-record shape and reject the call.
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "def hof(f: ('a) => 'b, x: 'a): 'b = f(x)\nhof((lst) => lst.size(), [1, 2, 3])",
+        )
+        .unwrap(),
+        Value::Int(3)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem (type-checker spurious rejection)

A higher-order call with the lambda argument first was spuriously rejected:

```kl
def hof(f: ('a) => 'b, x: 'a): 'b = f(x)
hof((lst) => lst.size(), [1, 2, 3])
// type mismatch: record { size: () => 'a; ... } is not compatible with List<Int>
```

Found by the type-soundness hunt.

## Root cause

Arguments were checked left-to-right, so the lambda `(lst) => lst.size()` was checked while `'a` was still free. Its body's method dispatch (`lst.size()`) committed `'a` to a structural-record shape (field access on an unresolved variable assumes a record), and the later `[1, 2, 3]` argument then failed to unify with that shape. The free-function form `size(lst)` happened to work because it unifies `lst` with `List<a>` instead.

## Fix

In `infer_call` / `infer_constrained_call`, check non-lambda arguments first so they pin the shared type variables, then check the lambda arguments. The lambda body is now inferred with `'a` already resolved to `List<Int>`.

## Verification

- `hof((lst) => lst.size(), [1, 2, 3])` → 3; `lst.head()` variant → 1; value-first calls unaffected.
- New regression case in `typechecker_specs_are_covered_more_directly`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 483 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)