### PR TITLE
fix: check refutable payload sub-patterns in match exhaustiveness

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -4454,26 +4454,65 @@ impl TypeChecker {
         if closed {
             return Ok(());
         }
-        let Type::Enum(enum_name, _) = self.resolve(scrutinee_type) else {
+        let Type::Enum(enum_name, enum_args) = self.resolve(scrutinee_type) else {
             return Ok(());
         };
-        let Some(schema) = self.enum_schemas.get(&enum_name) else {
+        let Some(schema) = self.enum_schemas.get(&enum_name).cloned() else {
             return Ok(());
         };
-        let mut covered = HashSet::new();
-        for arm in arms {
-            if arm.guard.is_some() {
-                continue;
-            }
-            if let klassic_syntax::Pattern::Constructor { name, .. } = &arm.pattern {
-                covered.insert(name.clone());
-            }
-        }
+        let patterns: Vec<&klassic_syntax::Pattern> = arms
+            .iter()
+            .filter(|arm| arm.guard.is_none())
+            .map(|arm| &arm.pattern)
+            .collect();
+        let substitutions: HashMap<String, Type> = schema
+            .type_params
+            .iter()
+            .cloned()
+            .zip(enum_args.iter().cloned())
+            .collect();
+        // A variant is covered when it is matched and — for a single-field
+        // variant — its payload sub-patterns are themselves exhaustive, so a
+        // refutable payload (`case Wrap(1)`) or a nested constructor
+        // (`case Full(Full(x))`) that leaves part of the variant unhandled is
+        // reported as missing. Multi-field variants keep the lenient
+        // presence-covers behavior (full matrix coverage is future work).
         let missing: Vec<&str> = schema
             .variants
             .iter()
+            .filter(|(variant, field_types)| {
+                let variant_args: Vec<&[klassic_syntax::Pattern]> = patterns
+                    .iter()
+                    .filter_map(|pattern| match pattern {
+                        klassic_syntax::Pattern::Constructor { name, args, .. }
+                            if name == variant =>
+                        {
+                            Some(args.as_slice())
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                if variant_args.is_empty() {
+                    return true; // variant never matched
+                }
+                if field_types.is_empty() {
+                    return false; // nullary variant: presence covers it
+                }
+                if variant_args
+                    .iter()
+                    .any(|args| args.iter().all(pattern_is_irrefutable))
+                {
+                    return false; // an irrefutable-payload arm fully covers it
+                }
+                if field_types.len() == 1 {
+                    let field_type = substitute_generics(&field_types[0], &substitutions);
+                    let field_patterns: Vec<&klassic_syntax::Pattern> =
+                        variant_args.iter().map(|args| &args[0]).collect();
+                    return !self.patterns_cover(&field_patterns, &field_type);
+                }
+                false // multi-field: leniently considered covered
+            })
             .map(|(variant, _)| variant.as_str())
-            .filter(|variant| !covered.contains(*variant))
             .collect();
         if missing.is_empty() {
             Ok(())
@@ -4485,6 +4524,75 @@ impl TypeChecker {
                     missing.join(", ")
                 ),
             ))
+        }
+    }
+
+    /// Whether `patterns` exhaustively cover every value of `ty`, used to
+    /// check a constructor variant's payload sub-patterns recursively. A
+    /// wildcard or variable covers everything; a `Bool` needs both `true` and
+    /// `false`; an enum needs every variant covered (recursing into
+    /// single-field payloads); any other type (`Int`, `String`, ...) is only
+    /// covered by a wildcard/variable.
+    fn patterns_cover(&self, patterns: &[&klassic_syntax::Pattern], ty: &Type) -> bool {
+        use klassic_syntax::Pattern;
+        if patterns
+            .iter()
+            .any(|p| matches!(p, Pattern::Wildcard { .. } | Pattern::Variable { .. }))
+        {
+            return true;
+        }
+        match self.resolve(ty) {
+            Type::Bool => {
+                let has_true = patterns
+                    .iter()
+                    .any(|p| matches!(p, Pattern::LiteralBool { value: true, .. }));
+                let has_false = patterns
+                    .iter()
+                    .any(|p| matches!(p, Pattern::LiteralBool { value: false, .. }));
+                has_true && has_false
+            }
+            Type::Enum(enum_name, enum_args) => {
+                let Some(schema) = self.enum_schemas.get(&enum_name).cloned() else {
+                    return false;
+                };
+                let substitutions: HashMap<String, Type> = schema
+                    .type_params
+                    .iter()
+                    .cloned()
+                    .zip(enum_args.iter().cloned())
+                    .collect();
+                schema.variants.iter().all(|(variant, field_types)| {
+                    let variant_args: Vec<&[Pattern]> = patterns
+                        .iter()
+                        .filter_map(|pattern| match pattern {
+                            Pattern::Constructor { name, args, .. } if name == variant => {
+                                Some(args.as_slice())
+                            }
+                            _ => None,
+                        })
+                        .collect();
+                    if variant_args.is_empty() {
+                        return false;
+                    }
+                    if field_types.is_empty() {
+                        return true;
+                    }
+                    if variant_args
+                        .iter()
+                        .any(|args| args.iter().all(pattern_is_irrefutable))
+                    {
+                        return true;
+                    }
+                    if field_types.len() == 1 {
+                        let field_type = substitute_generics(&field_types[0], &substitutions);
+                        let field_patterns: Vec<&Pattern> =
+                            variant_args.iter().map(|args| &args[0]).collect();
+                        return self.patterns_cover(&field_patterns, &field_type);
+                    }
+                    true
+                })
+            }
+            _ => false,
         }
     }
 

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -446,6 +446,75 @@ fn map_specs_are_covered() {
 }
 
 #[test]
+fn exhaustiveness_checks_refutable_payload_subpatterns() {
+    // A constructor arm with a refutable payload does not cover its whole
+    // variant, so the match is non-exhaustive and rejected (it used to be
+    // accepted and crash at runtime with `no match arm matched value`).
+    let literal_payload = evaluate_text(
+        "<expr>",
+        "enum W { case Wrap(n: Int); case End }\n\
+         def f(w: W): Int = w match { case Wrap(1) => 11; case End => 99 }\n\
+         f(Wrap(42))",
+    )
+    .expect_err("a refutable literal payload should not cover the variant");
+    assert!(literal_payload.to_string().contains("not exhaustive"));
+
+    let nested_payload = evaluate_text(
+        "<expr>",
+        "enum Box { case Full(c: Box); case Empty }\n\
+         def f(b: Box): Int = b match { case Full(Full(x)) => 1; case Empty => 2 }\n\
+         f(Full(Empty))",
+    )
+    .expect_err("a nested constructor payload should not cover the variant");
+    assert!(nested_payload.to_string().contains("not exhaustive"));
+
+    // Valid coverage still type-checks: multiple arms jointly covering a
+    // variant's payload, a sole-variant nested payload, a refutable arm
+    // followed by a catch-all, and a Boolean payload matched on both values.
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "enum O<a> { case Some(v: a); case None }\n\
+             def f(o: O<O<Int>>): Int = o match { case Some(Some(v)) => v; case Some(None) => 0; case None => -1 }\n\
+             f(Some(Some(7)))",
+        )
+        .unwrap(),
+        Value::Int(7)
+    );
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "enum Step { case St(a: Int) }\n\
+             enum R<e> { case Good(s: Step); case Bad(m: e) }\n\
+             def f(r: R<String>): Int = r match { case Good(St(a)) => a; case Bad(m) => 0 }\n\
+             f(Good(St(9)))",
+        )
+        .unwrap(),
+        Value::Int(9)
+    );
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "enum W { case Wrap(n: Int); case End }\n\
+             def f(w: W): Int = w match { case Wrap(1) => 11; case Wrap(x) => x; case End => 99 }\n\
+             f(Wrap(42))",
+        )
+        .unwrap(),
+        Value::Int(42)
+    );
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "enum B { case Wrap(b: Boolean) }\n\
+             def f(x: B): Int = x match { case Wrap(true) => 1; case Wrap(false) => 0 }\n\
+             f(Wrap(true))",
+        )
+        .unwrap(),
+        Value::Int(1)
+    );
+}
+
+#[test]
 fn match_resolves_constructors_against_the_scrutinee_enum() {
     // A user enum may reuse a prelude constructor name (`Ok`/`Err`,
     // `Some`/`None`). A match arm's constructor must resolve against the


### PR DESCRIPTION
## Problem (type soundness hole)

A constructor arm with a refutable payload was treated as covering its whole variant, so a non-exhaustive match type-checked and crashed at runtime:

```kl
enum W { case Wrap(n: Int); case End }
w match { case Wrap(1) => 11; case End => 99 }       // Wrap(42) -> no match arm at runtime

enum Box { case Full(c: Box); case Empty }
b match { case Full(Full(x)) => 1; case Empty => 2 } // Full(Empty) -> no match arm at runtime
```

The exhaustiveness pass inserted a variant into the `covered` set for any unguarded constructor arm, ignoring whether the payload sub-patterns actually covered it. Found by the type-soundness hunt.

## Fix

Check coverage recursively for single-field variants. A variant is covered when an arm has an irrefutable payload, or when its arms' payload sub-patterns jointly cover the field type. The new `patterns_cover` recursion handles wildcards/variables, both Boolean values, and nested enums:

- `Some(Some(v))` + `Some(None)` jointly cover `Some` (accepted)
- a sole-variant nested payload `Ok(Step(item, next))` covers `Ok` (std.json — accepted)
- a Boolean payload needs both `true` and `false`
- `Wrap(1)` / `Full(Full(x))` alone leave the variant partly uncovered (rejected)

Multi-field variants keep the existing lenient behavior (full matrix coverage remains future work), so **no valid match is newly rejected** — a single-field recursion only tightens, it can't introduce a new soundness hole.

## Verification

- Reject: refutable literal payload, nested constructor payload.
- Accept: joint coverage, sole-variant nested, refutable-then-catch-all, Boolean true+false, triple-nested joint coverage, lenient multi-field.
- New regression test `exhaustiveness_checks_refutable_payload_subpatterns`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 483 passed) — including the std.json and nested-pattern tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)