### PR TITLE
fix: element-type the free Map/Set builtins instead of Dynamic

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -3452,13 +3452,22 @@ impl TypeChecker {
                         Box::new(Type::Dynamic),
                     ),
                 ),
+                // Element-typed over fresh generalized variables (declared
+                // `declare_poly`, so each use instantiates fresh): the key /
+                // value type flows out instead of `Dynamic`.
                 (
                     "keys",
-                    Type::Function(vec![Type::Dynamic], Box::new(Type::Dynamic)),
+                    Type::Function(
+                        vec![Type::Map(Box::new(Type::Var(0)), Box::new(Type::Var(1)))],
+                        Box::new(Type::List(Box::new(Type::Var(0)))),
+                    ),
                 ),
                 (
                     "values",
-                    Type::Function(vec![Type::Dynamic], Box::new(Type::Dynamic)),
+                    Type::Function(
+                        vec![Type::Map(Box::new(Type::Var(0)), Box::new(Type::Var(1)))],
+                        Box::new(Type::List(Box::new(Type::Var(1)))),
+                    ),
                 ),
                 (
                     "isEmpty",
@@ -3515,17 +3524,37 @@ impl TypeChecker {
                     Type::Function(vec![Type::Dynamic], Box::new(Type::Dynamic)),
                 ),
                 ("empty", Type::Function(vec![], Box::new(Type::Dynamic))),
+                // Two sets of the same element type in, a set of that type
+                // out, over a fresh generalized variable.
                 (
                     "union",
-                    Type::Function(vec![Type::Dynamic, Type::Dynamic], Box::new(Type::Dynamic)),
+                    Type::Function(
+                        vec![
+                            Type::Set(Box::new(Type::Var(0))),
+                            Type::Set(Box::new(Type::Var(0))),
+                        ],
+                        Box::new(Type::Set(Box::new(Type::Var(0)))),
+                    ),
                 ),
                 (
                     "intersect",
-                    Type::Function(vec![Type::Dynamic, Type::Dynamic], Box::new(Type::Dynamic)),
+                    Type::Function(
+                        vec![
+                            Type::Set(Box::new(Type::Var(0))),
+                            Type::Set(Box::new(Type::Var(0))),
+                        ],
+                        Box::new(Type::Set(Box::new(Type::Var(0)))),
+                    ),
                 ),
                 (
                     "subtract",
-                    Type::Function(vec![Type::Dynamic, Type::Dynamic], Box::new(Type::Dynamic)),
+                    Type::Function(
+                        vec![
+                            Type::Set(Box::new(Type::Var(0))),
+                            Type::Set(Box::new(Type::Var(0))),
+                        ],
+                        Box::new(Type::Set(Box::new(Type::Var(0)))),
+                    ),
                 ),
             ],
             "FileInput" => &[
@@ -5046,13 +5075,25 @@ fn builtin_module_type_exports(path: &str) -> Option<ModuleTypeExports> {
                     Box::new(Type::Dynamic),
                 ),
             ),
+            // `Map#keys(m)` / `Map#values(m)` are element-typed over fresh
+            // generalized variables (the `Type::Var`s are generalized by
+            // `free_vars` and instantiated per use), so a key/value flows out
+            // as its real type rather than `Dynamic` — e.g.
+            // `foldLeft(Map#keys(%["a": 1]))(0)((acc, k) => acc + k)` is now a
+            // type error instead of silently folding a String as an Int.
             (
                 "keys",
-                Type::Function(vec![Type::Dynamic], Box::new(Type::Dynamic)),
+                Type::Function(
+                    vec![Type::Map(Box::new(Type::Var(0)), Box::new(Type::Var(1)))],
+                    Box::new(Type::List(Box::new(Type::Var(0)))),
+                ),
             ),
             (
                 "values",
-                Type::Function(vec![Type::Dynamic], Box::new(Type::Dynamic)),
+                Type::Function(
+                    vec![Type::Map(Box::new(Type::Var(0)), Box::new(Type::Var(1)))],
+                    Box::new(Type::List(Box::new(Type::Var(1)))),
+                ),
             ),
             (
                 "isEmpty",
@@ -5109,17 +5150,39 @@ fn builtin_module_type_exports(path: &str) -> Option<ModuleTypeExports> {
                 Type::Function(vec![Type::Dynamic], Box::new(Type::Dynamic)),
             ),
             ("empty", Type::Function(vec![], Box::new(Type::Dynamic))),
+            // `Set#union` / `intersect` / `subtract` take two sets of the same
+            // element type and return a set of that type, over a fresh
+            // generalized variable, so mixing element types is a type error
+            // instead of producing a `Dynamic`-typed set.
             (
                 "union",
-                Type::Function(vec![Type::Dynamic, Type::Dynamic], Box::new(Type::Dynamic)),
+                Type::Function(
+                    vec![
+                        Type::Set(Box::new(Type::Var(0))),
+                        Type::Set(Box::new(Type::Var(0))),
+                    ],
+                    Box::new(Type::Set(Box::new(Type::Var(0)))),
+                ),
             ),
             (
                 "intersect",
-                Type::Function(vec![Type::Dynamic, Type::Dynamic], Box::new(Type::Dynamic)),
+                Type::Function(
+                    vec![
+                        Type::Set(Box::new(Type::Var(0))),
+                        Type::Set(Box::new(Type::Var(0))),
+                    ],
+                    Box::new(Type::Set(Box::new(Type::Var(0)))),
+                ),
             ),
             (
                 "subtract",
-                Type::Function(vec![Type::Dynamic, Type::Dynamic], Box::new(Type::Dynamic)),
+                Type::Function(
+                    vec![
+                        Type::Set(Box::new(Type::Var(0))),
+                        Type::Set(Box::new(Type::Var(0))),
+                    ],
+                    Box::new(Type::Set(Box::new(Type::Var(0)))),
+                ),
             ),
         ],
         "FileInput" => &[

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -515,6 +515,41 @@ fn exhaustiveness_checks_refutable_payload_subpatterns() {
 }
 
 #[test]
+fn free_map_and_set_builtins_are_element_typed() {
+    // `Map#keys` / `Map#values` / `Set#union` carry the collection's element
+    // type instead of `Dynamic`, so a wrong-typed use is a type error rather
+    // than a silent Dynamic escape.
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "val vs: List<Int> = Map#values(%[\"a\": 1 \"b\": 2])\nfoldLeft(vs)(0)((acc, v) => acc + v)",
+        )
+        .unwrap(),
+        Value::Int(3)
+    );
+    let keys_wrong = evaluate_text(
+        "<expr>",
+        "val ks: List<Int> = Map#keys(%[\"a\": 1 \"b\": 2])\nks",
+    )
+    .expect_err("String keys assigned to List<Int> should fail");
+    assert!(keys_wrong.to_string().contains("type mismatch"));
+
+    let union_mixed = evaluate_text("<expr>", "Set#union(%(1 2 3), %(\"a\" \"b\"))")
+        .expect_err("union of differently-typed sets should fail");
+    assert!(union_mixed.to_string().contains("type mismatch"));
+
+    // Correct usage still type-checks.
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "val s: Set<Int> = Set#union(%(1 2), %(2 3))\nSet#toList(s).size()",
+        )
+        .unwrap(),
+        Value::Int(3)
+    );
+}
+
+#[test]
 fn match_resolves_constructors_against_the_scrutinee_enum() {
     // A user enum may reuse a prelude constructor name (`Ok`/`Err`,
     // `Some`/`None`). A match arm's constructor must resolve against the


### PR DESCRIPTION
## Problem (type soundness hole)

`Map#keys`, `Map#values`, and `Set#union`/`intersect`/`subtract` were typed `(Dynamic) => Dynamic`, so a wrong-typed use escaped the checker:

```kl
val r: Int = foldLeft(Map#keys(%["a": 1 "b": 2]))(0)((acc, k) => acc + k)
// type-checks; folds the String keys into the Int accumulator (r = "0ab")

val s: Set<Int> = Set#union(%(1 2 3), %("a" "b"))   // type-checks; mixed-element set
```

The method forms (`.keys()`, `.union()`, …) were already element-aware (#456); only the free module-member forms were `Dynamic`. Found by the type-soundness hunt.

## Fix

Type these members over fresh generalized variables — `keys` as `(Map<k, v>) => List<k>`, `values` as `(Map<k, v>) => List<v>`, and the set operations as `(Set<a>, Set<a>) => Set<a>`. The `Type::Var`s are generalized (`free_vars` collects them, `declare_poly` generalizes the binding) and instantiated fresh per use, so the element type flows out and a mismatched use is a type error.

The same entries appear in **two** tables — `builtin_module_type_exports` (module selectors) and `install_module_imports` (the `Map#keys` bindings) — both updated (the binding lookup wins, so only fixing the first had no effect).

## Verification

- `Map#keys` assigned to `List<Int>` and a mixed-element `Set#union` are now type errors; correct usage (`List<String>` keys, `List<Int>` values, same-type union) still type-checks.
- The `.keys()` method form is unaffected.
- Native still emits a clean diagnostic for the free forms it does not compile (type-checker-only change, codegen unchanged — pre-existing).
- New regression test `free_map_and_set_builtins_are_element_typed`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 483 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)