### PR TITLE
fix: capture a transitively-captured outer variable by value in native

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -27007,16 +27007,19 @@ impl NativeCodeGenerator {
                 for (name, value) in bindings {
                     captures.insert((*name).to_string(), value.clone());
                 }
-                // A statically-substituted binding (an enclosing lambda's
-                // parameter) is authoritative for that name. If an outer
-                // `val` of the same name was materialized into a runtime slot
-                // (e.g. while binding the enclosing lambda's captures), that
-                // slot must NOT be captured here — at call time a runtime
-                // capture shadows the static one, so the inner closure would
-                // read the outer val instead of the shadowing parameter.
+                // A name with a known static-constant capture is captured by
+                // that value, which is frame-independent and authoritative. It
+                // must NOT also be captured by a runtime slot: such a slot is a
+                // frame-relative offset that does not survive the enclosing
+                // frame, and at call time a runtime capture shadows the static
+                // one — so a transitively-captured outer parameter
+                // (`base` in `(x) => (y) => base + x + y`) would read whatever
+                // now sits at that stale offset (the middle layer's `x`)
+                // instead of its real value. This subsumes the
+                // binding-parameter removal that fixed the shadowing case.
                 let mut runtime_captures = self.current_runtime_captures();
-                for (name, _) in bindings {
-                    runtime_captures.remove(*name);
+                for name in captures.keys() {
+                    runtime_captures.remove(name);
                 }
                 let thread_aliases = self.current_thread_aliases_with_static_bindings(bindings);
                 let label = self.intern_static_lambda(

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -3747,6 +3747,66 @@ fn builds_native_executable_for_shadowed_param_in_returned_closure() {
     assert!(run.stderr.is_empty());
 }
 
+/// A variable captured transitively through an intermediate closure layer is
+/// read by value, not through a stale frame slot. `makeAdder(100)` then
+/// `f(10)` then `g(1)` must compute `base + x + y = 111`; the innermost
+/// closure's `base` (the outermost parameter) used to alias the middle
+/// layer's `x`, silently computing `x + x + y = 21`.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn builds_native_executable_for_transitively_captured_outer_variable() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-native-transcap-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-native-transcap-{unique}"));
+    fs::write(
+        &source_path,
+        "def makeAdder(base) = (x) => (y) => base + x + y\n\
+         val f = makeAdder(100)\n\
+         val g = f(10)\n\
+         println(g(1))\n\
+         val g2 = f(20)\n\
+         println(g2(2))\n",
+    )
+    .expect("source should write");
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(eval.status.success());
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(String::from_utf8_lossy(&eval.stdout), "111\n122\n");
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&eval.stdout),
+        "native must match eval for a transitively-captured outer variable"
+    );
+}
+
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[test]
 fn builds_native_executable_for_functions_capturing_top_level_bindings() {


### PR DESCRIPTION
## Problem (silent native miscompile, HIGH)

A variable captured through an intermediate closure layer was read through a stale frame slot, silently computing the wrong result:

```kl
def makeAdder(base) = (x) => (y) => base + x + y
val f = makeAdder(100)
val g = f(10)
println(g(1))          // eval 111, native 21
```

The innermost closure's `base` (the outermost parameter) aliased the middle layer's `x`, so native computed `x + x + y = 21` instead of `base + x + y`. Found by the hunt; a 2-level capture was already correct.

## Root cause

When the inner lambda is interned during the static fold, `base` has a correct static-constant capture (100) but **also a runtime slot** — allocated when the middle lambda was inlined for `f(10)`. That slot is a frame-relative offset that does not survive the enclosing frame, and at call time a runtime capture shadows the static one, so `base` read whatever now sits at that offset (the middle layer's `x`). Same class as #484 (shadowed parameter), but for a transitively-captured enclosing variable rather than a parameter.

## Fix

Drop from a folded lambda's runtime captures every name that has a static-constant capture: the static value is frame-independent and authoritative. This also subsumes the binding-parameter removal that fixed #484. Mutable captures are not static constants, so their live runtime slot is untouched.

## Verification

- `makeAdder(100)` → `f(10)` → `g(1)` now yields 111 (and a second instantiation `f(20)`/`g2(2)` yields 122).
- Still correct: the #484 shadowed-parameter case, an escaping mutable closure (`mutable c = 0; () => c; c = 5` → 5), 2-level capture, adder factory.
- New regression test `builds_native_executable_for_transitively_captured_outer_variable`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 484 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)