### PR TITLE
fix: snapshot the interpolation prefix around re-entrant holes in native

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -33220,6 +33220,9 @@ impl NativeCodeGenerator {
             };
             {
                 let parsed = self.lower_interpolation_enums(rewrite_expression((**hole).clone()));
+                // Collection-literal holes are formatted in place by this
+                // short-circuit; it owns its own evaluation and never falls
+                // through to the recursion-prone general path below.
                 if let Some(fragment) = self.compile_collection_literal_display_runtime_string(
                     &parsed,
                     span,
@@ -33237,12 +33240,47 @@ impl NativeCodeGenerator {
                     );
                     continue;
                 }
+                // A hole that can re-enter this interpolation site — a call
+                // into a function that itself interpolates, including direct
+                // or mutual recursion — would otherwise clobber the shared
+                // static buffer and offset cell mid-build (the inner build
+                // resets the offset to 0 and overwrites bytes). Snapshot the
+                // in-progress prefix to a GC heap string, evaluate the hole,
+                // then restore the prefix and offset before appending the
+                // fragment.
+                let reentrant = interpolation_hole_may_reenter(&parsed);
+                let snapshot_slot = if reentrant {
+                    self.push_scope();
+                    self.emit_runtime_string_to_heap_string(data, offset);
+                    let slot = self.allocate_anonymous_slot(NativeValue::HeapPointer);
+                    self.asm.store_rbp_slot(slot.offset, Reg::Rax);
+                    Some(slot)
+                } else {
+                    None
+                };
                 let fragment = self.compile_expr(&parsed)?;
                 let enum_shape = if fragment == NativeValue::HeapPointer {
                     self.pending_enum_shape.take()
                 } else {
                     None
                 };
+                if let Some(snapshot_slot) = snapshot_slot {
+                    // Spill the fragment's payload register, restore the
+                    // prefix the hole evaluation clobbered, then reload it.
+                    // The restore emits no allocation, so the unrooted spill
+                    // cannot be freed before the reload.
+                    let frag_slot = self.allocate_anonymous_slot(NativeValue::Int);
+                    self.asm.store_rbp_slot(frag_slot.offset, Reg::Rax);
+                    self.emit_reset_runtime_buffer_offset_label(offset);
+                    self.asm.load_rbp_slot(Reg::Rax, snapshot_slot.offset);
+                    self.emit_append_heap_string_to_runtime_buffer_offset_label(
+                        data,
+                        offset,
+                        span,
+                        "string interpolation result exceeds 65536 bytes",
+                    );
+                    self.asm.load_rbp_slot(Reg::Rax, frag_slot.offset);
+                }
                 if let Some(shape) = enum_shape {
                     let formatted = self.emit_enum_display_runtime_string(&shape, span)?;
                     if let Some(formatted) = self.native_string_ref(formatted) {
@@ -33339,6 +33377,9 @@ impl NativeCodeGenerator {
                     }
                 } else {
                     return Err(unsupported(span, "native string interpolation"));
+                }
+                if reentrant {
+                    self.pop_scope();
                 }
             }
         }
@@ -39624,6 +39665,30 @@ fn lookup_var_slot_in_scopes(scopes: &[HashMap<String, VarSlot>], name: &str) ->
         .iter()
         .rev()
         .find_map(|scope| scope.get(name).copied())
+}
+
+/// Whether evaluating an interpolation hole could re-enter an
+/// interpolation buffer — i.e. it may invoke a user function (which can
+/// recurse back into the same interpolation site). Only provably
+/// call-free holes (literals, identifiers, and arithmetic over them) are
+/// safe; every other shape is treated conservatively, since a false
+/// negative is a silent miscompile while a false positive only costs a
+/// prefix snapshot.
+fn interpolation_hole_may_reenter(expr: &Expr) -> bool {
+    match expr {
+        Expr::Int { .. }
+        | Expr::Double { .. }
+        | Expr::Bool { .. }
+        | Expr::String { .. }
+        | Expr::Null { .. }
+        | Expr::Unit { .. }
+        | Expr::Identifier { .. } => false,
+        Expr::Binary { lhs, rhs, .. } => {
+            interpolation_hole_may_reenter(lhs) || interpolation_hole_may_reenter(rhs)
+        }
+        Expr::Unary { expr, .. } => interpolation_hole_may_reenter(expr),
+        _ => true,
+    }
 }
 
 fn expr_contains_thread_call(expr: &Expr, thread_aliases: &HashSet<String>) -> bool {

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -135,7 +135,14 @@ cargo run -- -e "1 + 2"
   fragments with mutable block prefixes when their final values remain
   recoverable. Interpolation fragments that resolve to native runtime strings,
   or to dynamic native `Int` / `Boolean` values, produce fixed-buffer
-  `RuntimeString` values.
+  `RuntimeString` values. Because that fixed buffer and its offset cell are a
+  single static slot per interpolation site, a hole that can re-enter the site
+  (a call into a function that itself interpolates, including direct or mutual
+  recursion) snapshots the in-progress prefix into a GC heap string, evaluates
+  the hole, then restores the prefix and offset before appending the fragment;
+  without that snapshot the inner build resets the offset to 0 and the outer
+  resumed appending at the wrong position. Collection-literal holes keep their
+  in-place short-circuit and never reach the snapshot path.
   Static string and integer list values can be bound with `val`; static string
   helpers, including `split` and `join`, are folded at compile time for native
   codegen, and static string concatenation can produce immutable static values

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -3750,6 +3750,70 @@ fn builds_native_executable_for_shadowed_param_in_returned_closure() {
 /// A variable captured transitively through an intermediate closure layer is
 /// read by value, not through a stale frame slot. `makeAdder(100)` then
 /// `f(10)` then `g(1)` must compute `base + x + y = 111`; the innermost
+/// A recursive function whose body interpolates a recursive call used to
+/// corrupt its result: the interpolation buffer + offset cell are a single
+/// static slot per site, so the inner invocation reset the offset and the
+/// outer resumed appending at the wrong position (`show(Wrap(Wrap(Base)))`
+/// gave `[X][X]]` instead of `[[X]]`). The fix snapshots the in-progress
+/// prefix around a re-entrant hole and restores it after. The argument
+/// comes from `CommandLine#args().size()` so the recursion is genuinely
+/// runtime (a literal argument would be constant-folded and never hit the
+/// runtime buffer).
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn builds_native_executable_for_recursive_interpolation() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-native-recurinterp-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-native-recurinterp-{unique}"));
+    fs::write(
+        &source_path,
+        "enum E { case Wrap(inner: E); case Base }\n\
+         def show(e: E): String = e match { case Wrap(inner) => \"[#{show(inner)}]\"; case Base => \"X\" }\n\
+         val z = CommandLine#args().size()\n\
+         def tag(n: Int): String = if (n <= 0) \"X\" else \"A#{tag(n - 1)}B\"\n\
+         println(show(Wrap(Wrap(Base))))\n\
+         println(tag(z + 2))\n",
+    )
+    .expect("source should write");
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(eval.status.success());
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(String::from_utf8_lossy(&eval.stdout), "[[X]]\nAAXBB\n");
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&eval.stdout),
+        "native must match eval for a recursive function that interpolates a recursive call"
+    );
+}
+
 /// closure's `base` (the outermost parameter) used to alias the middle
 /// layer's `x`, silently computing `x + x + y = 21`.
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]


### PR DESCRIPTION
## Problem (silent native miscompile, HIGH)

A recursive function whose body interpolates a recursive call silently produced the wrong string:

```kl
enum E { case Wrap(inner: E); case Base }
def show(e: E): String =
  e match { case Wrap(inner) => "[#{show(inner)}]"; case Base => "X" }
println(show(Wrap(Wrap(Base))))   // eval [[X]], native [X][X]]
```

## Root cause

A site's runtime interpolation buffer and its offset cell are a single static `.data` slot. When a hole evaluates a call that re-enters the **same** interpolation site, the inner build resets the offset to 0 and overwrites bytes, so the outer resumed appending at the inner's leftover offset — `[X][X]]` instead of `[[X]]`.

This is not enum-specific. Earlier probes with literal arguments appeared to work only because the recursion was constant-folded at compile time and never reached the runtime buffer. A genuinely runtime argument such as `CommandLine#args().size()` reproduces the corruption for plain `Int` recursion too.

## Fix

For a hole that can re-enter the site — anything but a literal, an identifier, or arithmetic over them — snapshot the in-progress prefix into a GC heap string, evaluate the hole, then restore the prefix and offset before appending the fragment:

- The snapshot uses the existing `emit_runtime_string_to_heap_string` and lives in a rooted per-frame slot, so the hole's allocations cannot free it.
- The restore (`emit_reset_runtime_buffer_offset_label` + `emit_append_heap_string_to_runtime_buffer_offset_label`) emits no allocation, so the spilled fragment register stays valid until reloaded.
- Each re-entrant hole is wrapped in `push_scope`/`pop_scope`, so the snapshot/spill slots and their GC roots are released per hole — no shadow-stack growth in loops.
- Collection-literal holes keep their in-place short-circuit (which the general path doesn't support for side-effecting block elements) and never reach the snapshot path.

The `interpolation_hole_may_reenter` predicate is conservative: a false negative would be a miscompile, a false positive only costs a prefix snapshot.

## Verification

- `show(Wrap(Wrap(Base)))` → `[[X]]`; deeper nesting, differing literal prefixes (`A#{..}B` → `AAXBB`), and sibling holes with different arguments all match eval.
- Runtime-argument `Int` recursion (`CommandLine#args().size()`) now matches eval.
- Non-recursive interpolation (`"a=#{a} b=#{b} sum=#{a+a}"`) and the side-effecting collection-literal interpolation test are unchanged.
- GC churn: 30000 iterations of interpolation-recursion under heap pressure match eval.
- New regression test `builds_native_executable_for_recursive_interpolation`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 485 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)