### PR TITLE
feat: support Map#getOrElse in the native compiler

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -17600,6 +17600,12 @@ impl NativeCodeGenerator {
                 )?;
                 return Ok(self.emit_static_value(&value));
             }
+            // `m.getOrElse(k, d)` — the two-argument map form. (Option's
+            // one-argument `getOrElse` is an extension method already routed
+            // by `try_compile_enum_extension_method` above.)
+            "getOrElse" if arguments.len() == 2 => {
+                return self.compile_map_get_or_else(target, &arguments[0], &arguments[1], span);
+            }
             "toString" => "toString",
             "substring" => "substring",
             "at" => "at",
@@ -17645,6 +17651,81 @@ impl NativeCodeGenerator {
             span,
         };
         self.compile_call(&callee, &lowered, span)
+    }
+
+    /// Lower `m.getOrElse(k, d)` to a temp-bound conditional that reuses the
+    /// supported `containsKey` / `get` / `if` codegen:
+    ///
+    /// ```text
+    /// { val m' = m; val k' = k; if (m'.containsKey(k')) m'.get(k') else d }
+    /// ```
+    ///
+    /// Binding `m` and `k` to fresh vals first evaluates each exactly once,
+    /// matching the evaluator even when they carry side effects. The fresh
+    /// names are keyed on the call-site span so distinct call sites never
+    /// collide; nested calls shadow lexically through the block scope.
+    fn compile_map_get_or_else(
+        &mut self,
+        target: &Expr,
+        key: &Expr,
+        default: &Expr,
+        span: Span,
+    ) -> Result<NativeValue, Diagnostic> {
+        let map_name = format!("__getOrElse_map_{}", span.start);
+        let key_name = format!("__getOrElse_key_{}", span.start);
+        let map_id = Expr::Identifier {
+            name: map_name.clone(),
+            span,
+        };
+        let key_id = Expr::Identifier {
+            name: key_name.clone(),
+            span,
+        };
+        let contains = Expr::Call {
+            callee: Box::new(Expr::FieldAccess {
+                target: Box::new(map_id.clone()),
+                field: "containsKey".to_string(),
+                span,
+            }),
+            arguments: vec![key_id.clone()],
+            span,
+        };
+        let get = Expr::Call {
+            callee: Box::new(Expr::FieldAccess {
+                target: Box::new(map_id),
+                field: "get".to_string(),
+                span,
+            }),
+            arguments: vec![key_id],
+            span,
+        };
+        let conditional = Expr::If {
+            condition: Box::new(contains),
+            then_branch: Box::new(get),
+            else_branch: Some(Box::new(default.clone())),
+            span,
+        };
+        let block = Expr::Block {
+            expressions: vec![
+                Expr::VarDecl {
+                    mutable: false,
+                    name: map_name,
+                    annotation: None,
+                    value: Box::new(target.clone()),
+                    span,
+                },
+                Expr::VarDecl {
+                    mutable: false,
+                    name: key_name,
+                    annotation: None,
+                    value: Box::new(key.clone()),
+                    span,
+                },
+                conditional,
+            ],
+            span,
+        };
+        self.compile_expr(&block)
     }
 
     /// The enum name behind a tracked `ConcreteEnumShape`: look any of its

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -243,7 +243,10 @@ cargo run -- -e "1 + 2"
   `Map#get(...) == null` / `!= null` reuse the same unrolled search and
   cache the lookup needle in a fresh data slot so the comparison loop can
   reload the needle between iterations without losing it to register
-  reuse. The kind tag also drives display: `println` and string
+  reuse. The two-argument method `m.getOrElse(k, d)` lowers to a
+  temp-bound `{ val m' = m; val k' = k; if (m'.containsKey(k')) m'.get(k')
+  else d }`, reusing the supported `containsKey` / `get` / `if` codegen
+  while evaluating `m` and `k` exactly once. The kind tag also drives display: `println` and string
   interpolation emit `%(v1, v2, ...)` for runtime sets and
   `%[k: v, ...]` for runtime maps, matching the static-collection display
   rather than falling back to the bracketed list form.

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -2924,6 +2924,72 @@ assertResult(["a", "b", "c"])(head(cons(lineFn)(lineFns))(lines, 2))
     assert!(run.stderr.is_empty());
 }
 
+/// `m.getOrElse(k, d)` is lowered to a temp-bound `containsKey`/`get`/`if`,
+/// so the present and absent cases match the evaluator and the key is
+/// evaluated exactly once (the side-effecting key bumps the counter a single
+/// time).
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn builds_native_executable_for_map_get_or_else() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-native-getorelse-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-native-getorelse-{unique}"));
+    fs::write(
+        &source_path,
+        "val m = %[\"a\": 1, \"b\": 2]\n\
+         val s = %[\"x\": \"hi\"]\n\
+         mutable hits = 0\n\
+         def key(): String = { hits = hits + 1; \"a\" }\n\
+         println(m.getOrElse(\"a\", 0))\n\
+         println(m.getOrElse(\"z\", -1))\n\
+         println(s.getOrElse(\"x\", \"none\"))\n\
+         println(s.getOrElse(\"q\", \"none\"))\n\
+         println(m.getOrElse(key(), 99))\n\
+         println(hits)\n",
+    )
+    .expect("source should write");
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(eval.status.success());
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(
+        String::from_utf8_lossy(&eval.stdout),
+        "1\n-1\nhi\nnone\n1\n1\n"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&eval.stdout),
+        "native Map#getOrElse must match eval, evaluating the key once"
+    );
+}
+
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[test]
 fn builds_native_executable_for_runtime_return_map_function_values() {


### PR DESCRIPTION
## Gap

`m.getOrElse(k, d)` failed native build with `native method call is not supported by the native compiler yet`, even though the evaluator supports it and native already handles `.get`, `.containsKey`, and `.size()` on maps.

```kl
val m = %["a": 1, "b": 2]
println(m.getOrElse("a", 0))   // eval 1, native: build error (before)
println(m.getOrElse("z", -1))  // eval -1
```

## Implementation

Lower the two-argument map form to a temp-bound conditional that reuses the supported codegen:

```text
{ val m' = m; val k' = k; if (m'.containsKey(k')) m'.get(k') else d }
```

- Binding `m` and `k` to fresh vals first evaluates each **exactly once**, matching the evaluator even when an argument carries side effects.
- The body reuses the existing `containsKey` / `get` / `if` paths — no new map codegen.
- Fresh names are keyed on the call-site span, so distinct sites never collide; nested calls shadow lexically through the block scope.
- The if-expression merges the `get` and default branches, so their value types must agree (as in any `if`).
- The one-argument Option form of `getOrElse` is unaffected — it is routed earlier by the enum extension-method dispatch; only the `arguments.len() == 2` map form is intercepted.

## Verification

- Present/absent keys with `Int` and `String` values match eval.
- A side-effecting key (`m.getOrElse(key(), 99)`) bumps its counter exactly once, confirming single evaluation.
- New regression test `builds_native_executable_for_map_get_or_else`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 486 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)