### PR TITLE
feat: support Map#keys and Map#values in the native compiler

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -17606,6 +17606,12 @@ impl NativeCodeGenerator {
             "getOrElse" if arguments.len() == 2 => {
                 return self.compile_map_get_or_else(target, &arguments[0], &arguments[1], span);
             }
+            "keys" if arguments.is_empty() => {
+                return self.compile_map_keys_or_values(target, span, false);
+            }
+            "values" if arguments.is_empty() => {
+                return self.compile_map_keys_or_values(target, span, true);
+            }
             "toString" => "toString",
             "substring" => "substring",
             "at" => "at",
@@ -17726,6 +17732,32 @@ impl NativeCodeGenerator {
             span,
         };
         self.compile_expr(&block)
+    }
+
+    /// `m.keys()` / `m.values()` — return the key (or value) list of a map.
+    /// A runtime map reuses the existing `__gc_smap_keys`/`__gc_smap_values`
+    /// codegen; a static map literal projects its compile-time entries into a
+    /// fresh static list.
+    fn compile_map_keys_or_values(
+        &mut self,
+        target: &Expr,
+        span: Span,
+        is_values: bool,
+    ) -> Result<NativeValue, Diagnostic> {
+        if self.expr_yields_runtime_map(target) {
+            return self.compile_gc_smap_keys_or_values(
+                std::slice::from_ref(target),
+                span,
+                is_values,
+            );
+        }
+        let entries = self.static_map_entries_from_expr(target, span)?;
+        let elements = entries
+            .into_iter()
+            .map(|(key, value)| if is_values { value } else { key })
+            .collect();
+        let label = self.intern_static_list(elements);
+        Ok(self.emit_static_value(&StaticValue::StaticList { label }))
     }
 
     /// The enum name behind a tracked `ConcreteEnumShape`: look any of its

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -246,7 +246,10 @@ cargo run -- -e "1 + 2"
   reuse. The two-argument method `m.getOrElse(k, d)` lowers to a
   temp-bound `{ val m' = m; val k' = k; if (m'.containsKey(k')) m'.get(k')
   else d }`, reusing the supported `containsKey` / `get` / `if` codegen
-  while evaluating `m` and `k` exactly once. The kind tag also drives display: `println` and string
+  while evaluating `m` and `k` exactly once. `m.keys()` / `m.values()`
+  reuse the `__gc_smap_keys`/`__gc_smap_values` list builders for a runtime
+  map and project a static map literal's compile-time entries into a fresh
+  static list. The kind tag also drives display: `println` and string
   interpolation emit `%(v1, v2, ...)` for runtime sets and
   `%[k: v, ...]` for runtime maps, matching the static-collection display
   rather than falling back to the bracketed list form.

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -2990,6 +2990,67 @@ fn builds_native_executable_for_map_get_or_else() {
     );
 }
 
+/// `m.keys()` / `m.values()` over a static map project its compile-time
+/// entries into a list, matching the evaluator for direct printing,
+/// `foreach`, and chained list methods.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn builds_native_executable_for_map_keys_and_values() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-native-mapkeys-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-native-mapkeys-{unique}"));
+    fs::write(
+        &source_path,
+        "val m = %[\"a\": 1, \"b\": 2, \"c\": 3]\n\
+         println(m.keys())\n\
+         println(m.values())\n\
+         println(m.keys().size())\n\
+         foreach (k in m.keys()) { println(k) }\n\
+         foreach (v in m.values()) { println(v) }\n",
+    )
+    .expect("source should write");
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(eval.status.success());
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(
+        String::from_utf8_lossy(&eval.stdout),
+        "[a, b, c]\n[1, 2, 3]\n3\na\nb\nc\n1\n2\n3\n"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&eval.stdout),
+        "native Map#keys / Map#values must match eval"
+    );
+}
+
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[test]
 fn builds_native_executable_for_runtime_return_map_function_values() {


### PR DESCRIPTION
## Gap

`m.keys()` and `m.values()` failed native build with `native method call is not supported by the native compiler yet`, even though the evaluator supports them and the underlying list builders already existed internally as `__gc_smap_keys` / `__gc_smap_values`.

```kl
val m = %["a": 1, "b": 2]
println(m.keys())     // eval [a, b], native: build error (before)
println(m.values())   // eval [1, 2]
```

## Implementation

Wire the `keys` / `values` methods to existing machinery:

- A **runtime map** reuses the existing `__gc_smap_keys` / `__gc_smap_values` builders, which walk the map and emit a pointer list.
- A **static map literal** projects its compile-time entries into a fresh static list via `intern_static_list`.

No new codegen — both paths reuse what was already there.

## Verification

- `keys()` / `values()` over a static map match eval for direct printing, `foreach`, and chained list methods (`m.keys().size()`), with both `Int` and `String` values.
- New regression test `builds_native_executable_for_map_keys_and_values`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 487 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)