### PR TITLE
feat: support Set#toList in the native compiler

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -17612,6 +17612,11 @@ impl NativeCodeGenerator {
             "values" if arguments.is_empty() => {
                 return self.compile_map_keys_or_values(target, span, true);
             }
+            // `s.toList()` — the set form. (Option/Result `toList` is an
+            // extension method already routed by the enum dispatch above.)
+            "toList" if arguments.is_empty() => {
+                return self.compile_set_to_list(target, span);
+            }
             "toString" => "toString",
             "substring" => "substring",
             "at" => "at",
@@ -17758,6 +17763,23 @@ impl NativeCodeGenerator {
             .collect();
         let label = self.intern_static_list(elements);
         Ok(self.emit_static_value(&StaticValue::StaticList { label }))
+    }
+
+    /// `s.toList()` — the elements of a static set as a list, in insertion
+    /// order. A runtime set has no static element vector, so it stays a clean
+    /// diagnostic.
+    fn compile_set_to_list(
+        &mut self,
+        target: &Expr,
+        span: Span,
+    ) -> Result<NativeValue, Diagnostic> {
+        let value = self.compile_expr(target)?;
+        let NativeValue::StaticSet { label } = value else {
+            return Err(unsupported(span, "native Set#toList for non-static set"));
+        };
+        let elements = self.static_sets[label.0].elements.clone();
+        let list_label = self.intern_static_list(elements);
+        Ok(self.emit_static_value(&StaticValue::StaticList { label: list_label }))
     }
 
     /// The enum name behind a tracked `ConcreteEnumShape`: look any of its

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -227,7 +227,8 @@ cargo run -- -e "1 + 2"
   (`if(...) %(1, 2) else %(3, 4, 5)`) also merge through a runtime-list
   buffer that holds each branch's elements, with `size` / `Set#size` /
   `isEmpty` / `Set#isEmpty` / `contains` answering from the per-branch
-  dynamic length and slot contents.
+  dynamic length and slot contents. `s.toList()` projects a static set's
+  element vector into a fresh static list.
   Divergent static-map branches (any entry count, including
   `if(...) %["x": 1] else %["y": 2, "z": 3]`) also merge through a
   runtime-list buffer where keys and values alternate, with the buffer

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -3051,6 +3051,66 @@ fn builds_native_executable_for_map_keys_and_values() {
     );
 }
 
+/// `s.toList()` projects a static set's elements into a list, matching the
+/// evaluator for printing, `foreach`, chained list methods, and deduped
+/// literals.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn builds_native_executable_for_set_to_list() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-native-settolist-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-native-settolist-{unique}"));
+    fs::write(
+        &source_path,
+        "val nums = %(3, 1, 2, 1)\n\
+         val words = %(\"a\", \"b\")\n\
+         println(nums.toList())\n\
+         println(nums.toList().size())\n\
+         foreach (w in words.toList()) { println(w) }\n",
+    )
+    .expect("source should write");
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(eval.status.success());
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(
+        String::from_utf8_lossy(&eval.stdout),
+        "[3, 1, 2]\n3\na\nb\n"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&eval.stdout),
+        "native Set#toList must match eval"
+    );
+}
+
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[test]
 fn builds_native_executable_for_runtime_return_map_function_values() {


### PR DESCRIPTION
## Gap

`s.toList()` failed native build with `native method call is not supported by the native compiler yet`, even though the evaluator supports it and a static set already stores its element vector.

```kl
val st = %(1, 2, 3)
println(st.toList())   // eval [1, 2, 3], native: build error (before)
```

## Implementation

Project a static set's element vector into a fresh static list via `intern_static_list`, reusing the existing list machinery — no new codegen. A runtime set has no static element vector, so it stays a clean diagnostic. The Option/Result one-argument `toList` is unaffected; it is routed earlier by the enum extension-method dispatch, so only the set form reaches this path.

## Verification

- `toList()` over int and string sets matches eval for printing, `foreach`, and chained list methods (`s.toList().size()`), including deduped literals (`%(3, 1, 2, 1)` → `[3, 1, 2]`).
- New regression test `builds_native_executable_for_set_to_list`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 488 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)