### PR TITLE
fix: run a self-mutating interpolation hole at runtime in native

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -31789,6 +31789,13 @@ impl NativeCodeGenerator {
                 StringPart::Literal(text) => result.push_str(text),
                 StringPart::Interpolation(hole) => {
                     let hole = self.lower_interpolation_enums(rewrite_expression((**hole).clone()));
+                    // A hole that mutates a variable it also displays is
+                    // mistimed by the compile-time fold (it shows the value
+                    // before the mutation). Decline the static fold so the
+                    // runtime interpolation path evaluates it in order.
+                    if expr_contains_assignment(&hole) {
+                        return None;
+                    }
                     let value = if preview_effects && bindings.is_empty() {
                         self.preview_static_value_after_effectful_eval(&hole)?
                     } else if let Some(span) = preserve_effects_span
@@ -39823,6 +39830,60 @@ fn interpolation_hole_may_reenter(expr: &Expr) -> bool {
         }
         Expr::Unary { expr, .. } => interpolation_hole_may_reenter(expr),
         _ => true,
+    }
+}
+
+/// Whether an expression performs an assignment (mutation). The
+/// compile-time interpolation fold mistimes the displayed value of a hole
+/// that mutates a variable it also reads (it shows the value before the
+/// mutation); such a hole must run at runtime instead. A false negative
+/// only leaves that hole on the existing fold path, so unhandled shapes
+/// stay conservative.
+fn expr_contains_assignment(expr: &Expr) -> bool {
+    match expr {
+        Expr::Assign { .. } => true,
+        Expr::Block { expressions, .. } => expressions.iter().any(expr_contains_assignment),
+        Expr::Binary { lhs, rhs, .. } => {
+            expr_contains_assignment(lhs) || expr_contains_assignment(rhs)
+        }
+        Expr::Unary { expr, .. } => expr_contains_assignment(expr),
+        Expr::If {
+            condition,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            expr_contains_assignment(condition)
+                || expr_contains_assignment(then_branch)
+                || else_branch.as_deref().is_some_and(expr_contains_assignment)
+        }
+        Expr::Call {
+            callee, arguments, ..
+        } => expr_contains_assignment(callee) || arguments.iter().any(expr_contains_assignment),
+        Expr::FieldAccess { target, .. } => expr_contains_assignment(target),
+        Expr::Cleanup { body, cleanup, .. } => {
+            expr_contains_assignment(body) || expr_contains_assignment(cleanup)
+        }
+        Expr::VarDecl { value, .. } => expr_contains_assignment(value),
+        Expr::Match {
+            scrutinee, arms, ..
+        } => {
+            expr_contains_assignment(scrutinee)
+                || arms.iter().any(|arm| {
+                    arm.guard.as_ref().is_some_and(expr_contains_assignment)
+                        || expr_contains_assignment(&arm.body)
+                })
+        }
+        Expr::While {
+            condition, body, ..
+        } => expr_contains_assignment(condition) || expr_contains_assignment(body),
+        Expr::Foreach { iterable, body, .. } => {
+            expr_contains_assignment(iterable) || expr_contains_assignment(body)
+        }
+        Expr::StringInterpolation { parts, .. } => parts.iter().any(|part| {
+            matches!(part, StringPart::Interpolation(hole) if expr_contains_assignment(hole))
+        }),
+        _ => false,
     }
 }
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -133,7 +133,10 @@ cargo run -- -e "1 + 2"
   of interleaving it. Interpolated strings can also be folded into static native
   values when all fragments resolve through immutable static bindings, including
   fragments with mutable block prefixes when their final values remain
-  recoverable. Interpolation fragments that resolve to native runtime strings,
+  recoverable. A hole that assigns to a variable it also displays declines the
+  fold (which would show the pre-mutation value) and runs through the runtime
+  path so the displayed value reflects the mutation in order. Interpolation
+  fragments that resolve to native runtime strings,
   or to dynamic native `Int` / `Boolean` values, produce fixed-buffer
   `RuntimeString` values. Because that fixed buffer and its offset cell are a
   single static slot per interpolation site, a hole that can re-enter the site

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -4001,6 +4001,67 @@ fn builds_native_executable_for_recursive_interpolation() {
     );
 }
 
+/// An interpolation hole that mutates a variable it also displays was
+/// folded at compile time and showed the value *before* the mutation
+/// (`h=0` / `h=1` instead of `h=1` / `h=2`). Such a hole now declines the
+/// fold and runs at runtime, so the display order matches the evaluator.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn builds_native_executable_for_side_effecting_interpolation_hole() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-native-sideinterp-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-native-sideinterp-{unique}"));
+    fs::write(
+        &source_path,
+        "mutable c = 0\n\
+         def tick(): String = \"before=#{c} now=#{ { c = c + 1; c } }\"\n\
+         println(tick())\n\
+         println(tick())\n\
+         println(tick())\n",
+    )
+    .expect("source should write");
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(eval.status.success());
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(
+        String::from_utf8_lossy(&eval.stdout),
+        "before=0 now=1\nbefore=1 now=2\nbefore=2 now=3\n"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&eval.stdout),
+        "native must match eval for an interpolation hole that mutates as it displays"
+    );
+}
+
 /// closure's `base` (the outermost parameter) used to alias the middle
 /// layer's `x`, silently computing `x + x + y = 21`.
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]


### PR DESCRIPTION
## Problem (silent native miscompile, HIGH)

An interpolation hole that assigns to a variable it also displays was mistimed by the compile-time fold, showing the value **before** the mutation:

```kl
mutable h = 0
def g(): String = "h=#{ { h = h + 1; h } }"
println(g())   // eval h=1, native h=0
println(g())   // eval h=2, native h=1
```

The two-pass static fold (preview, then emit-effects) read the displayed value one step behind the mutation it emitted. This was a long-standing deferred finding.

## Fix

Decline the static fold when a hole contains an assignment, so the runtime interpolation path evaluates it in order — `compile_expr` runs the mutation and then reads the new value. The new `expr_contains_assignment` predicate is conservative: an unhandled shape just stays on the existing fold path, so it never forces a working hole off it incorrectly.

## Verification

- `tick()` mixing a read hole and a mutate hole prints `before=0 now=1`, `before=1 now=2`, `before=2 now=3` — matching eval.
- `+=` mutation and an accumulator pattern also match eval.
- Plain (non-mutating) interpolation is unchanged and still folds.
- New regression test `builds_native_executable_for_side_effecting_interpolation_hole`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 489 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)