### PR TITLE
fix: splice transitive stdlib imports in dependency order in native

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -1293,6 +1293,49 @@ fn collect_pattern_bindings(pattern: &Pattern, out: &mut HashSet<String>) {
 /// can only call earlier `def`s), and stdlib modules call prelude helpers,
 /// so the spliced declarations are inserted *after* the prelude and
 /// *before* the user program — i.e. `[prelude][modules][user]`.
+/// Order inlined module paths so that every module's own inlinable imports
+/// precede it. A module references the mangled defs and bare vals of what it
+/// imports, and native splices them into a single ordered translation unit
+/// where a `val` is not visible before its declaration — so a dependency
+/// must be spliced first (`std.result` imports `std.option`'s `val none`).
+fn topo_order_module_paths(
+    paths: &[String],
+    module_imports: &HashMap<String, Vec<InlineImport>>,
+) -> Vec<String> {
+    let mut ordered = Vec::with_capacity(paths.len());
+    // 0 = unseen, 1 = on the current DFS path, 2 = emitted.
+    let mut state: HashMap<String, u8> = HashMap::new();
+    for root in paths {
+        let mut stack: Vec<(String, bool)> = vec![(root.clone(), false)];
+        while let Some((path, processed)) = stack.pop() {
+            if processed {
+                if state.get(&path) != Some(&2) {
+                    state.insert(path.clone(), 2);
+                    ordered.push(path);
+                }
+                continue;
+            }
+            match state.get(&path).copied().unwrap_or(0) {
+                2 => continue,
+                1 => continue, // already on the path: break the cycle.
+                _ => {}
+            }
+            state.insert(path.clone(), 1);
+            stack.push((path.clone(), true));
+            if let Some(imports) = module_imports.get(&path) {
+                for import in imports {
+                    if paths.contains(&import.path)
+                        && state.get(&import.path).copied().unwrap_or(0) == 0
+                    {
+                        stack.push((import.path.clone(), false));
+                    }
+                }
+            }
+        }
+    }
+    ordered
+}
+
 fn inline_module_imports(
     expr: Expr,
     prelude_offset: usize,
@@ -1351,18 +1394,39 @@ fn inline_module_imports(
     for (path, parsed) in &user_parsed {
         parsed_by_path.insert(path.clone(), parsed.clone());
     }
-    for path in &paths {
-        if parsed_by_path.contains_key(path) {
+    // Worklist over `paths`: parsing a stdlib module can reveal further
+    // stdlib imports (e.g. `std.result` imports `std.option`), so append any
+    // newly-discovered inlinable module and keep going until the transitive
+    // closure is spliced. Without this a transitively-imported module is
+    // recorded in `module_imports` but never added to `paths`, so its decls
+    // are never spliced and references to it fail to resolve.
+    let mut index = 0;
+    while index < paths.len() {
+        let path = paths[index].clone();
+        index += 1;
+        if parsed_by_path.contains_key(&path) {
             continue;
         }
-        let source = stdlib_module_source(path).expect("inlinable module has a source");
-        let file = SourceFile::new(path, source.to_string());
+        let source = stdlib_module_source(&path).expect("inlinable module has a source");
+        let file = SourceFile::new(&path, source.to_string());
         let parsed = rewrite_expression(parse_source(&file)?);
         let mut own = Vec::new();
         collect_inlinable_imports(&parsed, user_modules, &mut own);
+        for import in &own {
+            if !paths.contains(&import.path)
+                && !user_modules.iter().any(|module| module.path == import.path)
+            {
+                paths.push(import.path.clone());
+            }
+        }
         module_imports.insert(path.clone(), own);
         parsed_by_path.insert(path.clone(), parsed);
     }
+
+    // Splice dependencies before dependents so a module's bare `val` imports
+    // (e.g. `std.option`'s `none`) are declared before `std.result` references
+    // them; native resolves a `val` only after its declaration.
+    let paths = topo_order_module_paths(&paths, &module_imports);
 
     // `mangled_modules` records each module's free def names so an importer
     // can expand a bulk import and resolve a selective one.

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -768,7 +768,12 @@ cargo run -- -e "1 + 2"
   field repr over a defaulted one (a defaulted field is only ever read in a
   tag-guarded dead arm, so trusting the resolved branch is sound), letting
   a string-payload `map` read back as a string rather than the
-  `None` arm's defaulted scalar.
+  `None` arm's defaulted scalar. Import discovery is transitive: a module
+  imported only from inside another inlined module (`std.result` imports
+  `std.option`) is found by a worklist over the parsed modules and spliced
+  too, and the spliced modules are ordered so each module's imports precede
+  it — a dependency's bare `val` (such as `std.option`'s `none`) must be
+  declared before the dependent references it.
 
   A portable C backend (roadmap PR 9 / PR 10) lives behind
   `--backend c`: `klassic --backend c build program.kl -o program.c`

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -3051,6 +3051,64 @@ fn builds_native_executable_for_map_keys_and_values() {
     );
 }
 
+/// `std.result` imports `std.option` internally, so importing only
+/// `std.result` must transitively splice `std.option` — including its bare
+/// `val none` — and order it first, since native resolves a `val` only after
+/// its declaration. Previously this failed native build with "std.option not
+/// available" and then "undefined variable `none`".
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn builds_native_executable_for_transitive_stdlib_import() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-native-transdep-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-native-transdep-{unique}"));
+    fs::write(
+        &source_path,
+        "import std.result.{ok, err, getOrElse, isOk}\n\
+         println(getOrElse(ok(5), 0))\n\
+         println(getOrElse(err(\"boom\"), 99))\n\
+         println(isOk(ok(1)))\n",
+    )
+    .expect("source should write");
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(eval.status.success());
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(String::from_utf8_lossy(&eval.stdout), "5\n99\ntrue\n");
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&eval.stdout),
+        "native must match eval when importing only std.result (transitive std.option)"
+    );
+}
+
 /// `s.toList()` projects a static set's elements into a list, matching the
 /// evaluator for printing, `foreach`, chained list methods, and deduped
 /// literals.


### PR DESCRIPTION
## Gap

Importing only `std.result` failed native build, even though `std.result` imports `std.option` internally and both compile to native on their own:

```kl
import std.result.{ok, err, getOrElse}
println(getOrElse(ok(5), 0))   // eval 5, native: build error
```

(The existing tests passed because they import `std.option` directly alongside `std.result`, sidestepping the transitive case.)

## Two gaps

1. **Transitive discovery.** Module-import discovery only walked the main program and user modules, so a stdlib module imported *only* from inside another stdlib module (`std.result` → `std.option`) was recorded but never added to the splice set — leaving its decls unspliced, surfacing as `module std.option ... is not available`. Discovery is now a worklist that appends each newly-parsed module's own inlinable imports until the transitive closure is spliced.

2. **Splice order.** The modules were emitted in discovery order, so a dependency landed *after* its dependent. `std.option` exports `none` as a bare `val` (not a free def, so it is not name-mangled), and native resolves a `val` only after its declaration — so `std.result`'s reference failed with `undefined variable none`. Splice order is now a topological sort of the import graph, so every module's imports precede it.

## Verification

- `import std.result.{...}` alone now builds and matches eval for `ok`/`err`/`getOrElse`/`isOk`.
- Directly importing `std.option` still works; the co-import tests are unchanged.
- New regression test `builds_native_executable_for_transitive_stdlib_import`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 490 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)