### PR TITLE
feat: dispatch a converting enum method chain by its return enum in native

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -3991,6 +3991,12 @@ struct NativeCodeGenerator {
     /// table. Names declared on exactly one enum are already rewritten by
     /// the desugar and never consult this map.
     ext_method_enum_types: HashMap<String, Vec<String>>,
+    /// Top-level `def` / `val` name -> the enum it provably produces, for
+    /// constructor aliases like `def some(v) = Some(v)` and `val none = None`.
+    /// Lets `static_expr_enum_name` resolve a helper's enum so a chained
+    /// extension method that returns a *different* enum than its receiver
+    /// (`Result.toOption` yields `Option`) dispatches against the right type.
+    enum_value_aliases: HashMap<String, String>,
     /// Variant name -> owning enum name, for every enum (generic and the
     /// monomorphic ones erased by the lowering). Lets codegen name the enum
     /// behind a receiver's tracked `ConcreteEnumShape` when dispatching an
@@ -4196,6 +4202,7 @@ impl NativeCodeGenerator {
             generic_enums: HashMap::new(),
             variant_to_generic_enum: HashMap::new(),
             ext_method_enum_types: HashMap::new(),
+            enum_value_aliases: HashMap::new(),
             variant_owner_enum: HashMap::new(),
             mono_enum_shapes: HashMap::new(),
             mono_enum_variants: HashMap::new(),
@@ -4716,6 +4723,7 @@ impl NativeCodeGenerator {
         self.predeclare_record_schemas(expr);
         self.register_generic_enums(expr);
         self.predeclare_top_level_functions(expr);
+        self.register_enum_value_aliases(expr);
         self.asm.push_reg(Reg::Rbp);
         self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
         self.emit_store_command_line_state();
@@ -17909,20 +17917,64 @@ impl NativeCodeGenerator {
                     field,
                     ..
                 } => {
-                    // A chained enum extension method returns the same enum
-                    // it is declared on (Option's map/filter/orElse/... all
-                    // yield Option). Resolve the inner receiver's enum, then
-                    // confirm `field` is an extension method on that enum.
+                    // A chained enum extension method usually returns the same
+                    // enum it is declared on (Option's map/filter/orElse/...
+                    // all yield Option). Resolve the inner receiver's enum and
+                    // confirm `field` is an extension method on it; then read
+                    // the method's own return enum, since some methods convert
+                    // (`Result.toOption` yields Option). Fall back to the
+                    // receiver enum when the return enum is not statically
+                    // known.
                     let inner_enum = self.static_receiver_enum_name(inner)?;
                     let declared_on = self.ext_method_enum_types.get(field)?;
-                    declared_on
-                        .iter()
-                        .any(|ty| ty == &inner_enum)
-                        .then_some(inner_enum)
+                    if !declared_on.iter().any(|ty| ty == &inner_enum) {
+                        return None;
+                    }
+                    let ext_fn = format!("__ext_{inner_enum}_{field}");
+                    if let Some(body) = self.functions.get(&ext_fn).map(|f| f.body.clone())
+                        && let Some(return_enum) = self.static_expr_enum_name(&body)
+                    {
+                        return Some(return_enum);
+                    }
+                    Some(inner_enum)
                 }
                 _ => None,
             },
             _ => None,
+        }
+    }
+
+    /// Record top-level `def` / `val` bindings whose body provably produces a
+    /// known enum (`def some(v) = Some(v)`, `val none = None`), so that
+    /// `static_expr_enum_name` can resolve a helper's enum. Constructor bodies
+    /// resolve directly through `variant_owner_enum`, so a single pass over the
+    /// already-spliced program suffices — no transitive closure is needed for
+    /// the std constructor aliases this targets.
+    fn register_enum_value_aliases(&mut self, expr: &Expr) {
+        fn collect(expr: &Expr, generator: &NativeCodeGenerator, out: &mut Vec<(String, String)>) {
+            match expr {
+                Expr::DefDecl { name, body, .. } => {
+                    if let Some(enum_name) = generator.static_expr_enum_name(body) {
+                        out.push((name.clone(), enum_name));
+                    }
+                }
+                Expr::VarDecl { name, value, .. } => {
+                    if let Some(enum_name) = generator.static_expr_enum_name(value) {
+                        out.push((name.clone(), enum_name));
+                    }
+                }
+                Expr::Block { expressions, .. } => {
+                    for sub in expressions {
+                        collect(sub, generator, out);
+                    }
+                }
+                _ => {}
+            }
+        }
+        let mut aliases = Vec::new();
+        collect(expr, self, &mut aliases);
+        for (name, enum_name) in aliases {
+            self.enum_value_aliases.entry(name).or_insert(enum_name);
         }
     }
 
@@ -17933,7 +17985,11 @@ impl NativeCodeGenerator {
     /// an enum the function might not actually return.
     fn static_expr_enum_name(&self, expr: &Expr) -> Option<String> {
         match expr {
-            Expr::Identifier { name, .. } => self.variant_owner_enum.get(name).cloned(),
+            Expr::Identifier { name, .. } => self
+                .variant_owner_enum
+                .get(name)
+                .or_else(|| self.enum_value_aliases.get(name))
+                .cloned(),
             Expr::Call {
                 callee, arguments, ..
             } => match callee.as_ref() {
@@ -17943,7 +17999,10 @@ impl NativeCodeGenerator {
                     {
                         return self.variant_owner_enum.get(value).cloned();
                     }
-                    self.variant_owner_enum.get(name).cloned()
+                    self.variant_owner_enum
+                        .get(name)
+                        .or_else(|| self.enum_value_aliases.get(name))
+                        .cloned()
                 }
                 _ => None,
             },

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -773,7 +773,13 @@ cargo run -- -e "1 + 2"
   `std.option`) is found by a worklist over the parsed modules and spliced
   too, and the spliced modules are ordered so each module's imports precede
   it — a dependency's bare `val` (such as `std.option`'s `none`) must be
-  declared before the dependent references it.
+  declared before the dependent references it. A chained enum extension
+  method that converts to a different enum (`Result.toOption` yields an
+  `Option`) is dispatched against its own return enum rather than the
+  receiver's: the extension function's body is read for the enum it
+  produces, resolving constructor-alias helpers (`some` / `none` / `ok` /
+  `err`) through a one-pass `def` / `val` -> enum map, so a following
+  `getOrElse` routes to the right type.
 
   A portable C backend (roadmap PR 9 / PR 10) lives behind
   `--backend c`: `klassic --backend c build program.kl -o program.c`

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -3109,6 +3109,64 @@ fn builds_native_executable_for_transitive_stdlib_import() {
     );
 }
 
+/// A chained enum extension method that converts to a *different* enum
+/// (`Result.toOption` yields an `Option`) must dispatch the next method
+/// against the returned enum, not the receiver's. Previously
+/// `ok(x).toOption().getOrElse(d)` failed native build because `getOrElse`
+/// was routed as a `Result` method onto an `Option` value.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn builds_native_executable_for_cross_enum_method_chain() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-native-crossenum-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-native-crossenum-{unique}"));
+    fs::write(
+        &source_path,
+        "import std.result.{ok, err}\n\
+         println(ok(42).toOption().getOrElse(0))\n\
+         println(err(\"boom\").toOption().getOrElse(-1))\n\
+         println(ok(5).toOption().map((x) => x * 10).getOrElse(0))\n",
+    )
+    .expect("source should write");
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(eval.status.success());
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(String::from_utf8_lossy(&eval.stdout), "42\n-1\n50\n");
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&eval.stdout),
+        "native must match eval for a cross-enum extension-method chain"
+    );
+}
+
 /// `s.toList()` projects a static set's elements into a list, matching the
 /// evaluator for printing, `foreach`, chained list methods, and deduped
 /// literals.


### PR DESCRIPTION
## Gap

`ok(42).toOption().getOrElse(0)` failed native build, even though `toOption()` alone and the evaluator both work:

```kl
import std.result.{ok, err}
println(ok(42).toOption().getOrElse(0))   // eval 42, native: build error
```

Receiver-type-aware method dispatch assumed a chained extension method returns the *same* enum it is declared on. `Result.toOption` is declared on `Result` but returns an `Option`, so the following `getOrElse` was routed as a `Result` method onto an `Option` value and rejected.

## Fix

Read the extension function's body for the enum it produces and dispatch the next method against that, falling back to the receiver enum when the return enum cannot be statically determined (e.g. `andThen`, which returns a lambda's result — unchanged, still its existing pre-existing behavior).

Resolving a converting method's body requires its constructor-alias helpers to name their enum (`toOption`'s body is `this match { case Ok(v) => some(v); case Err(m) => none }`). A one-pass scan records each top-level `def` / `val` that provably produces a known enum (`def some(v) = Some(v)` → `Option`, `val none = None` → `Option`) into a `enum_value_aliases` map, which `static_expr_enum_name` then consults.

## Verification

- `ok(x).toOption().getOrElse(d)`, `err(...).toOption().getOrElse(d)`, and `ok(x).toOption().map(...).getOrElse(d)` now match eval.
- Same-enum chains (`some(x).map(...).filter(...).getOrElse(d)`) are unchanged.
- New regression test `builds_native_executable_for_cross_enum_method_chain`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 491 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)