### PR TITLE
feat: support Map#put in the native compiler

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -17689,6 +17689,9 @@ impl NativeCodeGenerator {
             "toList" if arguments.is_empty() => {
                 return self.compile_set_to_list(target, span);
             }
+            "put" if arguments.len() == 2 => {
+                return self.compile_map_put(target, &arguments[0], &arguments[1], span);
+            }
             "toString" => "toString",
             "substring" => "substring",
             "at" => "at",
@@ -17852,6 +17855,40 @@ impl NativeCodeGenerator {
         let elements = self.static_sets[label.0].elements.clone();
         let list_label = self.intern_static_list(elements);
         Ok(self.emit_static_value(&StaticValue::StaticList { label: list_label }))
+    }
+
+    /// `m.put(k, v)` — a fresh static map with `k -> v` set. An existing key
+    /// is updated in place (its position is preserved), a new key is appended,
+    /// matching the evaluator. `m`, `k`, and `v` are evaluated once, in order;
+    /// a runtime map or non-static key/value stays a clean diagnostic.
+    fn compile_map_put(
+        &mut self,
+        target: &Expr,
+        key: &Expr,
+        value: &Expr,
+        span: Span,
+    ) -> Result<NativeValue, Diagnostic> {
+        let mut entries = self.static_map_entries_from_expr(target, span)?;
+        let key_value =
+            self.static_value_from_argument_preserving_effects(key, span, "native Map#put key")?;
+        let new_value = self.static_value_from_argument_preserving_effects(
+            value,
+            span,
+            "native Map#put value",
+        )?;
+        let mut updated = false;
+        for entry in &mut entries {
+            if self.static_value_equal_user(&entry.0, &key_value) {
+                entry.1 = new_value.clone();
+                updated = true;
+                break;
+            }
+        }
+        if !updated {
+            entries.push((key_value, new_value));
+        }
+        let label = self.intern_static_map(entries);
+        Ok(self.emit_static_value(&StaticValue::StaticMap { label }))
     }
 
     /// The enum name behind a tracked `ConcreteEnumShape`: look any of its

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -253,7 +253,9 @@ cargo run -- -e "1 + 2"
   while evaluating `m` and `k` exactly once. `m.keys()` / `m.values()`
   reuse the `__gc_smap_keys`/`__gc_smap_values` list builders for a runtime
   map and project a static map literal's compile-time entries into a fresh
-  static list. The kind tag also drives display: `println` and string
+  static list. `m.put(k, v)` builds a fresh static map from a static map's
+  entries — updating an existing key in place or appending a new one — so
+  the original map is untouched. The kind tag also drives display: `println` and string
   interpolation emit `%(v1, v2, ...)` for runtime sets and
   `%[k: v, ...]` for runtime maps, matching the static-collection display
   rather than falling back to the bracketed list form.

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -3051,6 +3051,67 @@ fn builds_native_executable_for_map_keys_and_values() {
     );
 }
 
+/// `m.put(k, v)` returns a fresh static map: an existing key is updated in
+/// place (position preserved), a new key is appended, and the original map
+/// is untouched — matching the evaluator.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn builds_native_executable_for_map_put() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-native-mapput-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-native-mapput-{unique}"));
+    fs::write(
+        &source_path,
+        "val m = %[\"a\": 1, \"b\": 2]\n\
+         println(m.put(\"c\", 3))\n\
+         println(m.put(\"a\", 9))\n\
+         println(m.put(\"a\", 9).keys())\n\
+         println(m.put(\"c\", 3).getOrElse(\"c\", 0))\n\
+         println(m.size())\n",
+    )
+    .expect("source should write");
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(eval.status.success());
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(
+        String::from_utf8_lossy(&eval.stdout),
+        "%[a: 1, b: 2, c: 3]\n%[a: 9, b: 2]\n[a, b]\n3\n2\n"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&eval.stdout),
+        "native Map#put must match eval"
+    );
+}
+
 /// `std.result` imports `std.option` internally, so importing only
 /// `std.result` must transitively splice `std.option` — including its bare
 /// `val none` — and order it first, since native resolves a `val` only after


### PR DESCRIPTION
## Gap

`m.put(k, v)` failed native build with `native method call is not supported by the native compiler yet`, even though the evaluator supports it.

```kl
val m = %["a": 1, "b": 2]
println(m.put("a", 9))   // eval %[a: 9, b: 2], native: build error (before)
```

## Implementation

Build a fresh static map from the receiver's entries via the existing `intern_static_map`:

- An existing key is **updated in place** (its position is preserved); a new key is **appended** — matching the evaluator's order semantics.
- The original map is untouched (immutable).
- `m`, `k`, and `v` are evaluated once, in order.
- A runtime map or a non-static key/value stays a clean diagnostic.

## Verification

- `put` of a new key appends, `put` of an existing key updates in place (`keys()` order preserved), chaining (`.put(...).getOrElse(...)`) works, and the original map's `size()` is unchanged — all match eval.
- New regression test `builds_native_executable_for_map_put`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 492 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)