### PR TITLE
feat: support Map#remove and Set#add / Set#remove in the native compiler

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -17692,6 +17692,12 @@ impl NativeCodeGenerator {
             "put" if arguments.len() == 2 => {
                 return self.compile_map_put(target, &arguments[0], &arguments[1], span);
             }
+            "remove" if arguments.len() == 1 => {
+                return self.compile_collection_remove(target, &arguments[0], span);
+            }
+            "add" if arguments.len() == 1 => {
+                return self.compile_set_add(target, &arguments[0], span);
+            }
             "toString" => "toString",
             "substring" => "substring",
             "at" => "at",
@@ -17889,6 +17895,74 @@ impl NativeCodeGenerator {
         }
         let label = self.intern_static_map(entries);
         Ok(self.emit_static_value(&StaticValue::StaticMap { label }))
+    }
+
+    /// `m.remove(k)` / `s.remove(x)` — a fresh static map or set without the
+    /// given key/element, preserving the order of the rest. The receiver and
+    /// argument are evaluated once; a runtime collection or non-static
+    /// argument stays a clean diagnostic.
+    fn compile_collection_remove(
+        &mut self,
+        target: &Expr,
+        arg: &Expr,
+        span: Span,
+    ) -> Result<NativeValue, Diagnostic> {
+        let value = self.compile_expr(target)?;
+        let arg_value = self.static_value_from_argument_preserving_effects(
+            arg,
+            span,
+            "native remove argument",
+        )?;
+        match value {
+            NativeValue::StaticMap { label } => {
+                let entries = self.static_maps[label.0].entries.clone();
+                let kept: Vec<_> = entries
+                    .into_iter()
+                    .filter(|(key, _)| !self.static_value_equal_user(key, &arg_value))
+                    .collect();
+                let label = self.intern_static_map(kept);
+                Ok(self.emit_static_value(&StaticValue::StaticMap { label }))
+            }
+            NativeValue::StaticSet { label } => {
+                let elements = self.static_sets[label.0].elements.clone();
+                let kept: Vec<_> = elements
+                    .into_iter()
+                    .filter(|element| !self.static_value_equal_user(element, &arg_value))
+                    .collect();
+                let label = self.intern_static_set(kept);
+                Ok(self.emit_static_value(&StaticValue::StaticSet { label }))
+            }
+            _ => Err(unsupported(span, "native remove for non-static map or set")),
+        }
+    }
+
+    /// `s.add(x)` — a fresh static set with `x` appended, deduped (a member
+    /// already present is a no-op). The receiver and argument are evaluated
+    /// once; a runtime set or non-static argument stays a clean diagnostic.
+    fn compile_set_add(
+        &mut self,
+        target: &Expr,
+        arg: &Expr,
+        span: Span,
+    ) -> Result<NativeValue, Diagnostic> {
+        let value = self.compile_expr(target)?;
+        let NativeValue::StaticSet { label } = value else {
+            return Err(unsupported(span, "native Set#add for non-static set"));
+        };
+        let arg_value = self.static_value_from_argument_preserving_effects(
+            arg,
+            span,
+            "native Set#add element",
+        )?;
+        let mut elements = self.static_sets[label.0].elements.clone();
+        if !elements
+            .iter()
+            .any(|element| self.static_value_equal_user(element, &arg_value))
+        {
+            elements.push(arg_value);
+        }
+        let label = self.intern_static_set(elements);
+        Ok(self.emit_static_value(&StaticValue::StaticSet { label }))
     }
 
     /// The enum name behind a tracked `ConcreteEnumShape`: look any of its

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -255,7 +255,9 @@ cargo run -- -e "1 + 2"
   map and project a static map literal's compile-time entries into a fresh
   static list. `m.put(k, v)` builds a fresh static map from a static map's
   entries — updating an existing key in place or appending a new one — so
-  the original map is untouched. The kind tag also drives display: `println` and string
+  the original map is untouched. `m.remove(k)`, `s.add(x)`, and `s.remove(x)`
+  build a fresh static map/set the same way (a set add dedups), interning the
+  filtered or extended entries. The kind tag also drives display: `println` and string
   interpolation emit `%(v1, v2, ...)` for runtime sets and
   `%[k: v, ...]` for runtime maps, matching the static-collection display
   rather than falling back to the bracketed list form.

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -3112,6 +3112,69 @@ fn builds_native_executable_for_map_put() {
     );
 }
 
+/// `m.remove(k)`, `s.add(x)`, and `s.remove(x)` build a fresh static map or
+/// set, preserving order, deduping a set add, and leaving the original
+/// untouched — matching the evaluator, including when chained.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn builds_native_executable_for_map_set_remove_and_add() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-native-removeadd-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-native-removeadd-{unique}"));
+    fs::write(
+        &source_path,
+        "val m = %[\"a\": 1, \"b\": 2, \"c\": 3]\n\
+         println(m.remove(\"b\"))\n\
+         println(m.size())\n\
+         val s = %(1, 2, 3)\n\
+         println(s.add(4))\n\
+         println(s.add(2))\n\
+         println(s.remove(2))\n\
+         println(s.add(4).remove(2).toList())\n",
+    )
+    .expect("source should write");
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(eval.status.success());
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(
+        String::from_utf8_lossy(&eval.stdout),
+        "%[a: 1, c: 3]\n3\n%(1, 2, 3, 4)\n%(1, 2, 3)\n%(1, 3)\n[1, 3, 4]\n"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&eval.stdout),
+        "native Map#remove / Set#add / Set#remove must match eval"
+    );
+}
+
 /// `std.result` imports `std.option` internally, so importing only
 /// `std.result` must transitively splice `std.option` — including its bare
 /// `val none` — and order it first, since native resolves a `val` only after


### PR DESCRIPTION
## Gap

`m.remove(k)`, `s.add(x)`, and `s.remove(x)` failed native build with `native method call is not supported by the native compiler yet`, even though the evaluator supports them.

## Implementation

Build a fresh static map or set from the receiver's entries, reusing `intern_static_map` / `intern_static_set`:

```kl
val m = %["a": 1, "b": 2, "c": 3]
println(m.remove("b"))   // %[a: 1, c: 3]
val s = %(1, 2, 3)
println(s.add(4))        // %(1, 2, 3, 4)
println(s.add(2))        // %(1, 2, 3) — already present (deduped)
println(s.remove(2))     // %(1, 3)
```

- `remove` keeps the order of the rest (it dispatches on whether the receiver is a static map or set); a set `add` appends and dedups; the original collection is untouched.
- Receiver and argument are evaluated once.
- A runtime collection or non-static argument stays a clean diagnostic.

This follows the same pattern as the recently-added `getOrElse` / `keys` / `values` / `toList` / `put`.

## Verification

- `remove` / `add` / `remove` over static maps and sets match eval, including dedup, order preservation, an unchanged original (`size()`), and chaining (`s.add(4).remove(2).toList()`).
- New regression test `builds_native_executable_for_map_set_remove_and_add`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 493 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)