### PR TITLE
feat: support Set union / intersect / subtract in the native compiler

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -1520,6 +1520,14 @@ fn inline_module_imports(
     })
 }
 
+/// Which binary set operation `compile_set_combine` performs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SetCombineOp {
+    Union,
+    Intersect,
+    Subtract,
+}
+
 /// Storage strategy for one monomorphic enum variant payload slot.
 ///
 /// Every slot of the backing `__gc_record` must hold a heap pointer so
@@ -17698,6 +17706,25 @@ impl NativeCodeGenerator {
             "add" if arguments.len() == 1 => {
                 return self.compile_set_add(target, &arguments[0], span);
             }
+            "union" if arguments.len() == 1 => {
+                return self.compile_set_combine(target, &arguments[0], span, SetCombineOp::Union);
+            }
+            "intersect" if arguments.len() == 1 => {
+                return self.compile_set_combine(
+                    target,
+                    &arguments[0],
+                    span,
+                    SetCombineOp::Intersect,
+                );
+            }
+            "subtract" if arguments.len() == 1 => {
+                return self.compile_set_combine(
+                    target,
+                    &arguments[0],
+                    span,
+                    SetCombineOp::Subtract,
+                );
+            }
             "toString" => "toString",
             "substring" => "substring",
             "at" => "at",
@@ -17962,6 +17989,60 @@ impl NativeCodeGenerator {
             elements.push(arg_value);
         }
         let label = self.intern_static_set(elements);
+        Ok(self.emit_static_value(&StaticValue::StaticSet { label }))
+    }
+
+    /// `a.union(b)` / `a.intersect(b)` / `a.subtract(b)` — combine two static
+    /// sets into a fresh one, taking the receiver's element order as the base.
+    /// Both sets are evaluated once; a runtime set stays a clean diagnostic.
+    fn compile_set_combine(
+        &mut self,
+        target: &Expr,
+        arg: &Expr,
+        span: Span,
+        op: SetCombineOp,
+    ) -> Result<NativeValue, Diagnostic> {
+        let lhs = self.compile_expr(target)?;
+        let NativeValue::StaticSet { label: lhs_label } = lhs else {
+            return Err(unsupported(span, "native set combine for non-static set"));
+        };
+        let rhs = self.compile_expr(arg)?;
+        let NativeValue::StaticSet { label: rhs_label } = rhs else {
+            return Err(unsupported(span, "native set combine for non-static set"));
+        };
+        let lhs_elements = self.static_sets[lhs_label.0].elements.clone();
+        let rhs_elements = self.static_sets[rhs_label.0].elements.clone();
+        let result: Vec<StaticValue> = match op {
+            SetCombineOp::Union => {
+                let mut combined = lhs_elements;
+                for element in rhs_elements {
+                    if !combined
+                        .iter()
+                        .any(|existing| self.static_value_equal_user(existing, &element))
+                    {
+                        combined.push(element);
+                    }
+                }
+                combined
+            }
+            SetCombineOp::Intersect => lhs_elements
+                .into_iter()
+                .filter(|element| {
+                    rhs_elements
+                        .iter()
+                        .any(|other| self.static_value_equal_user(other, element))
+                })
+                .collect(),
+            SetCombineOp::Subtract => lhs_elements
+                .into_iter()
+                .filter(|element| {
+                    !rhs_elements
+                        .iter()
+                        .any(|other| self.static_value_equal_user(other, element))
+                })
+                .collect(),
+        };
+        let label = self.intern_static_set(result);
         Ok(self.emit_static_value(&StaticValue::StaticSet { label }))
     }
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -257,7 +257,9 @@ cargo run -- -e "1 + 2"
   entries — updating an existing key in place or appending a new one — so
   the original map is untouched. `m.remove(k)`, `s.add(x)`, and `s.remove(x)`
   build a fresh static map/set the same way (a set add dedups), interning the
-  filtered or extended entries. The kind tag also drives display: `println` and string
+  filtered or extended entries, and `a.union(b)` / `a.intersect(b)` /
+  `a.subtract(b)` combine two static sets — taking the receiver's element
+  order as the base — into a fresh interned set. The kind tag also drives display: `println` and string
   interpolation emit `%(v1, v2, ...)` for runtime sets and
   `%[k: v, ...]` for runtime maps, matching the static-collection display
   rather than falling back to the bracketed list form.

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -3175,6 +3175,68 @@ fn builds_native_executable_for_map_set_remove_and_add() {
     );
 }
 
+/// `a.union(b)` / `a.intersect(b)` / `a.subtract(b)` combine two static sets
+/// into a fresh one, taking the receiver's element order as the base and
+/// leaving both operands untouched — matching the evaluator.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn builds_native_executable_for_set_combine() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-native-setcombine-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-native-setcombine-{unique}"));
+    fs::write(
+        &source_path,
+        "val a = %(1, 2, 3)\n\
+         val b = %(2, 3, 4)\n\
+         println(a.union(b))\n\
+         println(a.intersect(b))\n\
+         println(a.subtract(b))\n\
+         println(a.union(b).size())\n\
+         println(a.size())\n",
+    )
+    .expect("source should write");
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(eval.status.success());
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(
+        String::from_utf8_lossy(&eval.stdout),
+        "%(1, 2, 3, 4)\n%(2, 3)\n%(1)\n4\n3\n"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&eval.stdout),
+        "native Set#union / intersect / subtract must match eval"
+    );
+}
+
 /// `std.result` imports `std.option` internally, so importing only
 /// `std.result` must transitively splice `std.option` — including its bare
 /// `val none` — and order it first, since native resolves a `val` only after


### PR DESCRIPTION
## Gap

`a.union(b)`, `a.intersect(b)`, and `a.subtract(b)` failed native build with `native method call is not supported by the native compiler yet`, even though the evaluator supports them.

## Implementation

Combine two static sets into a fresh one via `intern_static_set`, taking the receiver's element order as the base:

```kl
val a = %(1, 2, 3)
val b = %(2, 3, 4)
println(a.union(b))      // %(1, 2, 3, 4)
println(a.intersect(b))  // %(2, 3)
println(a.subtract(b))   // %(1)
```

Both operands are evaluated once and left untouched. A runtime set stays a clean diagnostic. Same pattern as the recently-added `put` / `remove` / `add`.

## Verification

- `union` / `intersect` / `subtract` over static sets match eval, including chaining (`a.union(b).size()`) and an unchanged `a.size()`.
- New regression test `builds_native_executable_for_set_combine`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green (cli_smoke 494 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)