### PR TITLE
docs: string operations are character-indexed, not byte-indexed

### DIFF
--- a/docs/book/src/tour/strings.md
+++ b/docs/book/src/tour/strings.md
@@ -42,9 +42,9 @@ val mixed = "count = " + 42
 
 | Function | Behaviour |
 |---|---|
-| `length(s)` | Byte length |
-| `substring(s, i, j)` | Bytes `[i, j)` |
-| `at(s, i)` | One-byte string at index |
+| `length(s)` | Character (code point) count |
+| `substring(s, i, j)` | Characters `[i, j)` |
+| `at(s, i)` | One-character string at index |
 | `trim(s)`, `trimLeft(s)`, `trimRight(s)` | Strip ASCII whitespace |
 | `toLowerCase(s)`, `toUpperCase(s)` | ASCII case shift |
 | `replace(s, from, to)` | Replace first occurrence |


### PR DESCRIPTION
The string-operations table in `tour/strings.md` described `length`, `substring`, and `at` as byte-based, but they operate on Unicode code points:

- `length("é")` is `1` (not 2)
- `at("café", 3)` is `é` (a full character, not a partial byte)
- `substring("café", 0, 3)` is `caf`

Verified `eval == native`. The byte-based claim would mislead anyone sizing buffers or indexing multi-byte text. The internal `__gc_string_len` byte length is a separate GC builtin and is left as-is.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)