### PR TITLE
feat: order strings with the comparison operators

### DIFF
--- a/crates/klassic-eval/src/ops.rs
+++ b/crates/klassic-eval/src/ops.rs
@@ -278,12 +278,29 @@ fn eval_divide(lhs: Value, rhs: Value, span: Span) -> Result<Value, Diagnostic> 
 }
 
 fn eval_comparison(op: BinaryOp, lhs: Value, rhs: Value, span: Span) -> Result<Value, Diagnostic> {
+    // Two strings compare lexicographically by code point (UTF-8 byte order
+    // preserves code-point order), so sorting and range checks work on text.
+    if let (Value::String(lhs), Value::String(rhs)) = (&lhs, &rhs) {
+        let result = match op {
+            BinaryOp::Less => lhs < rhs,
+            BinaryOp::LessEqual => lhs <= rhs,
+            BinaryOp::Greater => lhs > rhs,
+            BinaryOp::GreaterEqual => lhs >= rhs,
+            _ => unreachable!("comparison operator expected"),
+        };
+        return Ok(Value::Bool(result));
+    }
     let (lhs, rhs) = match (numeric_value(&lhs), numeric_value(&rhs)) {
         (Some(lhs), Some(rhs)) => {
             let (lhs, rhs, _) = promote_numeric_pair(lhs, rhs);
             (lhs.as_f64(), rhs.as_f64())
         }
-        _ => return Err(Diagnostic::runtime(span, "comparison expects numbers")),
+        _ => {
+            return Err(Diagnostic::runtime(
+                span,
+                "comparison expects two numbers or two strings",
+            ));
+        }
     };
     let result = match op {
         BinaryOp::Less => lhs < rhs,

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -6124,6 +6124,17 @@ impl NativeCodeGenerator {
                 .mov_imm64(Reg::Rax, u64::from(equal == (op == BinaryOp::Equal)));
             return Ok(NativeValue::Bool);
         }
+        // Ordering of two compile-time-known strings folds to a constant.
+        // Runtime string ordering (sorting variables) is not lowered yet and
+        // falls through to a clean diagnostic.
+        if matches!(
+            op,
+            BinaryOp::Less | BinaryOp::LessEqual | BinaryOp::Greater | BinaryOp::GreaterEqual
+        ) && let Some(result) = self.static_string_ordering_from_exprs(lhs, rhs, op)
+        {
+            self.asm.mov_imm64(Reg::Rax, u64::from(result));
+            return Ok(NativeValue::Bool);
+        }
         if matches!(op, BinaryOp::Equal | BinaryOp::NotEqual)
             && let Some(value) = self.compile_map_get_null_equality(lhs, rhs, op, span)?
         {
@@ -30473,6 +30484,32 @@ impl NativeCodeGenerator {
         let lhs = self.static_value_from_expr(lhs)?;
         let rhs = self.static_value_from_expr(rhs)?;
         Some(self.static_value_equal_user(&lhs, &rhs))
+    }
+
+    /// Compare two compile-time-known strings lexicographically (UTF-8 byte
+    /// order preserves code-point order), matching the evaluator. Returns
+    /// `None` when either side is not a static string, so non-string or
+    /// runtime operands fall through.
+    fn static_string_ordering_from_exprs(
+        &mut self,
+        lhs: &Expr,
+        rhs: &Expr,
+        op: BinaryOp,
+    ) -> Option<bool> {
+        if !static_expr_is_pure(lhs) || !static_expr_is_pure(rhs) {
+            return None;
+        }
+        let lhs = self.static_value_from_expr(lhs)?;
+        let rhs = self.static_value_from_expr(rhs)?;
+        let lhs = self.static_string_from_value(&lhs)?;
+        let rhs = self.static_string_from_value(&rhs)?;
+        Some(match op {
+            BinaryOp::Less => lhs < rhs,
+            BinaryOp::LessEqual => lhs <= rhs,
+            BinaryOp::Greater => lhs > rhs,
+            BinaryOp::GreaterEqual => lhs >= rhs,
+            _ => return None,
+        })
     }
 
     fn static_equality_from_exprs_preserving_effects(

--- a/docs/book/src/tour/strings.md
+++ b/docs/book/src/tour/strings.md
@@ -63,6 +63,14 @@ val tidy = "  Klassic  ".trim().toUpperCase()
 println(tidy)   // KLASSIC
 ```
 
+Strings also order lexicographically by code point, so `<`, `<=`, `>`,
+and `>=` work on text and `std.list.sort` can sort it:
+
+```kl
+println("apple" < "banana")   // true
+println(sort(["banana", "apple"]))   // [apple, banana]
+```
+
 ## Formatting and padding
 
 `format(template, args)` fills each `{}` placeholder from the `args`

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -84,6 +84,28 @@ fn stdlib_negative_and_boundary_fixes() {
     );
 }
 
+/// Strings compare lexicographically by code point, so the ordering
+/// operators and `std.list.sort` work on text — not just numbers.
+#[test]
+fn strings_compare_lexicographically() {
+    let output = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "import std.list\nprintln(\"apple\" < \"banana\")\nprintln(\"b\" > \"a\")\nprintln(\"a\" <= \"a\")\nprintln(\"zebra\" >= \"apple\")\nprintln(sort([\"banana\", \"apple\", \"cherry\"]))",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        output.status.success(),
+        "string comparison should evaluate\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "true\ntrue\ntrue\ntrue\n[apple, banana, cherry]\n()\n"
+    );
+}
+
 /// Arity-mismatch diagnostics pluralize the noun: exactly one expected
 /// argument reads "1 argument", any other count reads "N arguments".
 #[test]
@@ -3234,6 +3256,68 @@ fn builds_native_executable_for_set_combine() {
         String::from_utf8_lossy(&run.stdout),
         String::from_utf8_lossy(&eval.stdout),
         "native Set#union / intersect / subtract must match eval"
+    );
+}
+
+/// Ordering of compile-time-known strings folds to a constant in native
+/// builds, matching the evaluator. (Runtime string ordering stays a clean
+/// diagnostic; it is not lowered yet.)
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn builds_native_executable_for_static_string_comparison() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-native-strcmp-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-native-strcmp-{unique}"));
+    fs::write(
+        &source_path,
+        "println(\"apple\" < \"banana\")\n\
+         println(\"b\" > \"a\")\n\
+         println(\"a\" <= \"a\")\n\
+         println(\"zebra\" >= \"apple\")\n\
+         val x = \"mango\"\n\
+         val y = \"melon\"\n\
+         println(x < y)\n",
+    )
+    .expect("source should write");
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(eval.status.success());
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(
+        build.status.success(),
+        "native build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+
+    assert_eq!(
+        String::from_utf8_lossy(&eval.stdout),
+        "true\ntrue\ntrue\ntrue\ntrue\n"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&eval.stdout),
+        "native static string comparison must match eval"
     );
 }
 


### PR DESCRIPTION
## Gap

`<`, `<=`, `>`, `>=` already type-checked for strings — the checker only unifies the operands — but the evaluator and native backend rejected them at runtime with `comparison expects numbers`. So string ordering was impossible, and even `std.list.sort` failed on text.

```kl
println("apple" < "banana")   // was: comparison expects numbers
println(sort(["banana", "apple"]))   // was: comparison expects numbers
```

## Implementation

- **Evaluator**: compare two strings lexicographically by code point (UTF-8 byte order preserves code-point order). `"apple" < "banana"`, range checks, and `std.list.sort` on strings now work. The number-only diagnostic now reads "two numbers or two strings".
- **Native**: fold ordering of two compile-time-known strings to a constant. Runtime string ordering (sorting variables) is not lowered yet and stays a clean diagnostic, so native still either matches the evaluator (static operands) or refuses cleanly (runtime operands) — no silent miscompile.

## Verification

- `"apple" < "banana"`, `"b" > "a"`, `"a" <= "a"`, and `sort(["banana", "apple", "cherry"])` → `[apple, banana, cherry]` all evaluate correctly.
- Static string comparison matches eval in native builds; runtime string ordering (e.g. sorting) remains a clean diagnostic.
- New tests `strings_compare_lexicographically` (evaluator, incl. `sort`) and `builds_native_executable_for_static_string_comparison`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, full `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)