### PR TITLE
docs: note native enum equality as a known native gap

### DIFF
--- a/docs/book/src/reference/enums.md
+++ b/docs/book/src/reference/enums.md
@@ -69,6 +69,7 @@ per instantiation, with payload shapes tracked through bindings,
 control-flow joins, and annotated function boundaries — so recursive
 functions over `Option<Int>`-style annotations work, and the checker
 also diagnoses match exhaustiveness and unreachable arms ahead of
-codegen. The remaining native gaps (for example a `List<SomeEnum>`
-payload field) fail at build time with a source-located diagnostic,
-never with wrong code.
+codegen. The remaining native gaps — comparing two enum values with
+`==` / `!=` (the evaluator compares them structurally), and payloads
+such as a `List<SomeEnum>` field — fail at build time with a
+source-located diagnostic, never with wrong code.


### PR DESCRIPTION
## What

The enums reference page (`docs/book/src/reference/enums.md`) described the native compiler's remaining gaps only by example — a `List<SomeEnum>` payload field. Comparing two enum values with `==` / `!=` is *also* unsupported by native codegen today: it fails at build time with a source-located diagnostic (`equality of heap values such as enums is not supported by the native compiler yet`), while the evaluator compares enums structurally.

This lists the equality gap alongside the existing example so the documented native surface matches the compiler.

## Why

Verified empirically against the current tree:

- `klassic build` on `Red == Red` → clean build-time diagnostic (no wrong code).
- `klassic -e 'enum C { case Red; case Blue }; println(Red == Red); println(Red == Blue)'` → `true` / `false` (structural).

The omission could lead a reader to assume native enum `==` works. It's a true, clean limitation (never a miscompile), now documented.

## Scope

Docs-only. No code change — the tree is byte-identical to `main` (cc61bd5). `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)