### PR TITLE
docs: document native enum and match coverage

### DIFF
--- a/docs/native-coverage.md
+++ b/docs/native-coverage.md
@@ -294,6 +294,30 @@ storage across normal and recursive native calls. Runtime line-list
 `foldLeft` can use the same storage for record accumulators, including
 empty `List<String>` fields.
 
+## Enums And Match
+
+Monomorphic enums lower to GC records with short-circuit tag dispatch:
+each variant is a heap cell whose first slot is the boxed tag and whose
+remaining slots box the payload. Supported payloads are integer (`Int` /
+`Long` / `Short` / `Byte`), `Boolean`, `String`, and nested
+monomorphic-enum fields, with distinct variant names. Generic enums
+(`Option<a>`, `Result<a, b>`, self-referential shapes) compile per
+instantiation, with payload shapes tracked through `val` bindings,
+control-flow joins, and fully-applied annotated function boundaries — so
+recursive functions over `Option<Int>`- or `Tree`-style annotations
+lower natively. Enum values format through `toString`, interpolation,
+and string concatenation.
+
+`match` lowers to a tag-test if-chain over constructor patterns,
+including nested constructor patterns, integer / string literal
+patterns, variable bindings, wildcards, and arm guards. The checker
+diagnoses match exhaustiveness and unreachable arms ahead of codegen.
+
+Remaining gaps fail at build time with a source-located diagnostic
+rather than miscompiling: comparing enum values with `==` / `!=` (the
+evaluator compares them structurally), and aggregate payload fields such
+as `List<SomeEnum>`.
+
 ## Runtime List Literals And Selectors
 
 Direct `head` over list literals can return runtime native values, including


### PR DESCRIPTION
## What

`docs/native-coverage.md` enumerates the language constructs the native compiler lowers to ELF, with sections for records, static/runtime lists, maps, and sets — but it had **no section for enums and match**, even though native builds have compiled monomorphic and generic enums (including recursion) for some time.

Adds an **Enums And Match** section covering:
- monomorphic lowering (GC records with boxed tag + boxed payload slots) and the supported payloads (`Int`/`Long`/`Short`/`Byte`, `Boolean`, `String`, nested monomorphic enums);
- generic enums compiled per instantiation with shape tracking across bindings, control-flow joins, and annotated function boundaries (so recursive `Option<Int>` / `Tree` functions lower natively);
- `match` pattern forms (nested constructors, integer/string literals, bindings, wildcards, guards) and the exhaustiveness / unreachable-arm diagnostics;
- the two remaining gaps that fail with a build-time diagnostic rather than wrong code: enum `==` / `!=` (the evaluator compares structurally) and aggregate payload fields such as `List<SomeEnum>`.

## Verification

Every claim was checked against the current native compiler (`klassic build`): Int/Bool/String/nested payloads, generic `Option<Int>`, recursive `Tree`, `toString`/interpolation/concat display, guard/literal/wildcard match arms — all produce the documented output; the two gaps produce the documented diagnostics; non-exhaustive and duplicate arms are rejected ahead of codegen.

## Scope

Docs-only. No code change — tree is byte-identical to `main` (de2e4eb). `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)