### PR TITLE
docs: document native extension-method coverage

### DIFF
--- a/docs/native-coverage.md
+++ b/docs/native-coverage.md
@@ -318,6 +318,19 @@ rather than miscompiling: comparing enum values with `==` / `!=` (the
 evaluator compares them structurally), and aggregate payload fields such
 as `List<SomeEnum>`.
 
+## Extension Methods
+
+`extension` declarations lower to ordinary native functions, and a
+`receiver.method(...)` call on a value of the extended type dispatches
+to the matching one. This covers extensions on built-in types such as
+`Int` and `String`, generic extensions like `extension <a>(this:
+List<a>)`, receiver use inside the body, and method chaining.
+Standard-library extension methods (for example `.reversed()` from
+`std.list` or `.capitalized()` from `std.string`) compile the same way
+once their module is imported; the evaluator auto-loads the standard
+library, so it additionally accepts those calls without an explicit
+import.
+
 ## Runtime List Literals And Selectors
 
 Direct `head` over list literals can return runtime native values, including


### PR DESCRIPTION
## What

`docs/native-coverage.md` had no mention of extension methods at all, even though `extension` declarations lower to ordinary native functions and `receiver.method(...)` dispatch is supported. Adds an **Extension Methods** section covering:
- user-defined extensions on built-in receiver types (`Int`, `String`), generic extensions (`extension <a>(this: List<a>)`), receiver use in the body, and chaining;
- standard-library extension methods (`.reversed()`, `.capitalized()`, …) which compile once their module is imported;
- the one accept-without-import difference: the evaluator auto-loads the standard library, so it accepts those calls without an explicit `import` while native requires one.

## Verification

Checked against the current native compiler (`klassic build`): `(10).addN(5)` → 15, `"hi".shout()` → `hi!`, a generic `List<a>` extension, `(5).inc().inc().inc()` → 8, and `import std.list; [1 2 3].reversed()` → `[3, 2, 1]`. The evaluator accepts `[1 2 3].reversed()` with no import (auto-load).

## Scope

Docs-only. No code change — tree is byte-identical to `main` (de4ad99). `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)