### PR TITLE
docs: document native type-class coverage

### DIFF
--- a/docs/native-coverage.md
+++ b/docs/native-coverage.md
@@ -331,6 +331,19 @@ once their module is imported; the evaluator auto-loads the standard
 library, so it additionally accepts those calls without an explicit
 import.
 
+## Type Classes
+
+`typeclass` declarations, their `instance` implementations, and
+constrained generic functions (`def f<'a>(x: 'a): R where Show<'a> =
+...`) lower natively. Both direct instance-method calls (`show(42)`) and
+dispatch through one or more constraints — including transitive
+constraints, where one constrained function calls another — resolve to
+the concrete instance at the call site and compile to ordinary native
+calls. Instances over concrete types such as `Int` and `String` and
+over applied types such as `List<Int>` are supported. A constraint with
+no matching instance is rejected ahead of codegen with a `missing
+instance` diagnostic, in native builds exactly as in the evaluator.
+
 ## Runtime List Literals And Selectors
 
 Direct `head` over list literals can return runtime native values, including


### PR DESCRIPTION
## What

`docs/native-coverage.md` mentioned typeclass methods only narrowly (in the static-folding section). Adds a **Type Classes** section documenting that `typeclass` declarations, `instance` implementations, and constrained generic functions (`def f<'a>(x: 'a): R where Show<'a> = ...`) lower natively:
- direct instance-method calls (`show(42)`) and dispatch through one or more (including transitive) constraints resolve to the concrete instance at the call site;
- instances over concrete types (`Int`, `String`) and applied types (`List<Int>`) are supported;
- a missing instance is rejected ahead of codegen with a `missing instance` diagnostic, the same as the evaluator.

## Verification

Checked against the current native compiler: direct dispatch, single- and multi-constraint generic dispatch, transitive constraint resolution, `List<Int>` instances, and the `missing instance for Show<Boolean>` rejection all behave identically under `klassic` and `klassic build`. The typeclass programs under `test-programs/` already exercise the native backend through `sample_programs.rs`.

## Scope

Docs-only. No code change — tree is byte-identical to `main` (d68aed7). `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)