### PR TITLE
docs: document native proof-surface coverage

### DIFF
--- a/docs/native-coverage.md
+++ b/docs/native-coverage.md
@@ -344,6 +344,19 @@ over applied types such as `List<Int>` are supported. A constraint with
 no matching instance is rejected ahead of codegen with a `missing
 instance` diagnostic, in native builds exactly as in the evaluator.
 
+## Proof Surface
+
+`axiom` and `theorem` declarations are a static, type-check-time
+surface — Klassic does not run a proof checker on theorem bodies, and
+the declarations are erased before codegen, so a native build compiles
+and runs the ordinary runtime portion of a program that uses them. The
+`--warn-trust` and `--deny-trust` gates apply to native builds exactly
+as they do to the evaluator: `--warn-trust` reports every theorem whose
+proof transitively depends on a trusted (`axiom` or `trust`-marked)
+declaration, and `--deny-trust` rejects the build when any reachable
+theorem does. Calling a zero-argument axiom in proof position is a
+shared type-check limitation, diagnosed identically by both paths.
+
 ## Runtime List Literals And Selectors
 
 Direct `head` over list literals can return runtime native values, including


### PR DESCRIPTION
## What

`docs/native-coverage.md` never mentioned the `axiom` / `theorem` / `trust` surface. Adds a **Proof Surface** section:
- the declarations are a static, type-check-time concern (no proof checker runs on bodies) and are erased before codegen, so a native build compiles and runs the runtime portion of a program that uses them;
- `--warn-trust` and `--deny-trust` apply to native builds exactly as to the evaluator — warn reports theorems transitively depending on a trusted (`axiom` or `trust`-marked) declaration, deny rejects the build when any reachable theorem does;
- the zero-argument-axiom-in-proof-position case is a shared type-check limitation diagnosed identically by both paths.

## Verification

Checked against `klassic build`: the trust-tour example (`axiom` + `theorem`) compiles and runs (`runs`) under both `klassic` and `klassic build`; `--deny-trust build` rejects with `trusted proof '…' is not allowed`; `--warn-trust build` reports `[trust] proof '…' is trusted` and still builds; the zero-arg axiom call yields `Prop is not callable` identically on both paths.

## Scope

Docs-only. No code change — tree is byte-identical to `main` (478e843). `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)