### PR TITLE
docs: document native cleanup-clause behavior and its abort gap

### DIFF
--- a/docs/native-coverage.md
+++ b/docs/native-coverage.md
@@ -357,6 +357,16 @@ declaration, and `--deny-trust` rejects the build when any reachable
 theorem does. Calling a zero-argument axiom in proof position is a
 shared type-check limitation, diagnosed identically by both paths.
 
+## Cleanup Clauses
+
+A `cleanup { ... }` clause runs after its associated expression on the
+normal completion path. Native builds do not unwind cleanup clauses when
+that expression aborts at runtime (for example on division by zero): the
+evaluator runs the clause before propagating the error, while a native
+build reports the error without running it. A program that aborts
+therefore differs only in the cleanup side effect, not in the final
+exit; restoring abort-time unwinding is a known gap.
+
 ## Runtime List Literals And Selectors
 
 Direct `head` over list literals can return runtime native values, including


### PR DESCRIPTION
## What

`docs/native-coverage.md` mentioned `cleanup` only incidentally (in the static-folding section). Adds a **Cleanup Clauses** section documenting both the support and the one eval/native divergence:
- native runs a `cleanup { ... }` clause after its associated expression on the **normal completion path**;
- it does **not** unwind the clause when the expression aborts at runtime (e.g. division by zero) — the evaluator runs the clause before propagating the error, native reports the error without running it;
- such programs differ only in the cleanup side effect, not the final exit; abort-time unwinding is a known gap.

## Verification

`val x = { println("body"); 10 } cleanup { println("cleanup ran") }` → both eval and native print `body` / `cleanup ran`. Replacing `10` with `10 / 0`: the evaluator prints `body` / `cleanup ran` then the division-by-zero error; the native build prints `body` then the error, without `cleanup ran`.

## Scope

Docs-only. No code change — tree is byte-identical to `main` (3998f49). `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)