### PR TITLE
fix: assertResult compares enum values structurally

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -8164,7 +8164,7 @@ impl NativeCodeGenerator {
                 self.asm.bind_text_label(ok);
                 Ok(NativeValue::Unit)
             }
-            NativeValue::Int | NativeValue::Bool | NativeValue::HeapPointer => {
+            NativeValue::Int | NativeValue::Bool => {
                 self.push_temp_reg(Reg::Rax);
                 let actual = self.compile_expr(&actual_arguments[0])?;
                 if actual != expected {
@@ -8178,6 +8178,33 @@ impl NativeCodeGenerator {
                 self.asm.cmp_reg_reg(Reg::Rcx, Reg::Rax);
                 self.asm.jcc_label(Condition::Equal, ok);
                 self.emit_assert_result_failed_runtime(span, expected);
+                self.asm.bind_text_label(ok);
+                Ok(NativeValue::Unit)
+            }
+            NativeValue::HeapPointer => {
+                // A heap value (enum, cons cell, ...) must compare
+                // structurally, not by heap identity — two freshly built
+                // copies of the same value have different addresses.
+                // `gc_deep_equal` walks both operands' GC structure, the
+                // same routine the `==` operator uses. The failure path
+                // reports a plain message rather than the raw pointers a
+                // value formatter would print for a heap value without a
+                // tracked shape.
+                self.push_temp_reg(Reg::Rax);
+                let actual = self.compile_expr(&actual_arguments[0])?;
+                if !matches!(actual, NativeValue::HeapPointer) {
+                    return Err(unsupported(
+                        span,
+                        "native assertResult for values with different types",
+                    ));
+                }
+                self.pop_temp_reg(Reg::Rdi);
+                self.asm.mov_reg_reg(Reg::Rsi, Reg::Rax);
+                self.asm.call_label(self.gc_deep_equal);
+                let ok = self.asm.create_text_label();
+                self.asm.cmp_reg_imm8(Reg::Rax, 0);
+                self.asm.jcc_label(Condition::NotEqual, ok);
+                self.emit_runtime_error(span, "assertResult failed");
                 self.asm.bind_text_label(ok);
                 Ok(NativeValue::Unit)
             }

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -1435,6 +1435,84 @@ fn native_enum_equality_survives_allocation_churn() {
     );
 }
 
+/// `assertResult` over enum values compares structurally through
+/// `gc_deep_equal`, matching the evaluator. It used to compare heap
+/// identity, so an assertion of two equal enums failed (and printed raw
+/// pointer addresses). Equal operands now pass; unequal operands abort
+/// with a non-zero exit.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_assert_result_compares_enums_structurally() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let pass_src = std::env::temp_dir().join(format!("klassic-ar-pass-{unique}.kl"));
+    let pass_bin = std::env::temp_dir().join(format!("klassic-ar-pass-{unique}"));
+    fs::write(
+        &pass_src,
+        "enum E { case A(v: Int); case B }\n\
+         assertResult(A(5))(A(5))\n\
+         assertResult(B)(B)\n\
+         println(\"ok\")\n",
+    )
+    .expect("source should write");
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            pass_src.to_string_lossy().as_ref(),
+            "-o",
+            pass_bin.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(
+        build.status.success(),
+        "native build should compile, got:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&pass_bin).output().expect("binary should run");
+    assert!(
+        run.status.success(),
+        "assertResult of equal enums must pass"
+    );
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "ok\n");
+    let _ = fs::remove_file(&pass_src);
+    let _ = fs::remove_file(&pass_bin);
+
+    // Unequal operands must abort before the following statement runs.
+    let fail_src = std::env::temp_dir().join(format!("klassic-ar-fail-{unique}.kl"));
+    let fail_bin = std::env::temp_dir().join(format!("klassic-ar-fail-{unique}"));
+    fs::write(
+        &fail_src,
+        "enum E { case A(v: Int); case B }\n\
+         assertResult(A(5))(A(6))\n\
+         println(\"unreachable\")\n",
+    )
+    .expect("source should write");
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            fail_src.to_string_lossy().as_ref(),
+            "-o",
+            fail_bin.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(build.status.success());
+    let run = Command::new(&fail_bin).output().expect("binary should run");
+    let _ = fs::remove_file(&fail_src);
+    let _ = fs::remove_file(&fail_bin);
+    assert!(
+        !run.status.success(),
+        "assertResult of unequal enums must abort"
+    );
+    assert!(
+        !String::from_utf8_lossy(&run.stdout).contains("unreachable"),
+        "the program must abort before the next statement"
+    );
+}
+
 /// Syntax errors for the parenthesization Klassic requires (and the
 /// `field: value` record syntax) carry a keyword-specific hint instead
 /// of the bare `expected (`, so users coming from Kotlin/Scala/Rust see


### PR DESCRIPTION
## What

Native `assertResult` compared `HeapPointer` operands (enums, cons cells, …) by **heap identity** — it lumped them in with `Int` / `Bool` and used a register compare. Two freshly built copies of the same enum have different addresses, so `assertResult(A(5))(A(5))` **failed** (printing raw pointer addresses) when the evaluator passes it.

Splits the heap-pointer case out and routes it through `gc_deep_equal` — the same structural walk the `==` operator uses (added in #523). The failure path now reports a plain `assertResult failed` instead of the raw pointers a shapeless heap value would otherwise format to.

## Behavior

- `assertResult(A(5))(A(5))` / `assertResult(B)(B)` → pass (matching the evaluator; previously failed).
- `assertResult(A(5))(A(6))` → aborts with a non-zero exit before the next statement (matching the evaluator's failure).

## Tests

`native_assert_result_compares_enums_structurally` — builds and runs both an all-equal assertion program (must exit 0, print `ok`) and an unequal one (must abort non-zero without printing the following statement).

## Gate

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (cli_smoke 498 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)