### PR TITLE
fix: C backend renders whole-number doubles with a trailing .0

### DIFF
--- a/crates/klassic-runtime/src/rt.rs
+++ b/crates/klassic-runtime/src/rt.rs
@@ -95,10 +95,23 @@ pub extern "C" fn klassic_rt_println_bool(value: i64) {
     println!("{}", if value != 0 { "true" } else { "false" });
 }
 
+/// Render an `f64` exactly like the evaluator's `Value::Double` display:
+/// a whole-number value keeps a single trailing decimal (`4.0`), while a
+/// fractional value uses the default formatting (`3.14`). Rust's default
+/// `f64` formatting drops the `.0`, which would print a `Double` as if it
+/// were an `Int`.
+fn format_double_like_evaluator(value: f64) -> String {
+    if value.fract() == 0.0 {
+        format!("{value:.1}")
+    } else {
+        format!("{value}")
+    }
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn klassic_rt_println_f64(value: f64) {
     // Match the evaluator's Double display.
-    println!("{value}");
+    println!("{}", format_double_like_evaluator(value));
 }
 
 #[unsafe(no_mangle)]
@@ -146,7 +159,7 @@ pub extern "C" fn klassic_rt_i64_to_str(value: i64) -> KStr {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn klassic_rt_f64_to_str(value: f64) -> KStr {
-    kstr_from_owned(value.to_string())
+    kstr_from_owned(format_double_like_evaluator(value))
 }
 
 #[unsafe(no_mangle)]

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -27022,6 +27022,81 @@ fn build_backend_c_strings_match_the_evaluator() {
     assert_eq!(String::from_utf8_lossy(&run_output.stdout), expected);
 }
 
+/// The C backend renders `Double` values exactly like the evaluator: a
+/// whole-number value keeps a single trailing decimal (`4.0`), not the
+/// bare integer Rust's default `f64` formatting would emit. The earlier
+/// runtime shim used `f64::to_string`, so a whole-number Double printed
+/// as `4` while the evaluator (and the direct native backend) printed
+/// `4.0`.
+#[test]
+fn build_backend_c_formats_doubles_like_evaluator() {
+    let cc_available = Command::new("cc")
+        .arg("--version")
+        .output()
+        .is_ok_and(|probe| probe.status.success());
+    if !cc_available {
+        return;
+    }
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_cdoubles_{stamp}.kl"));
+    let bin_path = dir.join(format!("klassic_cdoubles_{stamp}.bin"));
+    fs::write(
+        &source_path,
+        "println(4.0)\n\
+         println(2.0 * 3.0)\n\
+         println(0.0)\n\
+         println(100.0)\n\
+         println(10.0 / 2.0)\n\
+         println(3.14)\n\
+         println(1.5 + 2.25)\n",
+    )
+    .expect("temp source file should write");
+    let expected = "4.0\n6.0\n0.0\n100.0\n5.0\n3.14\n3.75\n";
+
+    let eval_output = Command::new(klassic_bin())
+        .arg(source_path.to_str().expect("path should be utf-8"))
+        .output()
+        .expect("binary should run");
+    assert!(eval_output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&eval_output.stdout),
+        expected,
+        "evaluator oracle"
+    );
+
+    let link_output = Command::new(klassic_bin())
+        .args([
+            "--backend",
+            "c",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        link_output.status.success(),
+        "C backend should compile doubles\nstderr:\n{}",
+        String::from_utf8_lossy(&link_output.stderr)
+    );
+    let run_output = Command::new(&bin_path)
+        .output()
+        .expect("compiled C binary should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&bin_path);
+    assert!(run_output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&run_output.stdout),
+        expected,
+        "C backend double formatting must match the evaluator"
+    );
+}
+
 /// The portable C backend (GitHub issue #425, roadmap PR 9) emits a
 /// single C99 translation unit for the Int/Bool/String/println/if/
 /// while/def subset behind `--backend c`. The generated source depends


### PR DESCRIPTION
## Bug

The C backend printed whole-number `Double` values as bare integers — `println(4.0)` emitted `4` instead of `4.0`, making a `Double` indistinguishable from an `Int` and diverging from both the evaluator and the direct (ELF) native backend, which print `4.0`.

Root cause: the `klassic_rt_println_f64` / `klassic_rt_f64_to_str` runtime shims used Rust's default `f64` formatting (`println!("{value}")` / `value.to_string()`), which drops the `.0` for whole numbers. The evaluator's `Value::Double` display instead formats a whole-number value with one trailing decimal (`format!("{value:.1}")`) and a fractional value with the default formatting.

## Fix

Route both shims through a `format_double_like_evaluator` helper that mirrors the evaluator: `value.fract() == 0.0` → `{value:.1}` (`4.0`), otherwise default (`3.14`). Isolated to `klassic-runtime` (the C backend's staticlib); the ELF backend has its own double printing and already matched.

## How it was found

Differential testing the C backend against the evaluator (the oracle). The existing C-backend string test only exercised *fractional* doubles (`12.56636`, `3.75`, `0.5`), so the whole-number case was never covered. Adds `build_backend_c_formats_doubles_like_evaluator` covering whole and fractional doubles.

## Verification

`println(4.0)` / `2.0 * 3.0` / `0.0` / `100.0` / `10.0 / 2.0` now emit `4.0` / `6.0` / `0.0` / `100.0` / `5.0` from the C backend, matching the evaluator; `3.14` / `3.75` unchanged. `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (cli_smoke 499 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)