### PR TITLE
fix: check Boolean match exhaustiveness at compile time

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -4483,6 +4483,35 @@ impl TypeChecker {
         if closed {
             return Ok(());
         }
+        // A `Boolean` scrutinee has a finite domain, so an unguarded match
+        // without a wildcard (which would have set `closed` above) is
+        // exhaustive only when both `true` and `false` appear — mirroring
+        // the enum check below and the nested `patterns_cover` rule.
+        if let Type::Bool = self.resolve(scrutinee_type) {
+            let unguarded: Vec<&klassic_syntax::Pattern> = arms
+                .iter()
+                .filter(|arm| arm.guard.is_none())
+                .map(|arm| &arm.pattern)
+                .collect();
+            if self.patterns_cover(&unguarded, &Type::Bool) {
+                return Ok(());
+            }
+            let has_true = unguarded
+                .iter()
+                .any(|p| matches!(p, klassic_syntax::Pattern::LiteralBool { value: true, .. }));
+            let has_false = unguarded
+                .iter()
+                .any(|p| matches!(p, klassic_syntax::Pattern::LiteralBool { value: false, .. }));
+            let missing = match (has_true, has_false) {
+                (true, false) => "false",
+                (false, true) => "true",
+                _ => "true, false",
+            };
+            return Err(type_error(
+                span,
+                format!("match on `Boolean` is not exhaustive: missing {missing}"),
+            ));
+        }
         let Type::Enum(enum_name, enum_args) = self.resolve(scrutinee_type) else {
             return Ok(());
         };

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -515,6 +515,76 @@ fn exhaustiveness_checks_refutable_payload_subpatterns() {
 }
 
 #[test]
+fn bool_scrutinee_match_must_be_exhaustive() {
+    // A `Boolean` has a finite domain, so a top-level match missing `true`
+    // or `false` (and without a wildcard) is non-exhaustive and rejected at
+    // type-check time — it used to be accepted and crash at runtime with
+    // `no match arm matched value`, unlike the enum check.
+    let missing_false = evaluate_text(
+        "<expr>",
+        "def f(b: Boolean): Int = b match { case true => 1 }\nf(false)",
+    )
+    .expect_err("a Boolean match missing `false` should be rejected");
+    assert!(
+        missing_false
+            .to_string()
+            .contains("not exhaustive: missing false"),
+        "got: {missing_false}"
+    );
+
+    let missing_true = evaluate_text(
+        "<expr>",
+        "def f(b: Boolean): Int = b match { case false => 0 }\nf(true)",
+    )
+    .expect_err("a Boolean match missing `true` should be rejected");
+    assert!(
+        missing_true
+            .to_string()
+            .contains("not exhaustive: missing true"),
+        "got: {missing_true}"
+    );
+
+    // A guard does not unconditionally cover its value, so a guarded `true`
+    // arm leaves `true` uncovered.
+    let guarded = evaluate_text(
+        "<expr>",
+        "def f(b: Boolean): Int = b match { case true if b => 1; case false => 0 }\nf(true)",
+    )
+    .expect_err("a guarded `true` arm does not cover `true`");
+    assert!(
+        guarded.to_string().contains("not exhaustive"),
+        "got: {guarded}"
+    );
+
+    // Exhaustive forms still type-check (no false rejection): both literals,
+    // either order, a wildcard, or a bare variable.
+    for (program, expected) in [
+        (
+            "def f(b: Boolean): Int = b match { case true => 1; case false => 0 }\nf(true)",
+            1,
+        ),
+        (
+            "def f(b: Boolean): Int = b match { case false => 0; case true => 1 }\nf(true)",
+            1,
+        ),
+        (
+            "def f(b: Boolean): Int = b match { case true => 1; case _ => 0 }\nf(false)",
+            0,
+        ),
+        (
+            "def f(b: Boolean): Int = b match { case x => 99 }\nf(true)",
+            99,
+        ),
+    ] {
+        assert_eq!(
+            evaluate_text("<expr>", program).unwrap(),
+            Value::Int(expected),
+            "exhaustive Boolean match should type-check: {program}"
+        );
+    }
+}
+
+#[test]
 fn free_map_and_set_builtins_are_element_typed() {
     // `Map#keys` / `Map#values` / `Set#union` carry the collection's element
     // type instead of `Dynamic`, so a wrong-typed use is a type error rather


### PR DESCRIPTION
## Bug

A non-exhaustive match on a `Boolean` scrutinee was accepted by the type checker and crashed at runtime for the missing case — inconsistent with enums, which are rejected at compile time:

```kl
def f(b: Boolean): Int = b match { case true => 1 }   // accepted
f(false)   // runtime: no match arm matched value: false
```

`enum E { case A; case B }` with only `case A` is correctly rejected (`match on \`E\` is not exhaustive: missing B`), but the same gap on `Boolean` slipped through.

## Fix

`check_match_coverage` handled only enum scrutinees. A `Boolean` has a finite domain, so extend it: when the scrutinee resolves to `Bool` and the match is not already closed by a wildcard/variable, require both `true` and `false` and report whichever is missing. This reuses the existing `patterns_cover` rule already applied to nested Boolean payloads.

- `case true` only → `not exhaustive: missing false`
- `case false` only → `not exhaustive: missing true`
- a guarded `case true if …` does not cover `true` (guards don't unconditionally match)
- `case true; case false` (either order), `case _`, and `case x` continue to type-check

## Tests

`bool_scrutinee_match_must_be_exhaustive` (language_regressions): should-reject (missing true / false / guarded-only) and should-accept (both literals either order, wildcard, variable). Enum exhaustiveness control unchanged.

## Gate

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` all green (no existing program relied on the gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)