### PR TITLE
fix: reject a repeated literal match arm as unreachable

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -4449,6 +4449,7 @@ impl TypeChecker {
     ) -> Result<(), Diagnostic> {
         let mut closed = false;
         let mut closed_variants: HashSet<String> = HashSet::new();
+        let mut closed_literals: HashSet<String> = HashSet::new();
         for arm in arms {
             if closed {
                 return Err(type_error(
@@ -4475,6 +4476,19 @@ impl TypeChecker {
                 if args.iter().all(pattern_is_irrefutable) {
                     closed_variants.insert(name.clone());
                 }
+            }
+            // The same is true for a repeated literal pattern: a second
+            // unguarded `case true` or `case 1` can never run because the
+            // first already matches that value. A guarded literal arm does
+            // not close the value, so a later arm for it stays live.
+            if arm.guard.is_none()
+                && let Some(key) = literal_pattern_key(&arm.pattern)
+                && !closed_literals.insert(key.clone())
+            {
+                return Err(type_error(
+                    arm.span,
+                    format!("unreachable match arm: {key} is already matched by a preceding arm"),
+                ));
             }
             if arm.guard.is_none() && pattern_is_irrefutable(&arm.pattern) {
                 closed = true;
@@ -6249,6 +6263,21 @@ fn pattern_is_irrefutable(pattern: &klassic_syntax::Pattern) -> bool {
         pattern,
         klassic_syntax::Pattern::Wildcard { .. } | klassic_syntax::Pattern::Variable { .. }
     )
+}
+
+/// A user-facing, type-distinct key for a literal pattern, used to detect a
+/// repeated `case` that can never run. The rendering doubles as both the
+/// uniqueness key and the diagnostic text, and never collides across types
+/// (`` `1` `` for an `Int`, `` `"1"` `` for a `String`). Non-literal
+/// patterns return `None`.
+fn literal_pattern_key(pattern: &klassic_syntax::Pattern) -> Option<String> {
+    use klassic_syntax::Pattern;
+    match pattern {
+        Pattern::LiteralBool { value, .. } => Some(format!("`{value}`")),
+        Pattern::LiteralInt { value, .. } => Some(format!("`{value}`")),
+        Pattern::LiteralString { value, .. } => Some(format!("`{value:?}`")),
+        _ => None,
+    }
 }
 
 fn occurs_in(var: GenericVar, ty: &Type) -> bool {

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -585,6 +585,54 @@ fn bool_scrutinee_match_must_be_exhaustive() {
 }
 
 #[test]
+fn repeated_literal_match_arm_is_unreachable() {
+    // A repeated unguarded literal arm can never run — the constructor check
+    // already rejected a duplicate `case A`, but a duplicate `case true`,
+    // `case 1`, or `case "a"` used to be silently accepted as dead code.
+    for (program, needle) in [
+        (
+            "def f(b: Boolean): Int = b match { case true => 1; case true => 2; case false => 0 }\nf(true)",
+            "`true` is already matched",
+        ),
+        (
+            "def f(n: Int): Int = n match { case 1 => 10; case 1 => 20; case _ => 0 }\nf(1)",
+            "`1` is already matched",
+        ),
+        (
+            "def f(s: String): Int = s match { case \"a\" => 1; case \"a\" => 2; case _ => 0 }\nf(\"a\")",
+            "`\"a\"` is already matched",
+        ),
+    ] {
+        let err = evaluate_text("<expr>", program)
+            .expect_err("a repeated literal arm should be rejected as unreachable");
+        assert!(
+            err.to_string().contains("unreachable match arm") && err.to_string().contains(needle),
+            "got: {err}"
+        );
+    }
+
+    // Distinct literals, a guarded duplicate (the guard keeps the later arm
+    // live), and the same literal across different scrutinee types all stay
+    // accepted.
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "def f(n: Int): Int = n match { case 1 => 10; case 2 => 20; case _ => 0 }\nf(2)",
+        )
+        .unwrap(),
+        Value::Int(20)
+    );
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "def f(n: Int): Int = n match { case 1 if false => 10; case 1 => 20; case _ => 0 }\nf(1)",
+        )
+        .unwrap(),
+        Value::Int(20)
+    );
+}
+
+#[test]
 fn free_map_and_set_builtins_are_element_typed() {
     // `Map#keys` / `Map#values` / `Set#union` carry the collection's element
     // type instead of `Dynamic`, so a wrong-typed use is a type error rather


### PR DESCRIPTION
## Bug

The match checker rejects a duplicate unguarded constructor arm (`case A` after `case A` → `unreachable match arm: \`A\` is already matched`), but a duplicate **literal** arm was silently accepted as dead code:

```kl
def f(b: Boolean): Int = b match { case true => 1; case true => 2; case false => 0 }  // accepted
def f(n: Int): Int = n match { case 1 => 10; case 1 => 20; case _ => 0 }              // accepted
```

The second `case true` / `case 1` can never run.

## Fix

Track matched literal values (`closed_literals`) alongside the existing constructor set in `check_match_coverage`, and reject a repeated unguarded literal the same way. A small `literal_pattern_key` helper renders a type-distinct, user-facing key that doubles as the uniqueness key and the diagnostic text (`` `1` `` for an `Int` vs `` `"1"` `` for a `String`, so they never collide).

- `case true; case true` / `case 1; case 1` / `case "a"; case "a"` → `unreachable match arm: \`…\` is already matched by a preceding arm`
- a guarded literal arm does not close its value, so `case 1 if g` followed by `case 1` stays live
- distinct literals and the same literal across different scrutinee types are unaffected

## Tests

`repeated_literal_match_arm_is_unreachable` (language_regressions): rejects duplicate bool/int/string arms; accepts distinct literals and a guarded duplicate.

## Gate

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` all green (no existing program had a duplicate literal arm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)