### PR TITLE
fix: allow the .toString() method on every numeric type

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -4834,6 +4834,10 @@ impl TypeChecker {
         let resolved = self.resolve(target);
         match resolved {
             Type::Int
+            | Type::Long
+            | Type::Short
+            | Type::Byte
+            | Type::Float
             | Type::Double
             | Type::Bool
             | Type::Unit

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -585,6 +585,38 @@ fn bool_scrutinee_match_must_be_exhaustive() {
 }
 
 #[test]
+fn tostring_method_works_on_every_numeric_type() {
+    // The `.toString()` value method was accepted on `Int` and `Double` but
+    // not on `Long`, `Short`, `Byte`, or `Float`, even though the free
+    // `toString(...)` function renders all of them — the method form failed
+    // to type-check. They now match `Int`/`Double`.
+    assert_eq!(
+        evaluate_text("<expr>", "5L.toString()").unwrap(),
+        Value::String("5".to_string())
+    );
+    assert_eq!(
+        evaluate_text("<expr>", "2.5F.toString()").unwrap(),
+        Value::String("2.5".to_string())
+    );
+    assert_eq!(
+        evaluate_text("<expr>", "42.toString()").unwrap(),
+        Value::String("42".to_string())
+    );
+    assert_eq!(
+        evaluate_text("<expr>", "3.5.toString()").unwrap(),
+        Value::String("3.5".to_string())
+    );
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "def render(n: Long): String = n.toString()\nrender(42L)",
+        )
+        .unwrap(),
+        Value::String("42".to_string())
+    );
+}
+
+#[test]
 fn repeated_literal_match_arm_is_unreachable() {
     // A repeated unguarded literal arm can never run — the constructor check
     // already rejected a duplicate `case A`, but a duplicate `case true`,


### PR DESCRIPTION
## Bug

The `.toString()` value method type-checked on `Int` and `Double` but not on `Long`, `Short`, `Byte`, or `Float`:

```kl
5L.toString()    // no method or field `toString` on Long
2.5F.toString()  // no method or field `toString` on Float
```

The free `toString(5L)` renders them fine, and the evaluator's method dispatch (`value_method_builtin_name`) already routes `Long`/`Float` values — only the type checker's `builtin_value_method_type` left them out of the `toString` arm.

## Fix

Add `Long`, `Short`, `Byte`, and `Float` to the scalar `toString` arm so the method form is consistent across all numeric types (mirrors the existing `Int`/`Double` handling).

## Verification

`5L.toString()` → `"5"`, `2.5F.toString()` → `"2.5"`, and a `Long`-parameter function returning `n.toString()` all type-check and evaluate; `klassic build` produces the same output (eval==native).

## Gate

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)