### PR TITLE
fix: allow the .toString() method on List, Map, and Set

### DIFF
--- a/crates/klassic-eval/src/builtin_registry.rs
+++ b/crates/klassic-eval/src/builtin_registry.rs
@@ -195,6 +195,7 @@ pub(crate) fn value_method_builtin_name(value: &Value, field: &str) -> Option<&'
             _ => None,
         },
         Value::List(_) => match field {
+            "toString" => Some("toString"),
             "head" => Some("head"),
             "tail" => Some("tail"),
             "size" => Some("size"),
@@ -206,6 +207,7 @@ pub(crate) fn value_method_builtin_name(value: &Value, field: &str) -> Option<&'
             _ => None,
         },
         Value::Map(_) => match field {
+            "toString" => Some("toString"),
             "containsKey" => Some("Map#containsKey"),
             "containsValue" => Some("Map#containsValue"),
             "get" => Some("Map#get"),
@@ -219,6 +221,7 @@ pub(crate) fn value_method_builtin_name(value: &Value, field: &str) -> Option<&'
             _ => None,
         },
         Value::Set(_) => match field {
+            "toString" => Some("toString"),
             "contains" => Some("Set#contains"),
             "isEmpty" => Some("Set#isEmpty"),
             "size" => Some("Set#size"),

--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -4885,6 +4885,7 @@ impl TypeChecker {
                 _ => None,
             },
             Type::List(inner) => match field {
+                "toString" => Some(Type::Function(vec![], Box::new(Type::String))),
                 "head" => Some(Type::Function(vec![], inner.clone())),
                 "tail" => Some(Type::Function(vec![], Box::new(Type::List(inner.clone())))),
                 "size" => Some(Type::Function(vec![], Box::new(Type::Int))),
@@ -4932,6 +4933,7 @@ impl TypeChecker {
                 _ => None,
             },
             Type::Map(key, value) => match field {
+                "toString" => Some(Type::Function(vec![], Box::new(Type::String))),
                 // `m.containsKey(k)` / `m.containsValue(v)` / `m.get(k)` take the
                 // map's declared key/value type rather than `Dynamic`, matching
                 // `getOrElse`/`put`/`remove` below: a wrong-typed lookup such as
@@ -4971,6 +4973,7 @@ impl TypeChecker {
                 _ => None,
             },
             Type::Set(inner) => match field {
+                "toString" => Some(Type::Function(vec![], Box::new(Type::String))),
                 // `s.contains(x)` requires `x` to be the element type, matching
                 // `add`/`remove` below: a cross-type membership test such as
                 // `%(1 2 3).contains("s")` is rejected instead of typed `Dynamic`.

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -617,6 +617,34 @@ fn tostring_method_works_on_every_numeric_type() {
 }
 
 #[test]
+fn tostring_method_works_on_collections() {
+    // `.toString()` rendered scalars, records, and enums but not `List` /
+    // `Map` / `Set`, even though the free `toString(...)` does. They now
+    // match the free function (and the direct native backend renders them
+    // identically through its existing method dispatch).
+    assert_eq!(
+        evaluate_text("<expr>", "[1 2 3].toString()").unwrap(),
+        Value::String("[1, 2, 3]".to_string())
+    );
+    assert_eq!(
+        evaluate_text("<expr>", "%[\"a\":1 \"b\":2].toString()").unwrap(),
+        Value::String("%[a: 1, b: 2]".to_string())
+    );
+    assert_eq!(
+        evaluate_text("<expr>", "%(1 2 3).toString()").unwrap(),
+        Value::String("%(1, 2, 3)".to_string())
+    );
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "def render(xs: List<Int>): String = xs.toString()\nrender([5 6 7])",
+        )
+        .unwrap(),
+        Value::String("[5, 6, 7]".to_string())
+    );
+}
+
+#[test]
 fn repeated_literal_match_arm_is_unreachable() {
     // A repeated unguarded literal arm can never run — the constructor check
     // already rejected a duplicate `case A`, but a duplicate `case true`,


### PR DESCRIPTION
## Bug

`.toString()` worked as a value method on scalars, records, and enums, but not on collections:

```kl
[1 2 3].toString()       // no method or field `toString` on List<Int>
%["a":1].toString()      // no method or field `toString` on Map<String, Int>
%(1 2).toString()        // no method or field `toString` on Set<Int>
```

The free `toString([1 2 3])` renders them, and interpolation works — only the value-method form was missing.

## Fix

Add `toString` to the `List` / `Map` / `Set` arms of the type checker's `builtin_value_method_type` and the evaluator's `value_method_builtin_name`. The native backend's method dispatch already maps `toString` generically, so it routes and renders these identically — no native change needed.

## Verification

`[1 2 3].toString()` → `[1, 2, 3]`, `%["a":1 "b":2].toString()` → `%[a: 1, b: 2]`, `%(1 2 3).toString()` → `%(1, 2, 3)`, all identical between the evaluator and `klassic build`. Completes `.toString()` consistency across every value type (together with #528 for the numeric types).

## Gate

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)