### PR TITLE
fix: record constructors in space-separated list literals

### DIFF
--- a/crates/klassic-syntax/src/lib.rs
+++ b/crates/klassic-syntax/src/lib.rs
@@ -1083,11 +1083,22 @@ impl<'a> Lexer<'a> {
 struct Parser {
     tokens: Vec<Token>,
     index: usize,
+    /// Names of records declared so far. A `#Name` that resolves to a
+    /// declared record is a record constructor, never the infix-`#`
+    /// operator (`a #f b` == `f(a, b)`), so `[#P(1, 2) #P(3, 4)]` parses as
+    /// two space-separated elements instead of `P(#P(1, 2), ...)`. Records
+    /// must be declared before use (forward references already fail), so
+    /// the set is complete by the time a `#Name` is reached.
+    record_names: std::collections::HashSet<String>,
 }
 
 impl Parser {
     fn new(tokens: Vec<Token>) -> Self {
-        Self { tokens, index: 0 }
+        Self {
+            tokens,
+            index: 0,
+            record_names: std::collections::HashSet::new(),
+        }
     }
 
     fn parse_program(mut self) -> Result<Expr, Diagnostic> {
@@ -1181,6 +1192,7 @@ impl Parser {
     fn parse_record_declaration(&mut self) -> Result<Expr, Diagnostic> {
         let start = self.bump().span;
         let (name, name_span) = self.expect_identifier()?;
+        self.record_names.insert(name.clone());
         let (type_params, inline_constraints) = self.parse_optional_generic_param_names()?;
         if let Some(c) = inline_constraints.first() {
             return Err(Diagnostic::parse(
@@ -2537,10 +2549,9 @@ impl Parser {
             }
 
             if matches!(self.peek().kind, TokenKind::Hash)
-                && matches!(
-                    self.tokens.get(self.index + 1).map(|token| &token.kind),
-                    Some(TokenKind::Identifier(_))
-                )
+                && let Some(TokenKind::Identifier(infix_name)) =
+                    self.tokens.get(self.index + 1).map(|token| &token.kind)
+                && !self.record_names.contains(infix_name)
             {
                 let hash_span = self.bump().span;
                 let (name, name_span) = self.expect_identifier()?;

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -617,6 +617,48 @@ fn tostring_method_works_on_every_numeric_type() {
 }
 
 #[test]
+fn space_separated_list_accepts_record_constructors() {
+    // A space-separated collection literal of record constructors used to
+    // fail: the second `#P(...)` was swallowed by the infix-`#` operator
+    // (`a #f b` == `f(a, b)`), so `[#P(1, 2) #P(3, 4)]` parsed as
+    // `P(#P(1, 2), ...)` and errored. Comma / newline separators worked.
+    // Enum constructors and plain calls in space-separated lists always
+    // worked; record constructors now match.
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "record P { x: Int; y: Int }\n[#P(1, 2) #P(3, 4)].size()",
+        )
+        .unwrap(),
+        Value::Int(2)
+    );
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "record P { x: Int; y: Int }\nval xs = [#P(1, 2) #P(3, 4)]\nhead(xs).x + head(xs).y",
+        )
+        .unwrap(),
+        Value::Int(3)
+    );
+    // Single-field record constructors too (the trickier case, where the
+    // infix interpretation was syntactically valid).
+    assert_eq!(
+        evaluate_text("<expr>", "record Q { v: Int }\n[#Q(1) #Q(2) #Q(3)].size()",).unwrap(),
+        Value::Int(3)
+    );
+
+    // The infix-`#` operator on functions is unchanged.
+    assert_eq!(
+        evaluate_text("<expr>", "def add(a: Int, b: Int): Int = a + b\n3 #add 4",).unwrap(),
+        Value::Int(7)
+    );
+    assert_eq!(
+        evaluate_text("<expr>", "def add(a: Int, b: Int): Int = a + b\n3 #add(4)",).unwrap(),
+        Value::Int(7)
+    );
+}
+
+#[test]
 fn tostring_method_works_on_collections() {
     // `.toString()` rendered scalars, records, and enums but not `List` /
     // `Map` / `Set`, even though the free `toString(...)` does. They now


### PR DESCRIPTION
## Bug

`[#P(1, 2) #P(3, 4)]` (a space-separated list of record constructors) failed to parse:

```kl
record P { x: Int; y: Int }
[#P(1, 2) #P(3, 4)]   // "expected `)`"
[#Q(1) #Q(2)]         // "undefined variable `Q`"
```

After the first `#P(...)`, the infix-`#` operator (`a #f b` == `f(a, b)`) greedily consumed the next `#P(...)`, parsing it as `P(#P(1, 2), ...)`. Comma and newline separators worked (`[#P(1, 2), #P(3, 4)]`), and enum constructors / plain calls in space-separated lists always did — only record constructors hit the `#`-prefix (constructor) vs `#`-infix (operator) ambiguity. Spaces are lexed away, so the list parser couldn't tell the boundary.

## Fix

Track the names of records declared so far in the parser. A `#Name` that resolves to a declared record is a constructor, never the infix operator — so the postfix loop stops and the list parser reads the next element. Records must be declared before use (forward references already fail at evaluation), so the set is complete by the time a `#Name` is reached. The infix-`#` operator on functions (`3 #add 4`, `3 #add(4)`, `y #cons x`) is unchanged.

## Tests (test-first)

`space_separated_list_accepts_record_constructors`: multi-field and single-field record constructors in a space-separated list (the failing cases), plus regression coverage that `3 #add 4` / `3 #add(4)` still apply the infix operator. Verified eval==native (`[#P(1, 2), #P(3, 4)]`), and `test-programs/functions.kl` (which uses `#cons`) still passes.

## Gate

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)