### PR TITLE
fix: inner bindings shadow an outer static value in native

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -39471,10 +39471,25 @@ impl NativeCodeGenerator {
     }
 
     fn lookup_static_value(&self, name: &str) -> Option<StaticValue> {
-        self.static_scopes
-            .iter()
-            .rev()
-            .find_map(|scope| scope.get(name).cloned())
+        // The innermost binding wins. A runtime slot allocated for `name` in
+        // an inner scope (a `match` payload binding, a `foreach` variable, an
+        // inner-block `val`) shadows any outer static value, so stop at that
+        // scope and let the caller read the runtime slot instead of folding
+        // the outer constant. `scopes` and `static_scopes` are pushed and
+        // popped together, so they share indices.
+        for index in (0..self.static_scopes.len()).rev() {
+            if let Some(value) = self.static_scopes[index].get(name) {
+                return Some(value.clone());
+            }
+            if self
+                .scopes
+                .get(index)
+                .is_some_and(|scope| scope.contains_key(name))
+            {
+                return None;
+            }
+        }
+        None
     }
 
     fn lookup_var(&self, name: &str) -> Option<VarSlot> {

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -1513,6 +1513,67 @@ fn native_assert_result_compares_enums_structurally() {
     );
 }
 
+/// A `match` payload binding and a `foreach` variable that reuse the name
+/// of an outer `val` must shadow it. The outer `val` is tracked as a
+/// static constant; the inner runtime binding used to leak that constant
+/// into folded uses (`x + 1` read the outer value while bare `x` read the
+/// binding), so `case A(x) => x + 1` and `foreach (x in …)` miscompiled.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_inner_binding_shadows_outer_static_value() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time should be monotonic")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic-shadow-{unique}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic-shadow-{unique}"));
+    let program = "enum E { case A(v: Int) }\n\
+         val x = 100\n\
+         println(A(7) match { case A(x) => x + 1 })\n\
+         println(A(7) match { case A(x) => x * 2 })\n\
+         mutable s = 0\n\
+         foreach (x in [10 20 30]) { s = s + x }\n\
+         println(s)\n\
+         println(x)\n";
+    fs::write(&source_path, program).expect("source should write");
+    // The evaluator is the oracle: matched `x` is 7, the foreach `x` is the
+    // element, and the outer `x` is still 100 after the loop.
+    let expected = "8\n14\n60\n100\n";
+
+    let eval = Command::new(klassic_bin())
+        .arg(&source_path)
+        .output()
+        .expect("evaluator should run");
+    assert!(eval.status.success());
+    assert_eq!(String::from_utf8_lossy(&eval.stdout), expected);
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_string_lossy().as_ref(),
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("build should run");
+    assert!(
+        build.status.success(),
+        "native build should compile, got:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("native binary should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+    assert!(run.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        expected,
+        "an inner binding must shadow the outer static value"
+    );
+}
+
 /// Syntax errors for the parenthesization Klassic requires (and the
 /// `field: value` record syntax) carry a keyword-specific hint instead
 /// of the bare `expected (`, so users coming from Kotlin/Scala/Rust see


### PR DESCRIPTION
## Bug (silent miscompile)

A `match` payload binding or a `foreach` variable that reuses the name of an outer `val` was silently miscompiled in native builds:

```kl
enum E { case A(v: Int) }
val x = 100
A(7) match { case A(x) => x }       // 7   (correct)
A(7) match { case A(x) => x + 1 }   // 101 (WRONG, eval = 8 — used outer x=100)

val x = 99
foreach (x in [10 20 30]) { s = s + x }   // s = 297 (WRONG, eval = 60 — summed outer x)
```

Bare `x` read the binding, but `x` inside a foldable expression read the outer value. The outer `val` is tracked as a static constant, and `lookup_static_value` walked only the static-value scopes — so it returned the outer constant even when an inner scope held a runtime slot for the same name, and the arm/loop body folded that constant.

## Fix

Make `lookup_static_value` honor the **innermost** binding: walk scopes inner-first and stop at a runtime slot for the name (returning `None`, so the caller reads the slot) before reaching an outer static value. `scopes` and `static_scopes` are pushed/popped together, so they share indices. When a scope holds *both* a runtime slot and a static value for the name (e.g. a `foreach` over a static int list), the static value still wins, so ordinary constant folding is unchanged.

## Verification

`match`/`foreach` shadowing across scalar, string, two-binding, nested-loop, and runtime-list cases now match the evaluator; block-`val` / lambda-parameter shadowing and plain constant folding are unaffected. New native-build regression test `native_inner_binding_shadows_outer_static_value`. `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` all green.

(A related case — a closure capturing an inner-block `val` that shadows an outer `val` — goes through a separate capture-flattening path and is addressed separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)