### PR TITLE
feat: direct PE64 backend for x86_64-pc-windows-msvc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,24 @@ jobs:
 
       - name: Test
         run: cargo test
+
+  # Windows x86_64 job. This is the execution runner for the direct
+  # x86_64-pc-windows-msvc PE64 backend: the build-and-run tests
+  # are cfg-gated to Windows, so the generated machine code is
+  # crash-checked here on every push.
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build runtime staticlib
+        # cargo test alone doesn't produce libklassic_runtime.a, which
+        # the C-backend link tests resolve next to the klassic binary.
+        run: cargo build -p klassic-runtime
+
+      - name: Test
+        run: cargo test

--- a/crates/klassic-eval/src/lib.rs
+++ b/crates/klassic-eval/src/lib.rs
@@ -3962,6 +3962,13 @@ mod tests {
         );
     }
 
+    /// Renders a host path as the body of a Klassic string literal.
+    /// Windows separators must be doubled or `C:\Users\...` lexes as
+    /// an unsupported `\U` escape sequence.
+    fn kl_path(path: &std::path::Path) -> String {
+        path.display().to_string().replace('\\', "\\\\")
+    }
+
     #[test]
     fn evaluates_file_and_dir_modules() {
         let unique = SystemTime::now()
@@ -3977,14 +3984,14 @@ mod tests {
             "<expr>",
             &format!(
                 "Dir#mkdir(\"{}\")\nFileOutput#write(\"{}\", \"hello\")",
-                dir.display(),
-                file.display()
+                kl_path(&dir),
+                kl_path(&file)
             ),
         )
         .unwrap();
 
         assert_eq!(
-            evaluate_text("<expr>", &format!("FileInput#all(\"{}\")", file.display())).unwrap(),
+            evaluate_text("<expr>", &format!("FileInput#all(\"{}\")", kl_path(&file))).unwrap(),
             Value::String("hello".to_string())
         );
         assert_eq!(
@@ -3992,18 +3999,18 @@ mod tests {
                 "<expr>",
                 &format!(
                     "\"{}\" FileInput#open {{ stream => FileInput#readAll(stream) }}",
-                    file.display()
+                    kl_path(&file)
                 ),
             )
             .unwrap(),
             Value::String("hello".to_string())
         );
         assert_eq!(
-            evaluate_text("<expr>", &format!("Dir#isFile(\"{}\")", file.display())).unwrap(),
+            evaluate_text("<expr>", &format!("Dir#isFile(\"{}\")", kl_path(&file))).unwrap(),
             Value::Bool(true)
         );
         let listed =
-            evaluate_text("<expr>", &format!("Dir#listFull(\"{}\")", dir.display())).unwrap();
+            evaluate_text("<expr>", &format!("Dir#listFull(\"{}\")", kl_path(&dir))).unwrap();
         let Value::List(listed) = listed else {
             panic!("Dir#listFull should return a list");
         };
@@ -4015,7 +4022,7 @@ mod tests {
         assert_eq!(
             evaluate_text(
                 "<expr>",
-                &format!("Dir#copy(\"{}\", \"{}\")", file.display(), moved.display())
+                &format!("Dir#copy(\"{}\", \"{}\")", kl_path(&file), kl_path(&moved))
             )
             .unwrap(),
             Value::Unit
@@ -4023,7 +4030,7 @@ mod tests {
         assert_eq!(
             evaluate_text(
                 "<expr>",
-                &format!("FileOutput#exists(\"{}\")", moved.display())
+                &format!("FileOutput#exists(\"{}\")", kl_path(&moved))
             )
             .unwrap(),
             Value::Bool(true)
@@ -4032,12 +4039,12 @@ mod tests {
         assert_eq!(
             evaluate_text(
                 "<expr>",
-                &format!("Dir#delete(\"{}\")", empty_child.display())
+                &format!("Dir#delete(\"{}\")", kl_path(&empty_child))
             )
             .unwrap(),
             Value::Unit
         );
-        assert!(evaluate_text("<expr>", &format!("Dir#delete(\"{}\")", dir.display())).is_err());
+        assert!(evaluate_text("<expr>", &format!("Dir#delete(\"{}\")", kl_path(&dir))).is_err());
 
         let _ = fs::remove_file(&file);
         let _ = fs::remove_file(&moved);
@@ -4056,8 +4063,8 @@ mod tests {
             "<expr>",
             &format!(
                 "FileOutput#write(\"{}\", \"Line 1\")\nFileOutput#append(\"{}\", \"\\nLine 2\")",
-                file.display(),
-                file.display()
+                kl_path(&file),
+                kl_path(&file)
             ),
         )
         .unwrap();
@@ -4065,13 +4072,13 @@ mod tests {
         assert_eq!(
             evaluate_text(
                 "<expr>",
-                &format!("FileOutput#exists(\"{}\")", file.display())
+                &format!("FileOutput#exists(\"{}\")", kl_path(&file))
             )
             .unwrap(),
             Value::Bool(true)
         );
         assert_eq!(
-            evaluate_text("<expr>", &format!("FileInput#all(\"{}\")", file.display())).unwrap(),
+            evaluate_text("<expr>", &format!("FileInput#all(\"{}\")", kl_path(&file))).unwrap(),
             Value::String("Line 1\nLine 2".to_string())
         );
 
@@ -4092,7 +4099,7 @@ mod tests {
                 "<expr>",
                 &format!(
                     "\"{}\" FileInput#open {{ stream => FileInput#readAll(stream) }}",
-                    file.display()
+                    kl_path(&file)
                 ),
             )
             .unwrap(),
@@ -4103,7 +4110,7 @@ mod tests {
                 "<expr>",
                 &format!(
                     "\"{}\" FileInput#open {{ stream => FileInput#readLines(stream) }}",
-                    file.display()
+                    kl_path(&file)
                 ),
             )
             .unwrap(),

--- a/crates/klassic-eval/src/lib.rs
+++ b/crates/klassic-eval/src/lib.rs
@@ -3326,6 +3326,8 @@ fn eval_builtin(name: &str, arguments: &[Value], span: Span) -> Result<Value, Di
                 Diagnostic::runtime(span, format!("failed to get current dir: {error}"))
             }),
         "Dir#home" => env::var("HOME")
+            // Windows has no HOME by default; USERPROFILE is the equivalent.
+            .or_else(|_| env::var("USERPROFILE"))
             .map(Value::String)
             .map_err(|error| Diagnostic::runtime(span, format!("failed to get home dir: {error}"))),
         "Dir#temp" => Ok(Value::String(env::temp_dir().display().to_string())),

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -4923,6 +4923,26 @@ impl NativeCodeGenerator {
             .mov_imm64(Reg::Rax, self.platform.syscall_number(syscall));
     }
 
+    /// Diagnostic for a builtin whose native codegen needs a raw
+    /// syscall (or a startup-populated slot the current target
+    /// leaves zeroed, e.g. argv/envp on Windows) that isn't wired up
+    /// for `self.platform.target` yet. Every call site guards this
+    /// with an `is_windows` (or other per-target) check itself --
+    /// this only builds the message, naming the concrete target
+    /// triple so it stays accurate as more targets gain coverage.
+    /// This is the compile-time counterpart to the
+    /// `TargetPlatform::syscall_number` panic tripwire: a builtin
+    /// gated here never reaches that panic.
+    fn unsupported_on_target(&self, span: Span, name: &str) -> Diagnostic {
+        Diagnostic::compile(
+            span,
+            format!(
+                "`{name}` is not yet supported when targeting {}",
+                self.platform.target.standard_triple()
+            ),
+        )
+    }
+
     fn emit_store_command_line_state(&mut self) {
         if self.is_windows {
             // No CRT means no argc/argv/envp setup at this raw an
@@ -12322,6 +12342,9 @@ impl NativeCodeGenerator {
     }
 
     fn compile_sleep(&mut self, arguments: &[Expr], span: Span) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "sleep"));
+        }
         if arguments.len() != 1 {
             return Err(Diagnostic::compile(
                 span,
@@ -17281,6 +17304,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "stopwatch"));
+        }
         if arguments.len() != 1 {
             return Err(Diagnostic::compile(
                 span,
@@ -17351,6 +17377,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "Time#nowMillis"));
+        }
         if !arguments.is_empty() {
             return Err(Diagnostic::compile(
                 span,
@@ -23112,6 +23141,9 @@ impl NativeCodeGenerator {
         } else {
             "FileOutput#write"
         };
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, name));
+        }
         self.expect_static_arity(name, arguments, 2, span)?;
         if self.expr_may_yield_runtime_string(&arguments[0]) {
             let path_label = self.compile_runtime_path_argument(&arguments[0], span, name)?;
@@ -23178,6 +23210,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "FileOutput#writeLines"));
+        }
         self.expect_static_arity("FileOutput#writeLines", arguments, 2, span)?;
         if self.expr_may_yield_runtime_string(&arguments[0]) {
             let path_label =
@@ -23247,6 +23282,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "FileOutput#exists"));
+        }
         self.expect_static_arity("FileOutput#exists", arguments, 1, span)?;
         if self.expr_may_yield_runtime_string(&arguments[0]) {
             let path_label =
@@ -23274,6 +23312,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "FileOutput#delete"));
+        }
         self.expect_static_arity("FileOutput#delete", arguments, 1, span)?;
         if self.expr_may_yield_runtime_string(&arguments[0]) {
             let path_label =
@@ -23297,6 +23338,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "StandardInput#all"));
+        }
         self.expect_static_arity("StandardInput#all", arguments, 0, span)?;
         Ok(self.emit_standard_input_to_runtime_string(span, "StandardInput#all"))
     }
@@ -23306,6 +23350,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "StandardInput#lines"));
+        }
         self.expect_static_arity("StandardInput#lines", arguments, 0, span)?;
         let NativeValue::RuntimeString { data, len } =
             self.emit_standard_input_to_runtime_string(span, "StandardInput#lines")
@@ -23352,6 +23399,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "Environment#vars"));
+        }
         self.expect_static_arity("Environment#vars", arguments, 0, span)?;
         Ok(self.emit_environment_vars(span))
     }
@@ -23410,6 +23460,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "Environment#get"));
+        }
         self.expect_static_arity("Environment#get", arguments, 1, span)?;
         let key = self.compile_environment_key_argument(&arguments[0], span, "Environment#get")?;
         Ok(self.emit_environment_get_key_ref(
@@ -23424,6 +23477,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "Environment#exists"));
+        }
         self.expect_static_arity("Environment#exists", arguments, 1, span)?;
         let key =
             self.compile_environment_key_argument(&arguments[0], span, "Environment#exists")?;
@@ -23744,6 +23800,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "CommandLine#args"));
+        }
         self.expect_static_arity("CommandLine#args", arguments, 0, span)?;
         Ok(self.emit_command_line_args(span))
     }
@@ -23997,6 +24056,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "FileInput#all"));
+        }
         self.expect_static_arity("FileInput#all", arguments, 1, span)?;
         if self.expr_may_yield_runtime_string(&arguments[0]) {
             let path_label =
@@ -24029,6 +24091,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "FileInput#lines"));
+        }
         self.expect_static_arity("FileInput#lines", arguments, 1, span)?;
         if self.expr_may_yield_runtime_string(&arguments[0]) {
             let path_label =
@@ -24449,6 +24514,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "Dir#current"));
+        }
         self.expect_static_arity("Dir#current", arguments, 0, span)?;
         Ok(self.emit_dir_current(span))
     }
@@ -24478,6 +24546,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "Dir#home"));
+        }
         self.expect_static_arity("Dir#home", arguments, 0, span)?;
         Ok(self.emit_environment_get_static_key(
             "HOME",
@@ -24491,6 +24562,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "Dir#temp"));
+        }
         self.expect_static_arity("Dir#temp", arguments, 0, span)?;
         Ok(self.emit_environment_get_static_key_or_default("TMPDIR", "/tmp", span))
     }
@@ -24500,6 +24574,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "Dir#exists"));
+        }
         self.expect_static_arity("Dir#exists", arguments, 1, span)?;
         if self.expr_may_yield_runtime_string(&arguments[0]) {
             let path_label =
@@ -24523,6 +24600,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "Dir#isDirectory"));
+        }
         self.expect_static_arity("Dir#isDirectory", arguments, 1, span)?;
         if self.expr_may_yield_runtime_string(&arguments[0]) {
             let path_label =
@@ -24549,6 +24629,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "Dir#isFile"));
+        }
         self.expect_static_arity("Dir#isFile", arguments, 1, span)?;
         if self.expr_may_yield_runtime_string(&arguments[0]) {
             let path_label =
@@ -24574,6 +24657,9 @@ impl NativeCodeGenerator {
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
         let name = if recursive { "Dir#mkdirs" } else { "Dir#mkdir" };
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, name));
+        }
         self.expect_static_arity(name, arguments, 1, span)?;
         if self.expr_may_yield_runtime_string(&arguments[0]) {
             let path_label = self.compile_runtime_path_argument(&arguments[0], span, name)?;
@@ -24606,6 +24692,9 @@ impl NativeCodeGenerator {
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
         let name = if full { "Dir#listFull" } else { "Dir#list" };
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, name));
+        }
         self.expect_static_arity(name, arguments, 1, span)?;
         if self.expr_may_yield_runtime_string(&arguments[0]) {
             let (path_label, path) =
@@ -24667,6 +24756,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "Dir#delete"));
+        }
         self.expect_static_arity("Dir#delete", arguments, 1, span)?;
         if self.expr_may_yield_runtime_string(&arguments[0]) {
             let path_label =
@@ -24687,6 +24779,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "Dir#copy"));
+        }
         self.expect_static_arity("Dir#copy", arguments, 2, span)?;
         if self.expr_may_yield_runtime_string(&arguments[0])
             || self.expr_may_yield_runtime_string(&arguments[1])
@@ -24723,6 +24818,9 @@ impl NativeCodeGenerator {
         arguments: &[Expr],
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
+        if self.is_windows {
+            return Err(self.unsupported_on_target(span, "Dir#move"));
+        }
         self.expect_static_arity("Dir#move", arguments, 2, span)?;
         if self.expr_may_yield_runtime_string(&arguments[0])
             || self.expr_may_yield_runtime_string(&arguments[1])
@@ -33640,7 +33738,17 @@ impl NativeCodeGenerator {
             return Ok(());
         }
 
-        if let Some(name) = self.file_input_all_print_call_name(expr) {
+        // Windows has no Win64 shim for the read side of this
+        // fast-streaming path (it always reaches the raw `Open`/
+        // `Read`/`Close` syscalls below, even for a compile-time
+        // constant path), so this optimization is skipped on that
+        // target: falling through lets `self.compile_expr(expr)`
+        // dispatch to the ordinary `FileInput#all`/`readAll` builtin,
+        // which raises `unsupported_on_target` instead of the
+        // syscall-number tripwire.
+        if !self.is_windows
+            && let Some(name) = self.file_input_all_print_call_name(expr)
+        {
             let Expr::Call { arguments, .. } = expr else {
                 unreachable!("file input print call matched only call expressions");
             };
@@ -33659,7 +33767,12 @@ impl NativeCodeGenerator {
             return Ok(());
         }
 
-        if let Some(name) = self.file_input_lines_print_call_name(expr) {
+        // Same reasoning as the `file_input_all_print_call_name` guard
+        // above: skip the fast path on Windows so the plain
+        // `FileInput#lines`/`readLines` builtin gate fires instead.
+        if !self.is_windows
+            && let Some(name) = self.file_input_lines_print_call_name(expr)
+        {
             let Expr::Call { arguments, .. } = expr else {
                 unreachable!("file input lines print call matched only call expressions");
             };
@@ -33676,7 +33789,13 @@ impl NativeCodeGenerator {
             }
         }
 
-        if let Some((path, name)) = self.file_input_open_read_lines_print_call(expr)
+        // Same reasoning again: this path reaches
+        // `emit_file_read_to_runtime_string_from_path_label` directly,
+        // bypassing `compile_file_input_lines`'s gate, so it is
+        // skipped on Windows and falls through to the ordinary
+        // `FileInput#open` compile path instead.
+        if !self.is_windows
+            && let Some((path, name)) = self.file_input_open_read_lines_print_call(expr)
             && self.expr_may_yield_runtime_string(path)
         {
             let path_label = self.compile_runtime_path_argument(path, span, "FileInput#open")?;

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -24,6 +24,7 @@ pub enum NativeTarget {
     #[default]
     LinuxX86_64,
     MacosAarch64,
+    WindowsX86_64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -53,12 +54,14 @@ pub struct NativeDataLayout {
 pub enum NativeOperatingSystem {
     Linux,
     MacOs,
+    Windows,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NativeAbi {
     Gnu,
     Apple,
+    Msvc,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -83,6 +86,7 @@ const X86_64_DATA_LAYOUT: NativeDataLayout = NativeDataLayout {
 const AARCH64_DATA_LAYOUT: NativeDataLayout = X86_64_DATA_LAYOUT;
 
 const MACOS_AARCH64_ALIASES: &[&str] = &["macos-aarch64", "aarch64-apple-darwin"];
+const WINDOWS_X86_64_ALIASES: &[&str] = &["windows-x86_64", "x86_64-pc-windows-msvc"];
 
 const NATIVE_TARGET_SPECS: &[NativeTargetSpec] = &[
     NativeTargetSpec {
@@ -108,6 +112,24 @@ const NATIVE_TARGET_SPECS: &[NativeTargetSpec] = &[
         operating_system: NativeOperatingSystem::MacOs,
         abi: NativeAbi::Apple,
         executable_format: NativeExecutableFormat::MachO64,
+    },
+    // Reuses the entire DirectX86_64 (Linux) codegen: the generated
+    // machine code is identical Win64-compatible x86_64 instructions,
+    // this target only swaps the OS boundary (syscalls -> kernel32
+    // imports via Win64 shims, see `emit_syscall_number`'s Windows
+    // tripwire) and the container format (PE64 instead of ELF64, see
+    // `pe.rs`).
+    NativeTargetSpec {
+        target: NativeTarget::WindowsX86_64,
+        canonical_name: "windows-x86_64",
+        standard_triple: "x86_64-pc-windows-msvc",
+        aliases: WINDOWS_X86_64_ALIASES,
+        architecture: NativeArchitecture::X86_64,
+        backend: NativeBackend::DirectX86_64,
+        data_layout: X86_64_DATA_LAYOUT,
+        operating_system: NativeOperatingSystem::Windows,
+        abi: NativeAbi::Msvc,
+        executable_format: NativeExecutableFormat::Pe64,
     },
 ];
 
@@ -154,13 +176,6 @@ const PLANNED_TARGETS: &[PlannedTarget] = &[
         artifact: "executable",
         tier: 2,
     },
-    PlannedTarget {
-        triple: "x86_64-pc-windows-msvc",
-        aliases: &["windows-x86_64"],
-        backend: "portable-c",
-        artifact: "executable",
-        tier: 2,
-    },
 ];
 
 /// Result of recognising a `--target` argument. Distinguishing
@@ -179,6 +194,8 @@ impl NativeTarget {
         "x86_64-unknown-linux-gnu",
         "macos-aarch64",
         "aarch64-apple-darwin",
+        "windows-x86_64",
+        "x86_64-pc-windows-msvc",
         "native",
     ];
 
@@ -334,6 +351,7 @@ impl NativeTarget {
 pub enum NativeExecutableFormat {
     Elf64,
     MachO64,
+    Pe64,
 }
 
 impl NativeArchitecture {
@@ -453,6 +471,7 @@ mod cbackend;
 #[allow(clippy::result_large_err)]
 mod aarch64;
 mod macho;
+mod pe;
 
 /// Compile `text` to a portable C translation unit (`--backend c`).
 /// The supported subset is deliberately small (see `cbackend`);
@@ -3367,10 +3386,14 @@ fn write_executable_for_target(target: NativeTargetContext, object: ObjectFile) 
         NativeExecutableFormat::Elf64 => elf::write_executable(object, target.spec),
         // Mach-O images are laid out and signed by the aarch64 backend
         // itself (`aarch64::emit_macho_program`); the ObjectFile path
-        // is ELF-only.
+        // is ELF-only for Mach-O.
         NativeExecutableFormat::MachO64 => {
             unreachable!("Mach-O executables are written by the aarch64 backend")
         }
+        // PE64 images reuse the DirectX86_64 ObjectFile the same way
+        // ELF does (unlike Mach-O, the Windows target goes through
+        // this generic path since it shares the Linux codegen).
+        NativeExecutableFormat::Pe64 => pe::write_executable(object, target.spec),
     }
 }
 
@@ -3733,10 +3756,53 @@ const LINUX_X86_64_PLATFORM_CONSTANTS: PlatformConstants = PlatformConstants {
     sendfile_chunk_max: 0x7ffff000,
 };
 
-const PLATFORM_CONSTANTS_BY_TARGET: &[PlatformConstantsEntry] = &[PlatformConstantsEntry {
-    target: NativeTarget::LinuxX86_64,
-    constants: &LINUX_X86_64_PLATFORM_CONSTANTS,
-}];
+/// Placeholder constants for the Windows target. `syscall_numbers` and
+/// every Linux-specific flag/mode value here are never legitimately
+/// read: `TargetPlatform::syscall_number` panics unconditionally for a
+/// Windows target (see below) rather than returning one of these Linux
+/// syscall numbers, and every native-codegen call site that reaches a
+/// raw syscall must branch on `is_windows` *before* calling
+/// `emit_syscall_number` -- so any not-yet-Windows-gated syscall path
+/// is a compile-time tripwire instead of a silently wrong binary. Only
+/// the OS-independent bits (`stdin_fd`/`stdout_fd`/`stderr_fd`) carry
+/// real meaning on Windows: the Win64 shims (`__win_write` etc.)
+/// interpret those same small integers to pick a cached
+/// `GetStdHandle` result.
+const WINDOWS_X86_64_PLATFORM_CONSTANTS: PlatformConstants = PlatformConstants {
+    syscall_numbers: [0; PLATFORM_SYSCALL_COUNT],
+    stdin_fd: 0,
+    stdout_fd: 1,
+    stderr_fd: 2,
+    open_read_flags: 0,
+    open_write_truncate_flags: 0,
+    open_write_append_flags: 0,
+    open_directory_flags: 0,
+    default_file_mode: 0,
+    default_dir_mode: 0,
+    at_fdcwd: 0,
+    errno_no_entry: 0,
+    errno_exists: 0,
+    stat_file_type_mask: 0,
+    stat_directory_type: 0,
+    stat_regular_file_type: 0,
+    clock_realtime: 0,
+    clock_monotonic: 0,
+    mmap_prot_read_write: 0,
+    mmap_private_anonymous_flags: 0,
+    mmap_anonymous_fd: 0,
+    sendfile_chunk_max: 0,
+};
+
+const PLATFORM_CONSTANTS_BY_TARGET: &[PlatformConstantsEntry] = &[
+    PlatformConstantsEntry {
+        target: NativeTarget::LinuxX86_64,
+        constants: &LINUX_X86_64_PLATFORM_CONSTANTS,
+    },
+    PlatformConstantsEntry {
+        target: NativeTarget::WindowsX86_64,
+        constants: &WINDOWS_X86_64_PLATFORM_CONSTANTS,
+    },
+];
 
 impl TargetPlatform {
     fn for_target(target: NativeTarget) -> Self {
@@ -3748,7 +3814,21 @@ impl TargetPlatform {
         Self { target, constants }
     }
 
+    /// Linux syscall number for `syscall`. **Deliberate invariant
+    /// tripwire**: panics unconditionally when `self.target` is
+    /// Windows, since Windows has no raw syscall ABI available to
+    /// user code at all -- every codegen call site that can reach a
+    /// raw syscall instruction must check `is_windows` and dispatch
+    /// to a Win64 import-call shim *before* ever calling this method.
+    /// A panic here at compile time means some syscall-emission site
+    /// is missing that gate, which is far better than silently
+    /// emitting a Linux syscall number into a Windows binary.
     fn syscall_number(self, syscall: PlatformSyscall) -> u64 {
+        if self.target.operating_system() == NativeOperatingSystem::Windows {
+            panic!(
+                "internal error: Linux syscall emission reached on x86_64-pc-windows-msvc target (missing Windows gate)"
+            );
+        }
         self.constants.syscall_numbers[syscall as usize]
     }
 
@@ -3877,10 +3957,53 @@ enum PlatformSyscall {
     Getrlimit,
 }
 
+/// Windows-only runtime resources: the four Win64 import-call shims
+/// (each a self-aligning routine emitted once, called via
+/// `Assembler::call_label` from every OS-boundary site) plus the
+/// `.data` slots they use. `None` on every non-Windows target, so
+/// neither the shim bodies nor these `.data` slots are ever allocated
+/// (and therefore never shift a single byte of Linux codegen output).
+#[derive(Clone, Copy, Debug)]
+struct WindowsRuntime {
+    /// Calls `GetStdHandle` for stdout and stderr once at startup and
+    /// caches the two handles; called before any code that could
+    /// print or allocate.
+    win_init: TextLabel,
+    /// `write(fd, buf, len)`-shaped shim: rdi=fd (1 or 2), rsi=buf,
+    /// rdx=len in, rax=bytes written out. Wraps `WriteFile`.
+    win_write: TextLabel,
+    /// `mmap`-shaped shim: rsi=len in (other Linux mmap staging
+    /// registers are ignored), rax=base pointer or -1 out. Wraps
+    /// `VirtualAlloc`, converting its 0-on-failure return to -1 so
+    /// existing `cmp rax,0; jge ok`-style call sites keep working
+    /// unmodified.
+    win_mmap: TextLabel,
+    /// `exit(code)`-shaped shim: rdi=code in, never returns. Wraps
+    /// `ExitProcess`.
+    win_exit: TextLabel,
+    /// Cached `GetStdHandle(STD_OUTPUT_HANDLE)` result, populated by
+    /// `win_init`.
+    stdout_handle: DataLabel,
+    /// Cached `GetStdHandle(STD_ERROR_HANDLE)` result, populated by
+    /// `win_init`.
+    stderr_handle: DataLabel,
+    /// Scratch `DWORD` (stored as a zero-initialized qword so the
+    /// unused high 32 bits stay zero) for `WriteFile`'s required
+    /// `lpNumberOfBytesWritten` out-parameter.
+    write_bytes_scratch: DataLabel,
+}
+
 struct NativeCodeGenerator {
     source: SourceFile,
     user_view: Option<UserSourceView>,
     platform: TargetPlatform,
+    /// True when `platform.target`'s operating system is Windows.
+    /// Cached at construction so OS-boundary call sites can branch
+    /// without re-deriving it from `platform` each time.
+    is_windows: bool,
+    /// Win64 shim labels and `.data` slots, present only when
+    /// `is_windows`. See `WindowsRuntime`.
+    windows: Option<WindowsRuntime>,
     /// Seed cell for `Random#seed` / `Random#nextInt`. Lives in the
     /// data segment as a single u64 initialised to zero — same
     /// observable starting state as the evaluator's `RANDOM_STATE`.
@@ -4111,6 +4234,23 @@ impl NativeCodeGenerator {
         let stack_floor = asm.data_label_with_i64s(&[0]);
         let stack_overflow_abort = asm.create_text_label();
         let stack_overflow_text = asm.data_label_with_bytes(b"klassic: stack overflow\n");
+        let is_windows = platform.target.operating_system() == NativeOperatingSystem::Windows;
+        // Only allocated for the Windows target, so a Linux build's
+        // `.data`/`.text` label sequence -- and therefore its emitted
+        // bytes -- is completely unaffected by this branch.
+        let windows = if is_windows {
+            Some(WindowsRuntime {
+                win_init: asm.create_text_label(),
+                win_write: asm.create_text_label(),
+                win_mmap: asm.create_text_label(),
+                win_exit: asm.create_text_label(),
+                stdout_handle: asm.data_label_with_i64s(&[0]),
+                stderr_handle: asm.data_label_with_i64s(&[0]),
+                write_bytes_scratch: asm.data_label_with_i64s(&[0]),
+            })
+        } else {
+            None
+        };
         let mut record_schemas = HashMap::new();
         record_schemas.insert(
             "Point".to_string(),
@@ -4129,6 +4269,8 @@ impl NativeCodeGenerator {
             source,
             user_view,
             platform,
+            is_windows,
+            windows,
             random_state,
             asm,
             newline,
@@ -4224,6 +4366,14 @@ impl NativeCodeGenerator {
             static_eval_call_depth: 0,
             static_eval_fuel: 0,
         }
+    }
+
+    /// The Windows shim labels/data slots. Only call when
+    /// `self.is_windows` is true (every call site that reaches this
+    /// is itself behind an `is_windows` check).
+    fn windows_runtime(&self) -> WindowsRuntime {
+        self.windows
+            .expect("windows_runtime() called without a Windows target")
     }
 
     /// Call-body evaluations granted to one top-level fold attempt —
@@ -4737,6 +4887,11 @@ impl NativeCodeGenerator {
         self.register_enum_value_aliases(expr);
         self.asm.push_reg(Reg::Rbp);
         self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
+        if self.is_windows {
+            // Must run before anything that can print or allocate:
+            // caches the stdout/stderr handles the write shim needs.
+            self.asm.call_label(self.windows_runtime().win_init);
+        }
         self.emit_store_command_line_state();
         self.emit_initialize_stack_floor();
         self.emit_initialize_gc_heap();
@@ -4754,6 +4909,12 @@ impl NativeCodeGenerator {
         self.emit_gc_unpin_runtime();
         self.emit_gc_grow_heap_runtime();
         self.emit_gc_bounds_error_runtime();
+        if self.is_windows {
+            self.emit_win_init_runtime();
+            self.emit_win_write_runtime();
+            self.emit_win_mmap_runtime();
+            self.emit_win_exit_runtime();
+        }
         Ok(self.asm.finish())
     }
 
@@ -4763,6 +4924,23 @@ impl NativeCodeGenerator {
     }
 
     fn emit_store_command_line_state(&mut self) {
+        if self.is_windows {
+            // No CRT means no argc/argv/envp setup at this raw an
+            // entry point on Windows, and there's no equivalent of
+            // the Linux initial-stack layout `[rbp+8]` reads below
+            // (this is a normal `call`ed function on Windows, not a
+            // kernel-populated initial stack) -- so command-line
+            // access is simply unavailable in this slice.
+            self.asm.mov_imm64(Reg::Rax, 0);
+            self.asm.mov_data_addr(Reg::R10, self.command_line_argc);
+            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
+            self.asm
+                .mov_data_addr(Reg::R10, self.command_line_argv1_base);
+            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
+            self.asm.mov_data_addr(Reg::R10, self.environment_base);
+            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
+            return;
+        }
         self.asm.mov_data_addr(Reg::R10, self.command_line_argc);
         self.asm.load_ptr_disp32(Reg::R8, Reg::Rbp, 8);
         self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R8);
@@ -12695,15 +12873,27 @@ impl NativeCodeGenerator {
         self.asm.add_reg_imm32(Reg::Rsi, 8);
         self.asm.load_ptr_disp32(Reg::Rdx, Reg::Rax, 0);
         self.emit_gc_string_length_check(span, "__gc_string_println", Reg::Rdx);
-        self.emit_syscall_number(PlatformSyscall::Write);
+        if !self.is_windows {
+            self.emit_syscall_number(PlatformSyscall::Write);
+        }
         self.asm.mov_imm64(Reg::Rdi, self.platform.stdout_fd());
-        self.asm.syscall();
+        if self.is_windows {
+            self.asm.call_label(self.windows_runtime().win_write);
+        } else {
+            self.asm.syscall();
+        }
         // newline
-        self.emit_syscall_number(PlatformSyscall::Write);
+        if !self.is_windows {
+            self.emit_syscall_number(PlatformSyscall::Write);
+        }
         self.asm.mov_imm64(Reg::Rdi, self.platform.stdout_fd());
         self.asm.mov_data_addr(Reg::Rsi, self.newline);
         self.asm.mov_imm64(Reg::Rdx, 1);
-        self.asm.syscall();
+        if self.is_windows {
+            self.asm.call_label(self.windows_runtime().win_write);
+        } else {
+            self.asm.syscall();
+        }
         Ok(NativeValue::Unit)
     }
 
@@ -23633,9 +23823,15 @@ impl NativeCodeGenerator {
                 self.emit_runtime_error(span, "Process#exit expects a non-negative integer index");
                 return Ok(NativeValue::Unit);
             }
-            self.emit_syscall_number(PlatformSyscall::Exit);
+            if !self.is_windows {
+                self.emit_syscall_number(PlatformSyscall::Exit);
+            }
             self.asm.mov_imm64(Reg::Rdi, code as u64);
-            self.asm.syscall();
+            if self.is_windows {
+                self.asm.call_label(self.windows_runtime().win_exit);
+            } else {
+                self.asm.syscall();
+            }
             return Ok(NativeValue::Unit);
         }
 
@@ -23649,8 +23845,14 @@ impl NativeCodeGenerator {
         self.emit_runtime_error(span, "Process#exit expects a non-negative integer index");
         self.asm.bind_text_label(ok);
         self.asm.mov_reg_reg(Reg::Rdi, Reg::Rax);
-        self.emit_syscall_number(PlatformSyscall::Exit);
-        self.asm.syscall();
+        if !self.is_windows {
+            self.emit_syscall_number(PlatformSyscall::Exit);
+        }
+        if self.is_windows {
+            self.asm.call_label(self.windows_runtime().win_exit);
+        } else {
+            self.asm.syscall();
+        }
         Ok(NativeValue::Unit)
     }
 
@@ -23917,10 +24119,16 @@ impl NativeCodeGenerator {
         self.emit_runtime_error_if_rax_negative(span, &format!("{name} failed to open file"));
         self.asm.push_reg(Reg::Rax);
         self.asm.mov_reg_reg(Reg::Rdi, Reg::Rax);
-        self.emit_syscall_number(PlatformSyscall::Write);
+        if !self.is_windows {
+            self.emit_syscall_number(PlatformSyscall::Write);
+        }
         self.asm.mov_data_addr(Reg::Rsi, content_label);
         self.asm.mov_imm64(Reg::Rdx, bytes.len() as u64);
-        self.asm.syscall();
+        if self.is_windows {
+            self.asm.call_label(self.windows_runtime().win_write);
+        } else {
+            self.asm.syscall();
+        }
         self.emit_runtime_error_if_rax_negative(span, &format!("{name} failed to write file"));
         self.asm.pop_reg(Reg::Rdi);
         self.emit_syscall_number(PlatformSyscall::Close);
@@ -23957,10 +24165,16 @@ impl NativeCodeGenerator {
         self.emit_runtime_error_if_rax_negative(span, &format!("{name} failed to open file"));
         self.asm.push_reg(Reg::Rax);
         self.asm.mov_reg_reg(Reg::Rdi, Reg::Rax);
-        self.emit_syscall_number(PlatformSyscall::Write);
+        if !self.is_windows {
+            self.emit_syscall_number(PlatformSyscall::Write);
+        }
         self.asm.mov_data_addr(Reg::Rsi, content.data);
         self.emit_load_native_string_len(Reg::Rdx, content.len);
-        self.asm.syscall();
+        if self.is_windows {
+            self.asm.call_label(self.windows_runtime().win_write);
+        } else {
+            self.asm.syscall();
+        }
         self.emit_runtime_error_if_rax_negative(span, &format!("{name} failed to write file"));
         self.asm.pop_reg(Reg::Rdi);
         self.emit_syscall_number(PlatformSyscall::Close);
@@ -24152,11 +24366,17 @@ impl NativeCodeGenerator {
         self.asm.cmp_reg_imm8(Reg::Rax, 0);
         self.asm.jcc_label(Condition::Equal, done);
         self.asm.mov_reg_reg(Reg::R8, Reg::Rax);
-        self.emit_syscall_number(PlatformSyscall::Write);
+        if !self.is_windows {
+            self.emit_syscall_number(PlatformSyscall::Write);
+        }
         self.asm.mov_imm64(Reg::Rdi, fd);
         self.asm.mov_data_addr(Reg::Rsi, buffer);
         self.asm.mov_reg_reg(Reg::Rdx, Reg::R8);
-        self.asm.syscall();
+        if self.is_windows {
+            self.asm.call_label(self.windows_runtime().win_write);
+        } else {
+            self.asm.syscall();
+        }
         self.emit_runtime_error_if_rax_negative(span, &format!("{name} failed to write output"));
         self.asm.jmp_label(read_loop);
         self.asm.bind_text_label(done);
@@ -33944,9 +34164,15 @@ impl NativeCodeGenerator {
                 self.asm.mov_reg_reg(Reg::Rsi, Reg::Rax);
                 self.asm.add_reg_imm32(Reg::Rsi, 8);
                 self.asm.load_ptr_disp32(Reg::Rdx, Reg::Rax, 0);
-                self.emit_syscall_number(PlatformSyscall::Write);
+                if !self.is_windows {
+                    self.emit_syscall_number(PlatformSyscall::Write);
+                }
                 self.asm.mov_imm64(Reg::Rdi, fd);
-                self.asm.syscall();
+                if self.is_windows {
+                    self.asm.call_label(self.windows_runtime().win_write);
+                } else {
+                    self.asm.syscall();
+                }
             }
             NativeValue::Bool => self.emit_print_bool_fragment(fd),
             NativeValue::StaticFloat { bits } => {
@@ -34249,11 +34475,17 @@ impl NativeCodeGenerator {
 
         self.asm.mov_reg_reg(Reg::Rdx, Reg::R8);
         self.asm.sub_reg_reg(Reg::Rdx, Reg::R9);
-        self.emit_syscall_number(PlatformSyscall::Write);
+        if !self.is_windows {
+            self.emit_syscall_number(PlatformSyscall::Write);
+        }
         self.asm.mov_imm64(Reg::Rdi, fd);
         self.asm.mov_data_addr(Reg::Rsi, input.data);
         self.asm.add_reg_reg(Reg::Rsi, Reg::R9);
-        self.asm.syscall();
+        if self.is_windows {
+            self.asm.call_label(self.windows_runtime().win_write);
+        } else {
+            self.asm.syscall();
+        }
     }
 
     fn emit_runtime_lines_list_to_runtime_string(
@@ -35566,20 +35798,32 @@ impl NativeCodeGenerator {
     }
 
     fn emit_write_data(&mut self, fd: u64, label: DataLabel, len: usize) {
-        self.emit_syscall_number(PlatformSyscall::Write);
+        if !self.is_windows {
+            self.emit_syscall_number(PlatformSyscall::Write);
+        }
         self.asm.mov_imm64(Reg::Rdi, fd);
         self.asm.mov_data_addr(Reg::Rsi, label);
         self.asm.mov_imm64(Reg::Rdx, len as u64);
-        self.asm.syscall();
+        if self.is_windows {
+            self.asm.call_label(self.windows_runtime().win_write);
+        } else {
+            self.asm.syscall();
+        }
     }
 
     fn emit_write_data_dynamic_len(&mut self, fd: u64, data: DataLabel, len: DataLabel) {
-        self.emit_syscall_number(PlatformSyscall::Write);
+        if !self.is_windows {
+            self.emit_syscall_number(PlatformSyscall::Write);
+        }
         self.asm.mov_imm64(Reg::Rdi, fd);
         self.asm.mov_data_addr(Reg::Rsi, data);
         self.asm.mov_data_addr(Reg::Rdx, len);
         self.asm.load_ptr_disp32(Reg::Rdx, Reg::Rdx, 0);
-        self.asm.syscall();
+        if self.is_windows {
+            self.asm.call_label(self.windows_runtime().win_write);
+        } else {
+            self.asm.syscall();
+        }
     }
 
     /// Materialize a GC heap string (length-prefixed, pointer in rax)
@@ -37805,9 +38049,15 @@ impl NativeCodeGenerator {
     }
 
     fn emit_exit_code(&mut self, code: u64) {
-        self.emit_syscall_number(PlatformSyscall::Exit);
+        if !self.is_windows {
+            self.emit_syscall_number(PlatformSyscall::Exit);
+        }
         self.asm.mov_imm64(Reg::Rdi, code);
-        self.asm.syscall();
+        if self.is_windows {
+            self.asm.call_label(self.windows_runtime().win_exit);
+        } else {
+            self.asm.syscall();
+        }
     }
 
     fn emit_functions(&mut self) -> Result<(), Diagnostic> {
@@ -38127,10 +38377,16 @@ impl NativeCodeGenerator {
         self.asm.mov_byte_ptr_reg_imm8(Reg::Rsi, b'-');
         self.asm.inc_reg(Reg::Rcx);
         self.asm.bind_text_label(write);
-        self.emit_syscall_number(PlatformSyscall::Write);
+        if !self.is_windows {
+            self.emit_syscall_number(PlatformSyscall::Write);
+        }
         self.asm.mov_reg_reg(Reg::Rdi, Reg::R10);
         self.asm.mov_reg_reg(Reg::Rdx, Reg::Rcx);
-        self.asm.syscall();
+        if self.is_windows {
+            self.asm.call_label(self.windows_runtime().win_write);
+        } else {
+            self.asm.syscall();
+        }
         self.asm.leave();
         self.asm.ret();
     }
@@ -38195,6 +38451,14 @@ impl NativeCodeGenerator {
     /// Unlimited / failed lookups leave the floor at zero, which the
     /// prologue probe can never go below — probing disabled.
     fn emit_initialize_stack_floor(&mut self) {
+        if self.is_windows {
+            // `stack_floor`'s backing `.data` qword is already
+            // zero-initialized, and zero means "the prologue probe
+            // never fires" (see the field's doc comment) -- there is
+            // no Windows equivalent of `getrlimit(RLIMIT_STACK)`
+            // wired up in this slice, so the probe stays disabled.
+            return;
+        }
         const RLIMIT_STACK: u64 = 3;
         const STACK_FLOOR_MARGIN: i32 = 256 * 1024;
         let done = self.asm.create_text_label();
@@ -38227,6 +38491,210 @@ impl NativeCodeGenerator {
         self.asm.add_reg_imm32(Reg::Rsp, 16);
     }
 
+    /// Save every general-purpose register the codegen might have a
+    /// live value in in a fixed `rbp`-relative save area -- strictly
+    /// more conservative than a Linux `syscall`, which only clobbers
+    /// `rax`/`rcx`/`r11` -- so a Win64 shim is free to clobber any of
+    /// them internally, and pairs with `emit_win_shim_epilogue`.
+    ///
+    /// Deliberately does **not** assume anything about the incoming
+    /// `rsp` alignment: the ELF/Linux codegen this backend reuses was
+    /// never written to maintain the Win64 "16-byte aligned
+    /// immediately before every `call`" invariant (Linux `syscall`
+    /// has no such requirement), so a shim reached from inside a
+    /// deeply-nested call chain (closures passed to `.map`/
+    /// `foldLeft`, GC allocation paths, ...) can see `rsp` at any
+    /// parity. This save area is addressed purely via `rbp` (an
+    /// invariant reference point, set once and never adjusted here),
+    /// so it doesn't care what `rsp` becomes; the subsequent `and rsp,
+    /// -16` in `emit_win_shim_align_stack` then forces correct
+    /// alignment before the shim's own `call [rip+iat]` regardless of
+    /// how it was entered. Caller must have already done `push rbp;
+    /// mov rbp, rsp`.
+    fn emit_win_shim_save_registers(&mut self) {
+        self.asm
+            .sub_reg_imm32(Reg::Rsp, Self::WIN_SHIM_SAVE_AREA_SIZE);
+        self.asm.store_rbp_slot(8, Reg::Rbx);
+        self.asm.store_rbp_slot(16, Reg::Rcx);
+        self.asm.store_rbp_slot(24, Reg::Rdx);
+        self.asm.store_rbp_slot(32, Reg::Rsi);
+        self.asm.store_rbp_slot(40, Reg::Rdi);
+        self.asm.store_rbp_slot(48, Reg::R8);
+        self.asm.store_rbp_slot(56, Reg::R9);
+        self.asm.store_rbp_slot(64, Reg::R10);
+        self.asm.store_rbp_slot(72, Reg::R11);
+    }
+
+    /// 9 saved registers * 8 bytes, rounded up to a 16-byte multiple.
+    const WIN_SHIM_SAVE_AREA_SIZE: i32 = 80;
+
+    /// Forces 16-byte `rsp` alignment regardless of how the shim was
+    /// entered (`and rsp, -16` rounds down unconditionally, discarding
+    /// at most 15 bytes of headroom that already belongs to nothing),
+    /// then reserves `extra_bytes` more (must itself be a multiple of
+    /// 16 to preserve alignment) for the call's shadow space and any
+    /// stack arguments. Must run after `emit_win_shim_save_registers`
+    /// (which needs the *unaligned* `rsp` to still be usable via
+    /// `rbp`-relative addressing, unaffected either way) and before
+    /// the shim's `call_import`.
+    fn emit_win_shim_align_stack(&mut self, extra_bytes: i32) {
+        self.asm.and_reg_imm32(Reg::Rsp, -16);
+        self.asm.sub_reg_imm32(Reg::Rsp, extra_bytes);
+    }
+
+    /// Restores every register `emit_win_shim_save_registers` saved
+    /// (via `rbp`-relative loads, so this doesn't care what `rsp` was
+    /// left at by the shim body), then unwinds the whole frame in one
+    /// step (`mov rsp, rbp` undoes every `sub`/`and` since the
+    /// prologue) and returns. `rax` is left untouched -- callers set
+    /// it to the shim's return value before calling this.
+    fn emit_win_shim_epilogue(&mut self) {
+        self.asm.load_rbp_slot(Reg::R11, 72);
+        self.asm.load_rbp_slot(Reg::R10, 64);
+        self.asm.load_rbp_slot(Reg::R9, 56);
+        self.asm.load_rbp_slot(Reg::R8, 48);
+        self.asm.load_rbp_slot(Reg::Rdi, 40);
+        self.asm.load_rbp_slot(Reg::Rsi, 32);
+        self.asm.load_rbp_slot(Reg::Rdx, 24);
+        self.asm.load_rbp_slot(Reg::Rcx, 16);
+        self.asm.load_rbp_slot(Reg::Rbx, 8);
+        self.asm.mov_reg_reg(Reg::Rsp, Reg::Rbp);
+        self.asm.pop_reg(Reg::Rbp);
+        self.asm.ret();
+    }
+
+    /// Startup shim: caches `GetStdHandle(STD_OUTPUT_HANDLE)` and
+    /// `GetStdHandle(STD_ERROR_HANDLE)` into `.data` so `__win_write`
+    /// never has to call `GetStdHandle` itself. Called once, before
+    /// any code that could print or allocate.
+    fn emit_win_init_runtime(&mut self) {
+        const STD_OUTPUT_HANDLE: u64 = (-11i64) as u64;
+        const STD_ERROR_HANDLE: u64 = (-12i64) as u64;
+        let windows = self.windows_runtime();
+        self.asm.bind_text_label(windows.win_init);
+        self.asm.push_reg(Reg::Rbp);
+        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
+        self.emit_win_shim_save_registers();
+        self.emit_win_shim_align_stack(0x20); // shadow space only
+
+        self.asm.mov_imm64(Reg::Rcx, STD_OUTPUT_HANDLE);
+        self.asm.call_import(ImportSymbol::GetStdHandle);
+        self.asm.mov_data_addr(Reg::R10, windows.stdout_handle);
+        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
+
+        self.asm.mov_imm64(Reg::Rcx, STD_ERROR_HANDLE);
+        self.asm.call_import(ImportSymbol::GetStdHandle);
+        self.asm.mov_data_addr(Reg::R10, windows.stderr_handle);
+        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
+
+        self.emit_win_shim_epilogue();
+    }
+
+    /// `write(fd, buf, len)`-shaped shim wrapping `WriteFile`. Input:
+    /// rdi=fd (1 or 2, selecting the cached stdout/stderr handle from
+    /// `win_init`), rsi=buf, rdx=len -- the same three registers every
+    /// existing Linux `write` syscall call site already stages.
+    /// Output: rax=bytes written (read back from the scratch
+    /// `lpNumberOfBytesWritten` slot, mirroring what the Linux `write`
+    /// syscall would have left in rax on success).
+    fn emit_win_write_runtime(&mut self) {
+        let windows = self.windows_runtime();
+        self.asm.bind_text_label(windows.win_write);
+        self.asm.push_reg(Reg::Rbp);
+        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
+        self.emit_win_shim_save_registers();
+
+        // Select the cached handle by fd into rcx before rdi/rsi/rdx
+        // get reused for the WriteFile argument registers below.
+        let use_stderr = self.asm.create_text_label();
+        let handle_loaded = self.asm.create_text_label();
+        self.asm.cmp_reg_imm8(Reg::Rdi, 2);
+        self.asm.jcc_label(Condition::Equal, use_stderr);
+        self.asm.mov_data_addr(Reg::R10, windows.stdout_handle);
+        self.asm.jmp_label(handle_loaded);
+        self.asm.bind_text_label(use_stderr);
+        self.asm.mov_data_addr(Reg::R10, windows.stderr_handle);
+        self.asm.bind_text_label(handle_loaded);
+        self.asm.load_ptr_disp32(Reg::Rcx, Reg::R10, 0);
+
+        // r8 = len (original rdx) captured before rdx is overwritten
+        // with the buffer pointer below.
+        self.asm.mov_reg_reg(Reg::R8, Reg::Rdx);
+        self.asm.mov_reg_reg(Reg::Rdx, Reg::Rsi);
+        self.asm.mov_data_addr(Reg::R9, windows.write_bytes_scratch);
+        self.asm.xor_reg_reg(Reg::R10, Reg::R10);
+        // Shadow space (32) + 1 stack arg (lpOverlapped, 8 bytes),
+        // rounded up to 48 to stay a multiple of 16.
+        self.emit_win_shim_align_stack(0x30);
+        // lpOverlapped = NULL, the 5th arg at [rsp+0x20]. `rsp` is now
+        // the dynamically-aligned pointer computed above, so its
+        // offset from `rbp` isn't known at codegen time -- this must
+        // address it relative to `rsp` itself.
+        self.asm.store_ptr_disp32(Reg::Rsp, 0x20, Reg::R10);
+        self.asm.call_import(ImportSymbol::WriteFile);
+
+        // rax = bytes written, read back from the scratch DWORD
+        // (allocated as a zero-initialized qword, so the untouched
+        // high 32 bits keep this a correct zero-extended value).
+        self.asm
+            .mov_data_addr(Reg::R10, windows.write_bytes_scratch);
+        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
+
+        self.emit_win_shim_epilogue();
+    }
+
+    /// `mmap`-shaped shim wrapping `VirtualAlloc`. Input: rsi=len
+    /// (every existing Linux `mmap` staging site sets rdi/rdx/r10/r8/r9
+    /// too, for the syscall's addr/prot/flags/fd/offset arguments --
+    /// this shim ignores all of them and always requests a fresh
+    /// read-write anonymous mapping). Output: rax=base pointer, or -1
+    /// on failure -- `VirtualAlloc` itself returns 0 on failure, which
+    /// this shim converts to -1 so every existing `cmp rax,0; jge ok`
+    /// Linux-mmap-errno-style call site keeps working unmodified.
+    fn emit_win_mmap_runtime(&mut self) {
+        const MEM_COMMIT_RESERVE: u64 = 0x1000 | 0x2000;
+        const PAGE_READWRITE: u64 = 0x04;
+        let windows = self.windows_runtime();
+        self.asm.bind_text_label(windows.win_mmap);
+        self.asm.push_reg(Reg::Rbp);
+        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
+        self.emit_win_shim_save_registers();
+        self.emit_win_shim_align_stack(0x20); // shadow space only
+
+        self.asm.mov_imm64(Reg::Rcx, 0); // lpAddress = NULL
+        self.asm.mov_reg_reg(Reg::Rdx, Reg::Rsi); // dwSize
+        self.asm.mov_imm64(Reg::R8, MEM_COMMIT_RESERVE);
+        self.asm.mov_imm64(Reg::R9, PAGE_READWRITE);
+        self.asm.call_import(ImportSymbol::VirtualAlloc);
+
+        let done = self.asm.create_text_label();
+        self.asm.cmp_reg_imm8(Reg::Rax, 0);
+        self.asm.jcc_label(Condition::NotEqual, done);
+        self.asm.mov_imm64(Reg::Rax, (-1i64) as u64);
+        self.asm.bind_text_label(done);
+
+        self.emit_win_shim_epilogue();
+    }
+
+    /// `exit(code)`-shaped shim wrapping `ExitProcess`. Input: rdi=code.
+    /// Never returns, so unlike the other shims there is nothing to
+    /// restore; a trailing `ud2` is a defensive trap that should never
+    /// execute (mirrors the ELF backend's own exit call sites, which
+    /// also never expect control to fall through). Still forces
+    /// alignment via `and rsp, -16` for the same reason the other
+    /// shims do -- it can be reached from anywhere.
+    fn emit_win_exit_runtime(&mut self) {
+        let windows = self.windows_runtime();
+        self.asm.bind_text_label(windows.win_exit);
+        self.asm.push_reg(Reg::Rbp);
+        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
+        self.asm.and_reg_imm32(Reg::Rsp, -16);
+        self.asm.sub_reg_imm32(Reg::Rsp, 0x20);
+        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rdi);
+        self.asm.call_import(ImportSymbol::ExitProcess);
+        self.asm.ud2();
+    }
+
     /// Shared abort target for the function-prologue stack probe:
     /// report and exit instead of dying on the guard page with a bare
     /// SIGSEGV.
@@ -38243,7 +38711,9 @@ impl NativeCodeGenerator {
     fn emit_initialize_gc_heap(&mut self) {
         // mmap(NULL, GC_HEAP_SIZE, PROT_READ | PROT_WRITE,
         //      MAP_ANON | MAP_PRIVATE, -1, 0)
-        self.emit_syscall_number(PlatformSyscall::Mmap);
+        if !self.is_windows {
+            self.emit_syscall_number(PlatformSyscall::Mmap);
+        }
         self.asm.mov_imm64(Reg::Rdi, 0); // addr = NULL
         self.asm.mov_imm64(Reg::Rsi, Self::GC_HEAP_SIZE);
         self.asm
@@ -38253,7 +38723,11 @@ impl NativeCodeGenerator {
         self.asm
             .mov_imm64(Reg::R8, self.platform.mmap_anonymous_fd());
         self.asm.mov_imm64(Reg::R9, 0); // offset = 0
-        self.asm.syscall();
+        if self.is_windows {
+            self.asm.call_label(self.windows_runtime().win_mmap);
+        } else {
+            self.asm.syscall();
+        }
 
         // Bail out hard if mmap returned a negative errno value.
         let mmap_ok = self.asm.create_text_label();
@@ -38290,7 +38764,9 @@ impl NativeCodeGenerator {
         // Map the GC tables (root table, shadow stack, mark worklist)
         // in one anonymous mapping — mmap memory is zero-filled, which
         // is exactly the tables' required initial state.
-        self.emit_syscall_number(PlatformSyscall::Mmap);
+        if !self.is_windows {
+            self.emit_syscall_number(PlatformSyscall::Mmap);
+        }
         self.asm.mov_imm64(Reg::Rdi, 0);
         self.asm.mov_imm64(Reg::Rsi, Self::GC_TABLES_BYTES);
         self.asm
@@ -38300,7 +38776,11 @@ impl NativeCodeGenerator {
         self.asm
             .mov_imm64(Reg::R8, self.platform.mmap_anonymous_fd());
         self.asm.mov_imm64(Reg::R9, 0);
-        self.asm.syscall();
+        if self.is_windows {
+            self.asm.call_label(self.windows_runtime().win_mmap);
+        } else {
+            self.asm.syscall();
+        }
         let tables_ok = self.asm.create_text_label();
         self.asm.cmp_reg_imm8(Reg::Rax, 0);
         self.asm.jcc_label(Condition::GreaterEqual, tables_ok);
@@ -39068,7 +39548,9 @@ impl NativeCodeGenerator {
 
         // mmap(NULL, alloc_size, PROT_READ|PROT_WRITE,
         //      MAP_ANON|MAP_PRIVATE, -1, 0).
-        self.emit_syscall_number(PlatformSyscall::Mmap);
+        if !self.is_windows {
+            self.emit_syscall_number(PlatformSyscall::Mmap);
+        }
         self.asm.mov_imm64(Reg::Rdi, 0);
         self.asm.load_rbp_slot(Reg::Rsi, 8);
         self.asm
@@ -39078,7 +39560,11 @@ impl NativeCodeGenerator {
         self.asm
             .mov_imm64(Reg::R8, self.platform.mmap_anonymous_fd());
         self.asm.mov_imm64(Reg::R9, 0);
-        self.asm.syscall();
+        if self.is_windows {
+            self.asm.call_label(self.windows_runtime().win_mmap);
+        } else {
+            self.asm.syscall();
+        }
         self.asm.cmp_reg_imm8(Reg::Rax, 0);
         self.asm.jcc_label(Condition::Less, mmap_failed);
 
@@ -41431,10 +41917,57 @@ enum RelocKind {
     Abs64,
 }
 
+/// A `kernel32.dll` function imported by the PE64 backend's Win64
+/// shims. Variant order is load-bearing: it fixes the ILT/IAT slot
+/// order the `pe` writer lays the import table out in, and every
+/// `call [rip+disp32]` emitted by `Assembler::call_import` resolves
+/// against that same order via `ImportSymbol::iat_index`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ImportSymbol {
+    GetStdHandle,
+    WriteFile,
+    ExitProcess,
+    VirtualAlloc,
+}
+
+impl ImportSymbol {
+    const ALL: [ImportSymbol; 4] = [
+        ImportSymbol::GetStdHandle,
+        ImportSymbol::WriteFile,
+        ImportSymbol::ExitProcess,
+        ImportSymbol::VirtualAlloc,
+    ];
+
+    /// Exact, case-sensitive export name from `kernel32.dll`.
+    fn name(self) -> &'static str {
+        match self {
+            ImportSymbol::GetStdHandle => "GetStdHandle",
+            ImportSymbol::WriteFile => "WriteFile",
+            ImportSymbol::ExitProcess => "ExitProcess",
+            ImportSymbol::VirtualAlloc => "VirtualAlloc",
+        }
+    }
+
+    /// This symbol's zero-based slot in the ILT/IAT arrays.
+    fn iat_index(self) -> usize {
+        match self {
+            ImportSymbol::GetStdHandle => 0,
+            ImportSymbol::WriteFile => 1,
+            ImportSymbol::ExitProcess => 2,
+            ImportSymbol::VirtualAlloc => 3,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum RelocTarget {
     Text(TextLabel),
     Data(DataLabel),
+    /// Only produced by `Assembler::call_import` (PE64/Windows target
+    /// only). Patched by `pe::write_executable` against the IAT slot
+    /// for the symbol; `elf::patch_relocations` never sees one since
+    /// the Linux backend never calls `call_import`.
+    Import(ImportSymbol),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -41665,6 +42198,15 @@ impl Assembler {
         self.rex_w(dst, base);
         self.byte(0x8b);
         self.byte(0x80 | (((dst as u8) & 7) << 3) | ((base as u8) & 7));
+        // ModRM.rm == 100b (rsp's low 3 bits) doesn't mean "register
+        // rsp" for a memory operand -- it's the escape code that
+        // requires a following SIB byte. `0x24` = scale 00, no index
+        // (100b), base = rsp (100b): plain `[rsp+disp]`, no index
+        // register. Every other `base` this codegen uses (rbp, r10,
+        // r8, ...) has rm != 100b and needs no SIB byte.
+        if (base as u8) & 7 == 4 {
+            self.byte(0x24);
+        }
         self.text.extend_from_slice(&disp.to_le_bytes());
     }
 
@@ -41696,6 +42238,10 @@ impl Assembler {
         self.rex_w(src, base);
         self.byte(0x89);
         self.byte(0x80 | (((src as u8) & 7) << 3) | ((base as u8) & 7));
+        // See `load_ptr_disp32`: rm == 100b (rsp) requires a SIB byte.
+        if (base as u8) & 7 == 4 {
+            self.byte(0x24);
+        }
         self.text.extend_from_slice(&disp.to_le_bytes());
     }
 
@@ -41847,6 +42393,24 @@ impl Assembler {
         });
     }
 
+    /// `call qword ptr [rip+disp32]` (`FF 15 <disp32>`) through an
+    /// import's IAT slot -- the idiomatic Win64 way to call a DLL
+    /// import. The patch arithmetic is identical to a normal
+    /// `Rel32`/`call rel32` (`target - (pos_after_instruction)`), only
+    /// the target resolves against the IAT instead of a `Text`/`Data`
+    /// label, so this reuses `RelocKind::Rel32` with a
+    /// `RelocTarget::Import` target.
+    fn call_import(&mut self, symbol: ImportSymbol) {
+        self.bytes(&[0xff, 0x15]);
+        let pos = self.text.len();
+        self.imm32(0);
+        self.relocs.push(Reloc {
+            pos,
+            kind: RelocKind::Rel32,
+            target: RelocTarget::Import(symbol),
+        });
+    }
+
     fn inc_reg(&mut self, reg: Reg) {
         self.rex_w(Reg::Rax, reg);
         self.byte(0xff);
@@ -41948,6 +42512,12 @@ impl Assembler {
         self.bytes(&[0x0f, 0x05]);
     }
 
+    /// `ud2` — guaranteed-invalid instruction, used as a defensive
+    /// trap after a call that should never return (e.g. `ExitProcess`).
+    fn ud2(&mut self) {
+        self.bytes(&[0x0f, 0x0b]);
+    }
+
     /// `rep movsb` — copy `rcx` bytes from `[rsi]` to `[rdi]`, advancing
     /// both pointers and decrementing rcx until it reaches zero. The
     /// caller is responsible for setting up rsi / rdi / rcx beforehand.
@@ -42019,6 +42589,13 @@ mod elf {
             let target = match reloc.target {
                 RelocTarget::Text(label) => TEXT_VADDR + object.text_labels[label.0] as u64,
                 RelocTarget::Data(label) => data_vaddr + object.data_labels[label.0] as u64,
+                // `call_import` (the only source of an `Import`
+                // target) is only ever emitted by Windows-gated
+                // codegen paths; the Linux ELF backend never reaches
+                // one.
+                RelocTarget::Import(_) => {
+                    unreachable!("ELF relocations never target a PE import")
+                }
             };
             match reloc.kind {
                 RelocKind::Rel32 => {
@@ -42228,12 +42805,22 @@ mod tests {
             Some(NativeTarget::MacosAarch64)
         );
         assert_eq!(
+            NativeTarget::parse("windows-x86_64"),
+            Some(NativeTarget::WindowsX86_64)
+        );
+        assert_eq!(
+            NativeTarget::parse("x86_64-pc-windows-msvc"),
+            Some(NativeTarget::WindowsX86_64)
+        );
+        assert_eq!(
             NativeTarget::supported_names(),
             &[
                 "linux-x86_64",
                 "x86_64-unknown-linux-gnu",
                 "macos-aarch64",
                 "aarch64-apple-darwin",
+                "windows-x86_64",
+                "x86_64-pc-windows-msvc",
                 "native"
             ]
         );
@@ -42242,7 +42829,7 @@ mod tests {
     #[test]
     fn native_target_metadata_is_registry_backed() {
         let specs = NativeTarget::supported_specs();
-        assert_eq!(specs.len(), 2);
+        assert_eq!(specs.len(), 3);
         let linux = NativeTarget::LinuxX86_64;
         let spec = linux.spec();
         assert_eq!(spec.target, linux);
@@ -42275,6 +42862,23 @@ mod tests {
         assert_eq!(macos.operating_system(), NativeOperatingSystem::MacOs);
         assert_eq!(macos.abi(), NativeAbi::Apple);
         assert_eq!(macos.executable_format(), NativeExecutableFormat::MachO64);
+
+        let windows = NativeTarget::WindowsX86_64;
+        let spec = windows.spec();
+        assert_eq!(spec.target, windows);
+        assert_eq!(spec.canonical_name, "windows-x86_64");
+        assert_eq!(spec.standard_triple, "x86_64-pc-windows-msvc");
+        assert_eq!(spec.aliases, &["windows-x86_64", "x86_64-pc-windows-msvc"]);
+        // Reuses the entire DirectX86_64 (Linux) codegen -- only the
+        // OS boundary and executable format differ.
+        assert_eq!(windows.architecture(), NativeArchitecture::X86_64);
+        assert_eq!(windows.backend(), NativeBackend::DirectX86_64);
+        assert_eq!(windows.backend().name(), "direct-x86_64");
+        assert_eq!(windows.pointer_width_bits(), 64);
+        assert_eq!(windows.endianness(), NativeEndianness::Little);
+        assert_eq!(windows.operating_system(), NativeOperatingSystem::Windows);
+        assert_eq!(windows.abi(), NativeAbi::Msvc);
+        assert_eq!(windows.executable_format(), NativeExecutableFormat::Pe64);
     }
 
     #[test]
@@ -42320,7 +42924,7 @@ mod tests {
     fn linux_x86_64_platform_names_os_abi_constants() {
         let platform = TargetPlatform::for_target(NativeTarget::LinuxX86_64);
         assert_eq!(platform.target, NativeTarget::LinuxX86_64);
-        assert_eq!(PLATFORM_CONSTANTS_BY_TARGET.len(), 1);
+        assert_eq!(PLATFORM_CONSTANTS_BY_TARGET.len(), 2);
         assert_eq!(
             PLATFORM_CONSTANTS_BY_TARGET[0].target,
             NativeTarget::LinuxX86_64
@@ -42356,6 +42960,31 @@ mod tests {
         assert_eq!(platform.mmap_prot_read_write(), 3);
         assert_eq!(platform.mmap_private_anonymous_flags(), 0x22);
         assert_eq!(platform.mmap_anonymous_fd(), (-1_i64) as u64);
+    }
+
+    #[test]
+    #[should_panic(expected = "missing Windows gate")]
+    fn windows_syscall_number_is_a_compile_time_tripwire() {
+        // Windows has no raw syscall ABI: every codegen call site that
+        // could reach `emit_syscall_number` must branch on
+        // `is_windows` first. This asserts the tripwire itself fires
+        // -- a regression here would mean an un-gated syscall site
+        // could silently emit a Linux syscall number into a Windows
+        // binary instead of failing loudly at compile time.
+        let platform = TargetPlatform::for_target(NativeTarget::WindowsX86_64);
+        let _ = platform.syscall_number(PlatformSyscall::Write);
+    }
+
+    #[test]
+    fn windows_target_stdio_fds_match_linux() {
+        // Only the OS-independent fd numbers are meaningful on
+        // Windows (the Win64 shims interpret them to pick a cached
+        // GetStdHandle result) -- everything else in
+        // WINDOWS_X86_64_PLATFORM_CONSTANTS is an unread placeholder.
+        let platform = TargetPlatform::for_target(NativeTarget::WindowsX86_64);
+        assert_eq!(platform.stdin_fd(), 0);
+        assert_eq!(platform.stdout_fd(), 1);
+        assert_eq!(platform.stderr_fd(), 2);
     }
 
     #[test]

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -239,6 +239,8 @@ impl NativeTarget {
             Some(Self::LinuxX86_64)
         } else if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
             Some(Self::MacosAarch64)
+        } else if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
+            Some(Self::WindowsX86_64)
         } else {
             None
         }

--- a/crates/klassic-native/src/pe.rs
+++ b/crates/klassic-native/src/pe.rs
@@ -1,0 +1,374 @@
+//! Minimal PE32+ (PE64) console executable writer for the
+//! `x86_64-pc-windows-msvc` direct backend. Unlike the Mach-O arm64
+//! backend, Windows does not get its own codegen module: it reuses
+//! the *entire* `DirectX86_64` (Linux) code generator (see
+//! `NativeCodeGenerator`), which threads an `is_windows` flag through
+//! every OS-boundary site (writing to stdout/stderr, growing the GC
+//! heap via `mmap`, and process exit) so those sites call a small set
+//! of Win64 import-call shims (`__win_write`, `__win_mmap`,
+//! `__win_exit`, `__win_init`) instead of emitting a bare Linux
+//! `syscall` instruction. This module's only job is serializing the
+//! resulting `ObjectFile` (flat `text`/`data` byte buffers plus a
+//! label-based relocation list -- the exact same shape the ELF writer
+//! in `mod elf` consumes) as a valid, unsigned, import-only-from-
+//! `kernel32.dll` PE64 image: no linker, no CRT, no `.reloc` section
+//! (fixed `ImageBase`, `IMAGE_FILE_RELOCS_STRIPPED`).
+//!
+//! Layout follows the standard three-section shape a real linker
+//! would produce (`.text` RX, `.rdata` R holding the import
+//! directory/ILT/IAT/hint-name table, `.data` RW holding the
+//! generator's `object.data` blob verbatim -- it mixes read-only
+//! string constants with mutable globals like the GC heap pointers,
+//! so it must be writable as a whole). `AddressOfEntryPoint` is the
+//! very first byte of `.text`, exactly like the ELF writer's
+//! `_start`.
+
+use super::{ImportSymbol, NativeTargetSpec, ObjectFile, RelocKind, RelocTarget};
+
+const IMAGE_BASE: u64 = 0x1_4000_0000;
+const SECTION_ALIGNMENT: u64 = 0x1000;
+const FILE_ALIGNMENT: u64 = 0x200;
+
+const DOS_HEADER_SIZE: u64 = 64;
+const PE_SIGNATURE_SIZE: u64 = 4;
+const COFF_HEADER_SIZE: u64 = 20;
+/// Fixed PE32+ optional header: 112 bytes of scalar fields plus 16
+/// data directories * 8 bytes = 240. Must match
+/// `COFF.SizeOfOptionalHeader` exactly (checked by
+/// `build_target_windows_x86_64_emits_pe`).
+const OPTIONAL_HEADER_SIZE: u64 = 112 + 16 * 8;
+const SECTION_HEADER_SIZE: u64 = 40;
+const SECTION_COUNT: u16 = 3; // .text, .rdata, .data
+const NUMBER_OF_RVA_AND_SIZES: u32 = 16;
+
+const IMAGE_FILE_MACHINE_AMD64: u16 = 0x8664;
+const IMAGE_FILE_RELOCS_STRIPPED: u16 = 0x0001;
+const IMAGE_FILE_EXECUTABLE_IMAGE: u16 = 0x0002;
+const IMAGE_FILE_LARGE_ADDRESS_AWARE: u16 = 0x0020;
+
+const OPTIONAL_HEADER_MAGIC_PE32_PLUS: u16 = 0x020b;
+const IMAGE_SUBSYSTEM_WINDOWS_CUI: u16 = 3;
+/// `NX_COMPAT` only. Deliberately does *not* set `DYNAMIC_BASE` or
+/// `HIGH_ENTROPY_VA`: both require a real `.reloc` table, which this
+/// design omits (fixed `ImageBase`, `RELOCS_STRIPPED`).
+const IMAGE_DLLCHARACTERISTICS_NX_COMPAT: u16 = 0x0100;
+
+const IMAGE_SCN_CNT_CODE: u32 = 0x0000_0020;
+const IMAGE_SCN_CNT_INITIALIZED_DATA: u32 = 0x0000_0040;
+const IMAGE_SCN_MEM_EXECUTE: u32 = 0x2000_0000;
+const IMAGE_SCN_MEM_READ: u32 = 0x4000_0000;
+const IMAGE_SCN_MEM_WRITE: u32 = 0x8000_0000;
+
+/// 8 MiB -- Klassic programs recurse deeply (the native backend's own
+/// stack-overflow probe assumes real headroom); the default MSVC 1 MiB
+/// reserve is too small.
+const SIZE_OF_STACK_RESERVE: u64 = 0x0080_0000;
+const SIZE_OF_STACK_COMMIT: u64 = 0x0001_0000;
+/// The program never uses the default process heap (all dynamic
+/// allocation goes through `VirtualAlloc` directly), so these are
+/// harmless linker-style defaults.
+const SIZE_OF_HEAP_RESERVE: u64 = 0x0010_0000;
+const SIZE_OF_HEAP_COMMIT: u64 = 0x0000_1000;
+
+const KERNEL32_DLL: &str = "KERNEL32.DLL\0";
+
+fn align_to(value: u64, alignment: u64) -> u64 {
+    value.div_ceil(alignment) * alignment
+}
+
+struct Writer {
+    bytes: Vec<u8>,
+}
+
+impl Writer {
+    fn u8(&mut self, value: u8) {
+        self.bytes.push(value);
+    }
+
+    fn u16(&mut self, value: u16) {
+        self.bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn u32(&mut self, value: u32) {
+        self.bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn u64(&mut self, value: u64) {
+        self.bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn push_bytes(&mut self, data: &[u8]) {
+        self.bytes.extend_from_slice(data);
+    }
+
+    fn pad_to(&mut self, offset: usize) {
+        debug_assert!(self.bytes.len() <= offset);
+        self.bytes.resize(offset, 0);
+    }
+}
+
+/// Serialize `object` (the same flat text/data/relocs shape
+/// `elf::write_executable` consumes) as a complete PE32+ executable.
+/// `spec` is accepted for signature parity with the ELF writer but
+/// unused: every field this function needs (machine type, subsystem,
+/// section layout) is fixed for this single supported Windows target.
+pub(crate) fn write_executable(mut object: ObjectFile, _spec: &NativeTargetSpec) -> Vec<u8> {
+    let section_headers_size = SECTION_HEADER_SIZE * u64::from(SECTION_COUNT);
+    let headers_end = DOS_HEADER_SIZE
+        + PE_SIGNATURE_SIZE
+        + COFF_HEADER_SIZE
+        + OPTIONAL_HEADER_SIZE
+        + section_headers_size;
+    let size_of_headers = align_to(headers_end, FILE_ALIGNMENT);
+
+    // ---- .text ----
+    let text_rva = SECTION_ALIGNMENT;
+    let text_file_offset = size_of_headers;
+    let text_virtual_size = object.text.len() as u64;
+    let text_raw_size = align_to(text_virtual_size, FILE_ALIGNMENT);
+
+    // ---- .rdata: import directory table + ILT + IAT + hint/name + DLL name ----
+    let rdata_rva = align_to(text_rva + text_virtual_size, SECTION_ALIGNMENT);
+    let rdata_file_offset = align_to(text_file_offset + text_raw_size, FILE_ALIGNMENT);
+
+    let import_dir_off: u64 = 0;
+    let import_dir_size: u64 = 20 * 2; // one DLL descriptor + a zero terminator
+    let ilt_off = import_dir_off + import_dir_size;
+    let ilt_size = 8 * (ImportSymbol::ALL.len() as u64 + 1); // + zero terminator
+    let iat_off = ilt_off + ilt_size;
+    let iat_size = ilt_size;
+
+    let mut hint_name_offsets = Vec::with_capacity(ImportSymbol::ALL.len());
+    let mut cursor = iat_off + iat_size;
+    for symbol in ImportSymbol::ALL {
+        hint_name_offsets.push(cursor);
+        // WORD Hint + ASCIIZ name, padded to an even total length.
+        let entry_len = 2 + symbol.name().len() + 1;
+        cursor += align_to(entry_len as u64, 2);
+    }
+    let dll_name_off = cursor;
+    let rdata_virtual_size = dll_name_off + KERNEL32_DLL.len() as u64;
+    let rdata_raw_size = align_to(rdata_virtual_size, FILE_ALIGNMENT);
+
+    // ---- .data: the generator's object.data verbatim (RW: mixes
+    // read-only string constants with mutable globals) ----
+    let data_rva = align_to(rdata_rva + rdata_virtual_size, SECTION_ALIGNMENT);
+    let data_file_offset = align_to(rdata_file_offset + rdata_raw_size, FILE_ALIGNMENT);
+    let data_virtual_size = object.data.len() as u64;
+    let data_raw_size = align_to(data_virtual_size, FILE_ALIGNMENT);
+
+    let size_of_image = align_to(data_rva + data_virtual_size, SECTION_ALIGNMENT);
+
+    // ---- patch relocations now that every section's VA is final ----
+    let text_va = IMAGE_BASE + text_rva;
+    let data_va = IMAGE_BASE + data_rva;
+    let iat_va = IMAGE_BASE + rdata_rva + iat_off;
+    patch_relocations(&mut object, text_va, data_va, iat_va);
+
+    // ---- build .rdata content ----
+    let mut rdata = Writer {
+        bytes: Vec::with_capacity(rdata_virtual_size as usize),
+    };
+    // IMAGE_IMPORT_DESCRIPTOR for KERNEL32.DLL.
+    rdata.u32((rdata_rva + ilt_off) as u32); // OriginalFirstThunk (-> ILT)
+    rdata.u32(0); // TimeDateStamp
+    rdata.u32(0); // ForwarderChain
+    rdata.u32((rdata_rva + dll_name_off) as u32); // Name
+    rdata.u32((rdata_rva + iat_off) as u32); // FirstThunk (-> IAT)
+    rdata.push_bytes(&[0u8; 20]); // null descriptor terminator
+    debug_assert_eq!(rdata.bytes.len() as u64, ilt_off);
+    // ILT: RVAs into the hint/name table, non-ordinal (bit 63 clear).
+    for &offset in &hint_name_offsets {
+        rdata.u64(rdata_rva + offset);
+    }
+    rdata.u64(0);
+    debug_assert_eq!(rdata.bytes.len() as u64, iat_off);
+    // IAT: identical initial content to the ILT; the loader overwrites
+    // this array in place with resolved addresses. Generated `call
+    // [rip+disp32]` instructions (via `call_import`) target these
+    // slots, never the ILT.
+    for &offset in &hint_name_offsets {
+        rdata.u64(rdata_rva + offset);
+    }
+    rdata.u64(0);
+    debug_assert_eq!(rdata.bytes.len() as u64, hint_name_offsets[0]);
+    for (symbol, &offset) in ImportSymbol::ALL.iter().zip(hint_name_offsets.iter()) {
+        debug_assert_eq!(rdata.bytes.len() as u64, offset);
+        rdata.u16(0); // Hint
+        rdata.push_bytes(symbol.name().as_bytes());
+        rdata.u8(0); // NUL terminator
+        if !rdata.bytes.len().is_multiple_of(2) {
+            rdata.u8(0); // pad to an even offset for the next entry
+        }
+    }
+    debug_assert_eq!(rdata.bytes.len() as u64, dll_name_off);
+    rdata.push_bytes(KERNEL32_DLL.as_bytes());
+    debug_assert_eq!(rdata.bytes.len() as u64, rdata_virtual_size);
+    rdata.pad_to(rdata_raw_size as usize);
+
+    // ---- assemble the full file ----
+    let mut out = Writer {
+        bytes: Vec::with_capacity(size_of_image as usize),
+    };
+
+    // DOS header: the Windows loader only reads e_magic and follows
+    // e_lfanew straight to the PE signature, so a stub-less "tiny PE"
+    // (zero bytes between the two) loads fine.
+    out.push_bytes(b"MZ");
+    out.pad_to(0x3c);
+    out.u32(DOS_HEADER_SIZE as u32); // e_lfanew
+    debug_assert_eq!(out.bytes.len() as u64, DOS_HEADER_SIZE);
+
+    out.push_bytes(b"PE\0\0");
+
+    // COFF file header.
+    out.u16(IMAGE_FILE_MACHINE_AMD64);
+    out.u16(SECTION_COUNT);
+    out.u32(0); // TimeDateStamp
+    out.u32(0); // PointerToSymbolTable
+    out.u32(0); // NumberOfSymbols
+    out.u16(OPTIONAL_HEADER_SIZE as u16);
+    out.u16(
+        IMAGE_FILE_RELOCS_STRIPPED | IMAGE_FILE_EXECUTABLE_IMAGE | IMAGE_FILE_LARGE_ADDRESS_AWARE,
+    );
+
+    // Optional header (IMAGE_OPTIONAL_HEADER64 / PE32+).
+    out.u16(OPTIONAL_HEADER_MAGIC_PE32_PLUS);
+    out.u8(14); // MajorLinkerVersion (arbitrary, unchecked by the loader)
+    out.u8(0); // MinorLinkerVersion
+    out.u32(text_raw_size as u32); // SizeOfCode
+    out.u32((rdata_raw_size + data_raw_size) as u32); // SizeOfInitializedData
+    out.u32(0); // SizeOfUninitializedData (no .bss; heap comes from VirtualAlloc)
+    out.u32(text_rva as u32); // AddressOfEntryPoint
+    out.u32(text_rva as u32); // BaseOfCode
+    out.u64(IMAGE_BASE);
+    out.u32(SECTION_ALIGNMENT as u32);
+    out.u32(FILE_ALIGNMENT as u32);
+    out.u16(6); // MajorOperatingSystemVersion
+    out.u16(0); // MinorOperatingSystemVersion
+    out.u16(0); // MajorImageVersion
+    out.u16(0); // MinorImageVersion
+    out.u16(6); // MajorSubsystemVersion
+    out.u16(0); // MinorSubsystemVersion
+    out.u32(0); // Win32VersionValue (reserved, must be zero)
+    out.u32(size_of_image as u32);
+    out.u32(size_of_headers as u32);
+    out.u32(0); // CheckSum (not enforced for ordinary console EXEs)
+    out.u16(IMAGE_SUBSYSTEM_WINDOWS_CUI);
+    out.u16(IMAGE_DLLCHARACTERISTICS_NX_COMPAT);
+    out.u64(SIZE_OF_STACK_RESERVE);
+    out.u64(SIZE_OF_STACK_COMMIT);
+    out.u64(SIZE_OF_HEAP_RESERVE);
+    out.u64(SIZE_OF_HEAP_COMMIT);
+    out.u32(0); // LoaderFlags (obsolete, must be zero)
+    out.u32(NUMBER_OF_RVA_AND_SIZES);
+    // Data directories: only Export(0) and Import(1) are populated
+    // (IAT(12) is deliberately left {0,0} -- the loader resolves
+    // imports from the Import Directory Table, not this entry).
+    out.u32(0);
+    out.u32(0); // 0: Export
+    out.u32((rdata_rva + import_dir_off) as u32);
+    out.u32(import_dir_size as u32); // 1: Import
+    for _ in 2..16 {
+        out.u32(0);
+        out.u32(0);
+    }
+    debug_assert_eq!(
+        out.bytes.len() as u64,
+        DOS_HEADER_SIZE + PE_SIGNATURE_SIZE + COFF_HEADER_SIZE + OPTIONAL_HEADER_SIZE
+    );
+
+    write_section_header(
+        &mut out,
+        b".text",
+        text_virtual_size,
+        text_rva,
+        text_raw_size,
+        text_file_offset,
+        IMAGE_SCN_CNT_CODE | IMAGE_SCN_MEM_EXECUTE | IMAGE_SCN_MEM_READ,
+    );
+    write_section_header(
+        &mut out,
+        b".rdata",
+        rdata_virtual_size,
+        rdata_rva,
+        rdata_raw_size,
+        rdata_file_offset,
+        IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ,
+    );
+    write_section_header(
+        &mut out,
+        b".data",
+        data_virtual_size,
+        data_rva,
+        data_raw_size,
+        data_file_offset,
+        IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ | IMAGE_SCN_MEM_WRITE,
+    );
+    debug_assert_eq!(out.bytes.len() as u64, headers_end);
+
+    out.pad_to(size_of_headers as usize);
+    debug_assert_eq!(out.bytes.len() as u64, text_file_offset);
+    out.push_bytes(&object.text);
+    out.pad_to((text_file_offset + text_raw_size) as usize);
+
+    debug_assert_eq!(out.bytes.len() as u64, rdata_file_offset);
+    out.push_bytes(&rdata.bytes);
+    out.pad_to((rdata_file_offset + rdata_raw_size) as usize);
+
+    debug_assert_eq!(out.bytes.len() as u64, data_file_offset);
+    out.push_bytes(&object.data);
+    out.pad_to((data_file_offset + data_raw_size) as usize);
+
+    out.bytes
+}
+
+fn write_section_header(
+    out: &mut Writer,
+    name: &[u8],
+    virtual_size: u64,
+    virtual_address: u64,
+    size_of_raw_data: u64,
+    pointer_to_raw_data: u64,
+    characteristics: u32,
+) {
+    let mut name_field = [0u8; 8];
+    name_field[..name.len()].copy_from_slice(name);
+    out.push_bytes(&name_field);
+    out.u32(virtual_size as u32);
+    out.u32(virtual_address as u32);
+    out.u32(size_of_raw_data as u32);
+    out.u32(pointer_to_raw_data as u32);
+    out.u32(0); // PointerToRelocations
+    out.u32(0); // PointerToLinenumbers
+    out.u16(0); // NumberOfRelocations
+    out.u16(0); // NumberOfLinenumbers
+    out.u32(characteristics);
+}
+
+fn patch_relocations(object: &mut ObjectFile, text_va: u64, data_va: u64, iat_va: u64) {
+    for reloc in &object.relocs {
+        match reloc.kind {
+            RelocKind::Rel32 => {
+                let target = match reloc.target {
+                    RelocTarget::Text(label) => text_va + object.text_labels[label.0] as u64,
+                    RelocTarget::Data(label) => data_va + object.data_labels[label.0] as u64,
+                    RelocTarget::Import(symbol) => iat_va + (symbol.iat_index() as u64) * 8,
+                };
+                let next = text_va + reloc.pos as u64 + 4;
+                let value = (target as i64 - next as i64) as i32;
+                object.text[reloc.pos..reloc.pos + 4].copy_from_slice(&value.to_le_bytes());
+            }
+            RelocKind::Abs64 => {
+                let target = match reloc.target {
+                    RelocTarget::Text(label) => text_va + object.text_labels[label.0] as u64,
+                    RelocTarget::Data(label) => data_va + object.data_labels[label.0] as u64,
+                    RelocTarget::Import(_) => {
+                        unreachable!("no codegen path emits an Abs64 relocation against an import")
+                    }
+                };
+                object.text[reloc.pos..reloc.pos + 8].copy_from_slice(&target.to_le_bytes());
+            }
+        }
+    }
+}

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -61,11 +61,12 @@ cargo run -- -e "1 + 2"
 - REPL/session state
 
 ### `klassic-native`
-- Batch native compilation through `klassic build [--target linux-x86_64|x86_64-unknown-linux-gnu|macos-aarch64|aarch64-apple-darwin|native] <file.kl> -o <output>`
+- Batch native compilation through `klassic build [--target linux-x86_64|x86_64-unknown-linux-gnu|macos-aarch64|aarch64-apple-darwin|windows-x86_64|x86_64-pc-windows-msvc|native] <file.kl> -o <output>`
 - Reuses the Rust parser, rewrite pass, typechecker, and proof/trust analysis
-- Emits target-native machine code directly; both `LinuxX86_64` and `MacOsAArch64` are implemented
+- Emits target-native machine code directly; `LinuxX86_64`, `MacOsAArch64`, and `WindowsX86_64` are implemented
 - Also emits ad-hoc-signed Mach-O arm64 executables for `aarch64-apple-darwin` (direct backend, growing subset)
-- Carries an explicit `NativeTarget`; the implemented targets are `LinuxX86_64` and `MacOsAArch64`
+- `WindowsX86_64` reuses the `LinuxX86_64` codegen backend (`DirectX86_64`) wholesale and only swaps the OS boundary (Win64 import-call shims) and container format (PE64)
+- Carries an explicit `NativeTarget`; the implemented targets are `LinuxX86_64`, `MacOsAArch64`, and `WindowsX86_64`
 - Keeps supported targets in a metadata registry containing the compact name,
   standard triple, architecture, direct-codegen backend, data layout,
   operating system, ABI, and executable format
@@ -75,8 +76,9 @@ cargo run -- -e "1 + 2"
   spec with its platform constants before entering codegen
 - Keeps target-specific syscall numbers and OS constants such as fds, open
   modes, errno values, stat masks, clocks, mmap flags, and sendfile limits in a
-  target-keyed platform constants registry
-- Writes ELF64 executables (Linux x86_64) and ad-hoc-signed Mach-O arm64 executables (Apple Silicon) directly without invoking `cc`, `as`, `ld`, Java, Scala, or the JVM
+  target-keyed platform constants registry; `TargetPlatform::syscall_number`
+  panics for the Windows target as a deliberate tripwire (see below)
+- Writes ELF64 executables (Linux x86_64), ad-hoc-signed Mach-O arm64 executables (Apple Silicon), and PE64 executables (Windows x86_64) directly without invoking `cc`, `as`, `ld`, Java, Scala, or the JVM
 - Current native codegen covers the first vertical slice: integer and boolean
   expressions, string literal printing, `println` / `printlnError`, `assert`,
   curried `assertResult`, `if`, `while`, mutable integer/boolean locals,
@@ -848,6 +850,41 @@ cargo run -- -e "1 + 2"
   Silicon defaults to this backend and falls back to the portable C
   backend for programs outside the direct subset; Linux x86_64 keeps
   the full-featured direct ELF backend with no fallback.
+
+  `x86_64-pc-windows-msvc` (`--target x86_64-pc-windows-msvc` /
+  `windows-x86_64`) is the one target that does *not* get its own
+  codegen module: it reuses the entire `DirectX86_64` (Linux) code
+  generator as-is, since the generated x86_64 machine code is already
+  Win64-ABI-compatible; only the OS boundary and the container format
+  differ. `NativeCodeGenerator` carries an `is_windows` flag that gates
+  every syscall-emission site (`write`, `mmap`, `exit`) to call one of
+  four small Win64 import-call shims (`__win_write`, `__win_mmap`,
+  `__win_exit`, plus a `__win_init` startup routine that caches
+  `GetStdHandle` results) instead of a bare Linux `syscall`
+  instruction, and skips the two pieces of Linux-initial-stack-layout
+  setup (`argc`/`argv`/`envp`, the `getrlimit`-based stack-overflow
+  probe) that have no Windows equivalent at this raw an entry point.
+  `TargetPlatform::syscall_number` panics unconditionally for a
+  Windows target as a compile-time tripwire, so any not-yet-gated
+  syscall path (file/dir/time/thread/stdin — out of scope for this
+  slice) fails loudly instead of silently emitting a Linux syscall
+  number into a Windows binary. Each shim forces 16-byte `rsp`
+  alignment via `and rsp, -16` before its own `call [rip+iat]`
+  regardless of how it was entered — the reused Linux codegen was
+  never written to maintain the Win64 "aligned before every call"
+  invariant, so a shim reached from deep inside a closure/GC-allocation
+  call chain can see `rsp` at either parity, and assuming a fixed
+  incoming alignment reliably crashed inside `KERNELBASE.dll` on first
+  contact. The PE64 writer is `crates/klassic-native/src/pe.rs`: a
+  minimal three-section (`.text`/`.rdata`/`.data`) unsigned image
+  importing only `GetStdHandle`/`WriteFile`/`ExitProcess`/
+  `VirtualAlloc` from `kernel32.dll`, with a fixed `ImageBase` and no
+  `.reloc` section (mirrors the "no external toolchain" property of
+  the ELF and Mach-O writers). Verified end-to-end under WSL2 binfmt
+  interop (`./program.exe` launches the real Windows loader from
+  Linux) against hello-world, recursive `def`s, string/enum/record/list
+  operations, closures, and a GC-churn stress program, all matching
+  the evaluator's output byte-for-byte.
 
   The native runtime owns a dedicated GC heap that is separate from the
   static `.data` buffers used by the rest of the codegen. At program

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -866,9 +866,8 @@ cargo run -- -e "1 + 2"
   probe) that have no Windows equivalent at this raw an entry point.
   `TargetPlatform::syscall_number` panics unconditionally for a
   Windows target as a compile-time tripwire, so any not-yet-gated
-  syscall path (file/dir/time/thread/stdin — out of scope for this
-  slice) fails loudly instead of silently emitting a Linux syscall
-  number into a Windows binary. Each shim forces 16-byte `rsp`
+  syscall path fails loudly instead of silently emitting a Linux
+  syscall number into a Windows binary. Each shim forces 16-byte `rsp`
   alignment via `and rsp, -16` before its own `call [rip+iat]`
   regardless of how it was entered — the reused Linux codegen was
   never written to maintain the Win64 "aligned before every call"
@@ -885,6 +884,35 @@ cargo run -- -e "1 + 2"
   Linux) against hello-world, recursive `def`s, string/enum/record/list
   operations, closures, and a GC-churn stress program, all matching
   the evaluator's output byte-for-byte.
+
+  Every builtin whose native codegen would otherwise reach that
+  `syscall_number` tripwire on Windows is now gated at its own
+  `compile_*` entry point (`if self.is_windows { return Err(...) }`,
+  before any codegen for that builtin runs): `sleep`, `stopwatch`,
+  `Time#nowMillis`, `StandardInput#all`/`#lines`, the whole
+  `FileOutput#`/`FileInput#` family, the whole `Dir#` family,
+  `Environment#vars`/`#get`/`#exists`, and `CommandLine#args` each
+  raise a `` `Feature` is not yet supported when targeting
+  x86_64-pc-windows-msvc `` diagnostic instead of panicking.
+  `Environment#*` and `CommandLine#args` don't reach a raw syscall at
+  all — they walk the `environment_base`/`command_line_argc`/
+  `command_line_argv1_base` slots `emit_store_command_line_state`
+  leaves zeroed on Windows — so without a gate they would silently
+  compile a binary that always observes an empty environment/argument
+  list rather than failing to build; they're gated for that "wrong
+  answer, not a crash" reason instead. Two call sites reach a subset
+  of these builtins' raw codegen a second way and needed their own
+  guard: `emit_print_expr_fragment`'s `println(FileInput#all(...))` /
+  `println(FileInput#lines(...))` / `println(FileInput#open(path, s
+  => s.readLines()))` print-fusion fast paths stream a file straight
+  to the target fd without going through `compile_file_input_all`/
+  `compile_file_input_lines`, so each fast path is itself skipped
+  when `is_windows`, falling through to the ordinary (gated) call
+  dispatch. `thread { ... }` needed no gate of its own: a queued
+  thread body is compiled into the tail of `main` via the same
+  `compile_expr` dispatch as any other call site (no real OS thread,
+  no syscall of its own), so a thread body that touches a gated
+  builtin is already caught transitively.
 
   The native runtime owns a dedicated GC heap that is separate from the
   static `.data` buffers used by the rest of the codegen. At program

--- a/docs/native-coverage.md
+++ b/docs/native-coverage.md
@@ -584,7 +584,7 @@ lands. See `docs/roadmap-targets-stdlib.md` for the wider rationale.
 | `wasm32-wasi`                  | wasm module emitter    | wasm-module   | 2    | planned     |
 | `x86_64-apple-darwin`          | portable C backend     | executable    | 2    | planned     |
 | `aarch64-apple-darwin`         | direct Mach-O writer   | executable    | 1    | supported (small subset, growing) |
-| `x86_64-pc-windows-msvc`       | portable C backend     | executable    | 2    | planned     |
+| `x86_64-pc-windows-msvc`       | direct PE64 writer (reuses DirectX86_64 codegen) | executable | 0 | supported (core language: arithmetic, if/while, recursive def, strings, enums/match, records, lists, closures, GC) |
 
 Rules:
 
@@ -596,8 +596,17 @@ Rules:
   (`aarch64-apple-darwin`) is tier 1 and uses a direct Mach-O arm64 backend
   (svc #0x80), not the portable C backend.
 - Tier 2 targets reach the matrix through the portable runtime call
-  path / C backend. x86_64 macOS and Windows reach the matrix through the
-  portable C backend.
+  path / C backend. x86_64 macOS still reaches the matrix through the
+  portable C backend. `x86_64-pc-windows-msvc` is the one deliberate
+  exception below tier 2: it reuses the entire `DirectX86_64` (Linux)
+  code generator rather than going through the C backend or getting a
+  dedicated codegen module like aarch64 -- only the OS boundary
+  (syscalls -> Win64 `kernel32.dll` import-call shims) and the
+  container format (PE64, see `crates/klassic-native/src/pe.rs`)
+  differ. Non-core-language syscalls (file/dir/time/thread/stdin, ...)
+  are not yet gated for Windows; reaching one from a Windows build is
+  a deliberate compile-time panic (see `TargetPlatform::syscall_number`)
+  rather than a silently wrong binary, and is the next slice of work.
 - An unsupported target must produce a `TargetSpec`-style diagnostic,
   not a panic.
 

--- a/docs/native-coverage.md
+++ b/docs/native-coverage.md
@@ -603,10 +603,32 @@ Rules:
   dedicated codegen module like aarch64 -- only the OS boundary
   (syscalls -> Win64 `kernel32.dll` import-call shims) and the
   container format (PE64, see `crates/klassic-native/src/pe.rs`)
-  differ. Non-core-language syscalls (file/dir/time/thread/stdin, ...)
-  are not yet gated for Windows; reaching one from a Windows build is
-  a deliberate compile-time panic (see `TargetPlatform::syscall_number`)
-  rather than a silently wrong binary, and is the next slice of work.
+  differ. `TargetPlatform::syscall_number` still panics unconditionally
+  for the Windows target as a deliberate invariant tripwire, but as of
+  W1-b every native-codegen path that could reach it is gated first:
+  `sleep`, `stopwatch`, `Time#nowMillis` (`std.time`), `StandardInput#all`/
+  `StandardInput#lines` (`stdin()`/`stdinLines()`), the `FileOutput#`/
+  `FileInput#` family including `std.file` and the `println(FileInput#
+  all(...))`/`println(FileInput#lines(...))` print-fusion fast paths,
+  the `Dir#` family including `std.dir`, `Environment#vars`/`#get`/
+  `#exists` (`std.env`, and the `env()`/`getEnv()`/`hasEnv()` prelude
+  aliases), and `CommandLine#args` (`args()`, `std.cli`, `std.process`)
+  all fail to build for `x86_64-pc-windows-msvc` with a
+  `` `Feature` is not yet supported when targeting x86_64-pc-windows-msvc ``
+  diagnostic instead of reaching the panic. `Environment#*` and
+  `CommandLine#args` are gated even though they don't reach a syscall
+  at all, because their backing argv/envp slots are left zeroed on
+  Windows (see `emit_store_command_line_state`) and would otherwise
+  silently compile a binary that always observes empty arguments/
+  environment rather than failing to build. `thread { ... }` needs no
+  gate of its own -- a queued thread body is spliced into the tail of
+  `main` and compiled through the same per-builtin gates as any other
+  call site, so an OS-touching thread body is still caught, and a
+  thread body that stays inside the core language still builds.
+  Process spawning (`Process#run`/`nrun`) has no native-backend
+  implementation on any target yet, so there is nothing Windows-specific
+  to gate there. See `tests/cli_smoke.rs`'s
+  `build_target_windows_x86_64_gates_*` tests for the coverage.
 - An unsupported target must produce a `TargetSpec`-style diagnostic,
   not a panic.
 

--- a/docs/native-coverage.md
+++ b/docs/native-coverage.md
@@ -1,8 +1,12 @@
 # Native Compiler Coverage
 
 This document enumerates the language constructs the native compiler currently
-lowers to direct ELF for Linux x86_64, selectable as `linux-x86_64`,
-`x86_64-unknown-linux-gnu`, or `native` on a matching host. Anything not listed
+lowers to direct ELF for Linux x86_64 (selectable as `linux-x86_64`,
+`x86_64-unknown-linux-gnu`), PE64 for Windows x86_64 (selectable as
+`windows-x86_64`, `x86_64-pc-windows-msvc`), and direct Mach-O arm64 for macOS
+(selectable as `macos-aarch64`, `aarch64-apple-darwin`). On matching hosts, a
+target-less bare `klassic build` defaults to the host platform (i.e., `native`);
+Windows x86_64 hosts now use the direct PE64 backend. Anything not listed
 here fails at build time rather than falling back to the evaluator.
 
 ## Core Surface

--- a/docs/roadmap-targets-stdlib.md
+++ b/docs/roadmap-targets-stdlib.md
@@ -93,12 +93,28 @@ Targets are tracked as tiers; status lives in
   parity.
 - **Tier 2** — `wasm32-wasi` (WASI imports for I/O and env, no
   threads / processes initially), `x86_64-apple-darwin` (via runtime
-  call path / C backend), `x86_64-pc-windows-msvc` (same).
+  call path / C backend).
+- **Tier 0 (direct PE64)** — `x86_64-pc-windows-msvc`: reuses the
+  entire `DirectX86_64` (Linux) codegen as-is (the generated x86_64
+  machine code is already Win64-ABI-compatible) and only swaps the OS
+  boundary (a handful of Win64 `kernel32.dll` import-call shims
+  replacing bare Linux `syscall` instructions at the `write`/`mmap`/
+  `exit` sites) and the container format (a minimal unsigned PE64
+  writer, `crates/klassic-native/src/pe.rs`, no external toolchain).
+  Non-core-language syscalls are not yet gated for Windows and remain
+  a follow-up slice (see `docs/native-coverage.md`'s target-matrix
+  notes) — reaching one from a Windows build is a deliberate
+  compile-time panic, not a silently wrong binary.
 
-The original key rule here ("no Mach-O / PE direct syscall paths")
-was revised on 2026-06-11: macOS arm64 is important enough to deserve
-a direct backend, and the C backend remains the portable fallback.
-Windows still enters through the portable runtime call path only.
+The original key rule here ("no Mach-O / PE direct syscall paths") was
+revised twice. On 2026-06-11: macOS arm64 is important enough to
+deserve a direct backend, and the C backend remains the portable
+fallback. Windows was revised again after that: rather than a
+dedicated PE codegen module mirroring aarch64's Mach-O backend,
+Windows reuses the Linux x86_64 codegen outright, since a Win64-ABI
+console program built from the same instruction stream as a Linux ELF
+program needs no new instruction encoder at all — only new OS-boundary
+plumbing and a new container writer.
 
 ## Runtime Sharing Strategy
 
@@ -111,18 +127,24 @@ the native compiler genuinely share:
   / env / fs / time / sleep / args / exit
 - C-ABI shim functions (`klassic_rt_*`) the portable backends call
 
-There are two execution paths:
+There are three execution paths:
 
 1. **Direct syscall path** — Linux x86_64 today, plus possible AArch64
    Linux additions. This path inlines syscalls into the emitted
    executable and does not link `klassic-runtime` at all. It exists
    because writing a tiny tool that has no external dependencies is
    one of Klassic's selling points; this path must stay fast and small.
-2. **Runtime call path** — macOS, Windows, Wasm, and the portable C
-   backend. The native compiler emits calls into `klassic-runtime`,
-   which is the only place that owns OS-specific behaviour. The
-   evaluator uses the same runtime crate by linking to it as a Rust
-   dependency.
+2. **Runtime call path** — macOS (x86_64) and the portable C backend.
+   The native compiler emits calls into `klassic-runtime`, which is
+   the only place that owns OS-specific behaviour. The evaluator uses
+   the same runtime crate by linking to it as a Rust dependency.
+3. **Direct OS-import path** — `aarch64-apple-darwin` (Mach-O, `svc
+   #0x80` syscalls) and `x86_64-pc-windows-msvc` (PE64, Win64
+   `kernel32.dll` import-call shims). Like path 1, no `klassic-runtime`
+   dependency and no external toolchain; unlike path 1, the OS gives
+   no raw syscall ABI to user code (Windows) or the kernel demands an
+   embedded code signature (Apple Silicon), so each target's writer
+   handles its own OS-specific obligation instead of sharing one.
 
 The evaluator should converge on the runtime crate's primitives over
 time, so evaluator and native always agree on display, equality, and

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -28725,3 +28725,397 @@ fn build_target_windows_x86_64_enum_match_runs() {
     );
     assert_eq!(String::from_utf8_lossy(&run_output.stdout), "12\n9\n");
 }
+
+/// Shared assertion for W1-b Windows-target gating (slice after
+/// W1-a's `x86_64-pc-windows-msvc` PE64 backend landed): cross-builds
+/// `source` for the Windows target and asserts the build fails with a
+/// clean, span-aware diagnostic containing `expected_diagnostic`
+/// rather than panicking. Every not-yet-Windows-gated syscall path in
+/// `klassic-native` reaches `TargetPlatform::syscall_number`'s
+/// deliberate `panic!` tripwire (see that method's doc comment in
+/// `crates/klassic-native/src/lib.rs`), so asserting the absence of
+/// "internal error" / "panicked" here is what actually distinguishes
+/// a real gate from an unguarded path that happened to hit a
+/// different early error first. Runs on any host (including Linux
+/// CI): building for the Windows target never requires executing the
+/// result.
+fn assert_windows_target_gate(unique_tag: &str, source: &str, expected_diagnostic: &str) {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_pe_gate_{unique_tag}_{stamp}.kl"));
+    let exe_path = dir.join(format!("klassic_pe_gate_{unique_tag}_{stamp}.exe"));
+    fs::write(&source_path, source).expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "x86_64-pc-windows-msvc",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            exe_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&exe_path);
+    let stderr = String::from_utf8_lossy(&build_output.stderr);
+    assert!(
+        !build_output.status.success(),
+        "windows build of gated feature ({unique_tag}) should fail to build\nstdout:\n{}\nstderr:\n{stderr}",
+        String::from_utf8_lossy(&build_output.stdout)
+    );
+    assert!(
+        !stderr.contains("internal error") && !stderr.contains("panicked"),
+        "windows build of gated feature ({unique_tag}) must fail with a clean diagnostic, not a panic\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(expected_diagnostic),
+        "windows build of gated feature ({unique_tag}) should mention {expected_diagnostic:?}\nstderr:\n{stderr}"
+    );
+}
+
+/// `sleep` reaches the `Nanosleep` syscall (`compile_sleep`) and has
+/// no Win64 shim, so it must be gated rather than panic.
+#[test]
+fn build_target_windows_x86_64_gates_sleep() {
+    assert_windows_target_gate(
+        "sleep",
+        "sleep(0)\nprintln(\"unreachable\")\n",
+        "`sleep` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+}
+
+/// `stopwatch` and `Time#nowMillis` both reach the `ClockGettime`
+/// syscall (`compile_stopwatch` / `compile_time_now_millis`) and have
+/// no Win64 shim.
+#[test]
+fn build_target_windows_x86_64_gates_time() {
+    assert_windows_target_gate(
+        "time_stopwatch",
+        "val e = stopwatch(() => 1)\nprintln(e)\n",
+        "`stopwatch` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "time_now_millis",
+        "println(Time#nowMillis())\n",
+        "`Time#nowMillis` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+}
+
+/// `StandardInput#all` / `StandardInput#lines` (and their `stdin()` /
+/// `stdinLines()` aliases) reach the `Read` syscall
+/// (`emit_standard_input_to_runtime_string`) and have no Win64 shim.
+#[test]
+fn build_target_windows_x86_64_gates_stdin() {
+    assert_windows_target_gate(
+        "stdin_all",
+        "println(StandardInput#all())\n",
+        "`StandardInput#all` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "stdin_lines",
+        "println(StandardInput#lines())\n",
+        "`StandardInput#lines` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+}
+
+/// `std.file` / `FileOutput#` / `FileInput#` reach `Open`/`Read`/
+/// `Write`/`Close`/`Unlink` (`emit_file_write*`,
+/// `emit_file_read_to_runtime_string*`, `emit_file_delete*`), none of
+/// which have a Win64 shim beyond the stdout/stderr-only `win_write`
+/// (which the file-write helpers reuse for the *shape* of the call
+/// but which would resolve to the wrong handle for a real file
+/// descriptor, so the whole operation is gated instead of only the
+/// `Open`/`Close` bookends). Also covers the `println(FileInput#all
+/// (...))` / `println(FileInput#lines(...))` /
+/// `println(FileInput#open(path, s => s.readLines()))` print-fusion
+/// fast paths in `emit_print_expr_fragment`, which stream straight to
+/// the target fd and would otherwise bypass the
+/// `compile_file_input_all` / `compile_file_input_lines` gates.
+#[test]
+fn build_target_windows_x86_64_gates_file() {
+    assert_windows_target_gate(
+        "file_write",
+        "FileOutput#write(\"a.txt\", \"hi\")\n",
+        "`FileOutput#write` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "file_append",
+        "FileOutput#append(\"a.txt\", \"hi\")\n",
+        "`FileOutput#append` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "file_write_lines",
+        "FileOutput#writeLines(\"a.txt\", [\"x\"])\n",
+        "`FileOutput#writeLines` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "file_exists",
+        "println(FileOutput#exists(\"a.txt\"))\n",
+        "`FileOutput#exists` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "file_delete",
+        "FileOutput#delete(\"a.txt\")\n",
+        "`FileOutput#delete` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "file_input_all",
+        "println(FileInput#all(\"Cargo.toml\"))\n",
+        "`FileInput#all` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "file_input_read_all",
+        "println(FileInput#readAll(\"Cargo.toml\"))\n",
+        "`FileInput#all` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "file_input_lines",
+        "println(FileInput#lines(\"Cargo.toml\"))\n",
+        "`FileInput#lines` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "file_input_read_lines",
+        "println(FileInput#readLines(\"Cargo.toml\"))\n",
+        "`FileInput#lines` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    // Print-fusion fast paths in `emit_print_expr_fragment` that
+    // bypass the plain `FileInput#all`/`FileInput#lines` call
+    // dispatch entirely -- these must be independently confirmed
+    // gated, not just the plain-call form above.
+    assert_windows_target_gate(
+        "file_input_all_print_fusion",
+        "println(FileInput#all(\"Cargo.toml\"))\n",
+        "`FileInput#all` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "file_input_lines_print_fusion",
+        "println(FileInput#lines(\"Cargo.toml\"))\n",
+        "`FileInput#lines` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "file_input_open_print_fusion",
+        "println(FileInput#open(\"Cargo.toml\", (stream) => FileInput#readLines(stream)))\n",
+        "`FileInput#lines` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+}
+
+/// `std.dir` / `Dir#*` reach `Getcwd`/`Access`/`Newfstatat`/`Mkdir`/
+/// `Rmdir`/`Rename`/`Open`/`Getdents64`/`Close`/`Sendfile` (or, for
+/// `home`/`temp`, the argv/envp startup slots W1-a leaves zeroed on
+/// Windows -- see `emit_store_command_line_state` -- which would
+/// otherwise silently return `"/tmp"` for `Dir#temp` or a spurious
+/// "not set" runtime error for `Dir#home` instead of a compile-time
+/// diagnostic), none of which have a Win64 shim.
+#[test]
+fn build_target_windows_x86_64_gates_dir() {
+    assert_windows_target_gate(
+        "dir_current",
+        "println(Dir#current())\n",
+        "`Dir#current` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "dir_home",
+        "println(Dir#home())\n",
+        "`Dir#home` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "dir_temp",
+        "println(Dir#temp())\n",
+        "`Dir#temp` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "dir_exists",
+        "println(Dir#exists(\"src\"))\n",
+        "`Dir#exists` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "dir_is_directory",
+        "println(Dir#isDirectory(\"src\"))\n",
+        "`Dir#isDirectory` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "dir_is_file",
+        "println(Dir#isFile(\"Cargo.toml\"))\n",
+        "`Dir#isFile` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "dir_mkdir",
+        "Dir#mkdir(\"newdir\")\n",
+        "`Dir#mkdir` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "dir_mkdirs",
+        "Dir#mkdirs(\"a/b/c\")\n",
+        "`Dir#mkdirs` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "dir_list",
+        "println(Dir#list(\"src\"))\n",
+        "`Dir#list` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "dir_list_full",
+        "println(Dir#listFull(\"src\"))\n",
+        "`Dir#listFull` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "dir_delete",
+        "Dir#delete(\"newdir\")\n",
+        "`Dir#delete` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "dir_copy",
+        "Dir#copy(\"a.txt\", \"b.txt\")\n",
+        "`Dir#copy` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "dir_move",
+        "Dir#move(\"a.txt\", \"b.txt\")\n",
+        "`Dir#move` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+}
+
+/// `Environment#vars` / `Environment#get` / `Environment#exists` (and
+/// the `env()` / `getEnv()` / `hasEnv()` prelude aliases, plus
+/// `std.env`) all walk the `environment_base` linked block that W1-a
+/// leaves zeroed on Windows (see `emit_store_command_line_state`) --
+/// unlike the syscall-backed families above, an ungated build of
+/// these would not panic at all, it would silently compile a binary
+/// where `Environment#vars()` is always `[]`, `Environment#exists`
+/// is always `false`, and `Environment#get` always raises the
+/// "missing environment variable" runtime error, so this is the
+/// "produces wrong results without syscalls" case called out
+/// alongside `CommandLine#args` below.
+#[test]
+fn build_target_windows_x86_64_gates_environment() {
+    assert_windows_target_gate(
+        "env_vars",
+        "println(Environment#vars())\n",
+        "`Environment#vars` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "env_get",
+        "println(Environment#get(\"PATH\"))\n",
+        "`Environment#get` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+    assert_windows_target_gate(
+        "env_exists",
+        "println(Environment#exists(\"PATH\"))\n",
+        "`Environment#exists` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+}
+
+/// `CommandLine#args` (and the `args()` prelude alias, plus
+/// `std.process.args`/`std.cli`) walks the argc/argv1 startup slots
+/// W1-a leaves zeroed on Windows (see
+/// `emit_store_command_line_state`), so an ungated build would
+/// silently compile a binary where `CommandLine#args()` is always
+/// `[]` instead of failing to build.
+#[test]
+fn build_target_windows_x86_64_gates_command_line_args() {
+    assert_windows_target_gate(
+        "command_line_args",
+        "println(CommandLine#args())\n",
+        "`CommandLine#args` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+}
+
+/// `thread { ... }` (`compile_thread`/`emit_queued_threads`) itself
+/// never reaches a syscall: unlike a real OS thread, a queued
+/// `thread` body is compiled straight into the tail of `main` and run
+/// serially before exit, so it needs no per-target gate of its own --
+/// confirmed here by asserting a `thread` body that touches no OS
+/// feature builds successfully for Windows. A `thread` body that
+/// *does* use a gated feature is caught transitively through that
+/// feature's own gate, confirmed by the second half of this test
+/// (`emit_queued_threads` calls `compile_expr` on the body, which
+/// dispatches through the same gated `compile_file_output_write` as
+/// any other call site).
+#[test]
+fn build_target_windows_x86_64_thread_gate_is_transitive() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_pe_thread_ok_{stamp}.kl"));
+    let exe_path = dir.join(format!("klassic_pe_thread_ok_{stamp}.exe"));
+    fs::write(
+        &source_path,
+        "mutable x = 1\nthread(() => { x = x + 1 })\nprintln(x)\n",
+    )
+    .expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "x86_64-pc-windows-msvc",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            exe_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&exe_path);
+    assert!(
+        build_output.status.success(),
+        "a thread body touching no OS feature should build for windows\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+
+    assert_windows_target_gate(
+        "thread_file_io",
+        "thread(() => { FileOutput#write(\"a.txt\", \"hi\") })\n",
+        "`FileOutput#write` is not yet supported when targeting x86_64-pc-windows-msvc",
+    );
+}
+
+/// Positive control for every gate above: importing a `std.*` module
+/// and calling only its pure helpers (no OS feature) must still build
+/// for Windows. `std.time`'s `formatIso`/`durationMillis` operate on
+/// an already-materialized epoch-millis integer and never call
+/// `Time#nowMillis` themselves, so this is a real "import without
+/// use" case rather than a trivially-empty program (`std.cli`'s
+/// otherwise-equally-pure `flag`/`option`/`positionals` were tried
+/// here first, but they hit an unrelated pre-existing native-compiler
+/// limitation -- "native recursive function requiring call-site
+/// inlining is not supported" -- on every target, including Linux, so
+/// they are not a usable positive control).
+#[test]
+fn build_target_windows_x86_64_pure_stdlib_use_is_not_gated() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_pe_pure_stdlib_{stamp}.kl"));
+    let exe_path = dir.join(format!("klassic_pe_pure_stdlib_{stamp}.exe"));
+    fs::write(
+        &source_path,
+        "import std.time\nprintln(formatIso(0))\nprintln(durationMillis(100, 250))\n",
+    )
+    .expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "x86_64-pc-windows-msvc",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            exe_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&exe_path);
+    assert!(
+        build_output.status.success(),
+        "std.cli pure-helper use should build for windows without tripping any OS-feature gate\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+}

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -28263,3 +28263,465 @@ fn process_run_captures_stdout_and_exit_codes() {
         "hello\n\n0\n-1\ntrue\n()\n"
     );
 }
+
+/// The Windows target reuses the entire DirectX86_64 (Linux) codegen
+/// (see `NativeCodeGenerator::is_windows` in `klassic-native`) and
+/// only swaps the OS boundary and the container format, so this
+/// structurally validates the PE64 bytes `pe::write_executable`
+/// produces without executing them -- runs on any host, including
+/// Linux CI. Actual execution is asserted by the
+/// `target_os = "windows"`-gated tests below. Mirrors the core of
+/// report-pe-spec.md's section 7 validation checklist.
+#[test]
+fn build_target_windows_x86_64_emits_pe() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_pe_{stamp}.kl"));
+    let exe_path = dir.join(format!("klassic_pe_{stamp}.exe"));
+    fs::write(&source_path, "println(\"hello windows\")\nprintln(7)\n")
+        .expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "x86_64-pc-windows-msvc",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            exe_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build_output.status.success(),
+        "windows cross build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+    let image = fs::read(&exe_path).expect("output should exist");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&exe_path);
+
+    let u16_at = |offset: usize| u16::from_le_bytes(image[offset..offset + 2].try_into().unwrap());
+    let u32_at = |offset: usize| u32::from_le_bytes(image[offset..offset + 4].try_into().unwrap());
+    let u64_at = |offset: usize| u64::from_le_bytes(image[offset..offset + 8].try_into().unwrap());
+
+    // 1: MZ + e_lfanew -> "PE\0\0".
+    assert_eq!(&image[0..2], b"MZ");
+    let e_lfanew = u32_at(0x3c) as usize;
+    assert!(e_lfanew + 4 <= image.len());
+    assert_eq!(&image[e_lfanew..e_lfanew + 4], b"PE\0\0");
+
+    let coff = e_lfanew + 4;
+    // 2: COFF.Machine == IMAGE_FILE_MACHINE_AMD64.
+    assert_eq!(u16_at(coff), 0x8664);
+    let number_of_sections = u16_at(coff + 2) as usize;
+    let size_of_optional_header = u16_at(coff + 16);
+    let characteristics = u16_at(coff + 18);
+    // RELOCS_STRIPPED | EXECUTABLE_IMAGE | LARGE_ADDRESS_AWARE.
+    assert_eq!(characteristics, 0x0023);
+
+    let opt = coff + 20;
+    // 4: PE32+ optional header magic (not PE32's 0x010b).
+    assert_eq!(u16_at(opt), 0x020b);
+    let number_of_rva_and_sizes = u32_at(opt + 108);
+    // 3, 5: header-size / data-directory-count consistency.
+    assert_eq!(number_of_rva_and_sizes, 16);
+    assert_eq!(
+        size_of_optional_header as u32,
+        112 + 8 * number_of_rva_and_sizes
+    );
+
+    let image_base = u64_at(opt + 24);
+    // 6: ImageBase 64 KiB aligned.
+    assert_eq!(image_base, 0x1_4000_0000);
+    assert_eq!(image_base % 0x10000, 0);
+
+    let section_alignment = u32_at(opt + 32) as u64;
+    let file_alignment = u32_at(opt + 36) as u64;
+    // 7: alignment sanity.
+    assert!(file_alignment.is_power_of_two() && file_alignment >= 0x200);
+    assert!(section_alignment.is_power_of_two() && section_alignment > file_alignment);
+
+    let size_of_image = u32_at(opt + 56) as u64;
+    let size_of_headers = u32_at(opt + 60) as u64;
+    let subsystem = u16_at(opt + 68);
+    // 20: console subsystem.
+    assert_eq!(subsystem, 3);
+
+    let entry_rva = u32_at(opt + 16) as u64;
+
+    let data_dir = opt + 112;
+    let import_dir_va = u32_at(data_dir + 8) as u64;
+    let import_dir_size = u32_at(data_dir + 12);
+    // 13: import data directory populated, sized for exactly one DLL
+    // descriptor plus its null terminator.
+    assert_ne!(import_dir_va, 0);
+    assert_ne!(import_dir_size, 0);
+    assert_eq!(import_dir_size % 20, 0);
+    assert_eq!(import_dir_size, 40);
+    // IAT data directory (index 12) is deliberately left {0,0}.
+    assert_eq!(u32_at(data_dir + 12 * 8), 0);
+    assert_eq!(u32_at(data_dir + 12 * 8 + 4), 0);
+
+    let section_table = opt + size_of_optional_header as usize;
+    struct Section {
+        va: u64,
+        virtual_size: u64,
+        raw_size: u64,
+        raw_ptr: u64,
+        characteristics: u32,
+    }
+    let mut sections = Vec::new();
+    for i in 0..number_of_sections {
+        let off = section_table + i * 40;
+        sections.push(Section {
+            virtual_size: u32_at(off + 8) as u64,
+            va: u32_at(off + 12) as u64,
+            raw_size: u32_at(off + 16) as u64,
+            raw_ptr: u32_at(off + 20) as u64,
+            characteristics: u32_at(off + 36),
+        });
+    }
+    assert_eq!(sections.len(), 3);
+
+    // 8, 9: every section's VA/PointerToRawData aligned, sections
+    // ascending and non-overlapping.
+    for (i, section) in sections.iter().enumerate() {
+        assert_eq!(
+            section.va % section_alignment,
+            0,
+            "section {i} VA misaligned"
+        );
+        assert_eq!(
+            section.raw_ptr % file_alignment,
+            0,
+            "section {i} PointerToRawData misaligned"
+        );
+        if i > 0 {
+            let previous = &sections[i - 1];
+            let previous_end = previous.va + align_up(previous.virtual_size, section_alignment);
+            assert!(
+                previous_end <= section.va,
+                "sections must be ascending and non-overlapping"
+            );
+        }
+    }
+
+    // 10: SizeOfImage exactly covers the last section.
+    let last = sections.last().expect("at least one section");
+    assert_eq!(
+        size_of_image,
+        align_up(last.va + last.virtual_size, section_alignment)
+    );
+
+    // 11: headers sized/aligned correctly and don't overlap the first
+    // section's raw data; first section starts at RVA
+    // `section_alignment` since headers are far smaller than one unit.
+    assert_eq!(size_of_headers % file_alignment, 0);
+    assert!(size_of_headers <= sections[0].raw_ptr);
+    assert_eq!(sections[0].va, section_alignment);
+
+    // 12: entry point lands inside an executable section.
+    const IMAGE_SCN_MEM_EXECUTE: u32 = 0x2000_0000;
+    let entry_section = sections
+        .iter()
+        .find(|s| entry_rva >= s.va && entry_rva < s.va + s.virtual_size)
+        .expect("entry point should be inside a section");
+    assert_ne!(entry_section.characteristics & IMAGE_SCN_MEM_EXECUTE, 0);
+
+    // 15-17: import directory descriptor, ILT/IAT, and hint/name
+    // entries resolve to valid in-bounds, readable data.
+    let rva_to_file_offset = |rva: u64| -> Option<usize> {
+        sections.iter().find_map(|s| {
+            if rva >= s.va && rva < s.va + s.virtual_size {
+                Some((s.raw_ptr + (rva - s.va)) as usize)
+            } else {
+                None
+            }
+        })
+    };
+    let descriptor_off = rva_to_file_offset(import_dir_va).expect("import dir should be mapped");
+    let original_first_thunk = u32_at(descriptor_off) as u64;
+    let name_rva = u32_at(descriptor_off + 12) as u64;
+    let first_thunk = u32_at(descriptor_off + 16) as u64;
+    // 14: the descriptor at the end of the sized array is the
+    // all-zero terminator.
+    let terminator_off =
+        rva_to_file_offset(import_dir_va).unwrap() + (import_dir_size as usize - 20);
+    assert_eq!(&image[terminator_off..terminator_off + 20], &[0u8; 20]);
+
+    let name_off = rva_to_file_offset(name_rva).expect("DLL name should be mapped");
+    let nul = image[name_off..].iter().position(|&b| b == 0).unwrap();
+    assert_eq!(&image[name_off..name_off + nul], b"KERNEL32.DLL");
+
+    assert_ne!(original_first_thunk, 0);
+    assert_ne!(first_thunk, 0);
+    let ilt_off = rva_to_file_offset(original_first_thunk).expect("ILT should be mapped");
+    let iat_off = rva_to_file_offset(first_thunk).expect("IAT should be mapped");
+    let mut ilt_names = Vec::new();
+    let mut iat_names = Vec::new();
+    for (table_off, names) in [(ilt_off, &mut ilt_names), (iat_off, &mut iat_names)] {
+        let mut i = 0;
+        loop {
+            let thunk = u64_at(table_off + i * 8);
+            if thunk == 0 {
+                break;
+            }
+            // 17: non-ordinal (bit 63 clear), hint/name RVA in bounds.
+            assert_eq!(thunk >> 63, 0);
+            let hint_name_off = rva_to_file_offset(thunk).expect("hint/name should be mapped");
+            let name_start = hint_name_off + 2; // skip the WORD hint
+            let name_end = image[name_start..]
+                .iter()
+                .position(|&b| b == 0)
+                .map(|len| name_start + len)
+                .expect("hint/name entry should be NUL-terminated");
+            names.push(String::from_utf8_lossy(&image[name_start..name_end]).into_owned());
+            i += 1;
+        }
+    }
+    // 16: ILT and IAT agree on count and order.
+    assert_eq!(ilt_names, iat_names);
+    assert_eq!(
+        ilt_names,
+        vec!["GetStdHandle", "WriteFile", "ExitProcess", "VirtualAlloc"]
+    );
+
+    // 19: RELOCS_STRIPPED implies no .reloc / DYNAMIC_BASE.
+    assert_eq!(u32_at(data_dir + 5 * 8), 0);
+    assert_eq!(u32_at(data_dir + 5 * 8 + 4), 0);
+    let dll_characteristics = u16_at(opt + 70);
+    assert_eq!(dll_characteristics & 0x0040, 0);
+
+    // 21: the file is not truncated.
+    let last_end = last.raw_ptr + last.raw_size;
+    assert!(image.len() as u64 >= size_of_headers);
+    assert!(image.len() as u64 >= last_end);
+}
+
+fn align_up(value: u64, alignment: u64) -> u64 {
+    value.div_ceil(alignment) * alignment
+}
+
+/// Shared middle-end regression guard for the Windows target, mirrored
+/// on `build_target_aarch64_apple_darwin_enum_cross_build`: runs on
+/// any host (including fast Linux CI) and exercises the constructs
+/// most likely to leak a shared-pass artifact the Windows codegen
+/// path doesn't understand (see the aarch64
+/// `__enum_shape_named`/`__enum_shape_hint` incident this pattern was
+/// modeled on) -- Int/Bool/String arithmetic, if/while, an annotated
+/// recursive def, string concat/interpolation, enum+match, records,
+/// and lists.
+#[test]
+fn build_target_windows_x86_64_cross_build_core_language() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_pe_core_{stamp}.kl"));
+    let exe_path = dir.join(format!("klassic_pe_core_{stamp}.exe"));
+    fs::write(
+        &source_path,
+        "def fib(n: Int): Int = if (n < 2) n else fib(n - 1) + fib(n - 2)\n\
+         val a = 3\n\
+         val b = 4\n\
+         println(a + b)\n\
+         println(a < b)\n\
+         mutable i = 0\n\
+         mutable total = 0\n\
+         while (i < 5) {\n\
+           total = total + i\n\
+           i = i + 1\n\
+         }\n\
+         println(total)\n\
+         println(fib(10))\n\
+         val name = \"Klassic\"\n\
+         println(\"hi \" + name + \"!\")\n\
+         println(\"len=#{name.length()}\")\n\
+         enum Shape { case Circle(radius: Int); case Square(side: Int) }\n\
+         def area(s: Shape): Int = s match { case Circle(r) => 3 * r * r; case Square(side) => side * side }\n\
+         println(area(Circle(2)))\n\
+         println(area(Square(3)))\n\
+         record Point { x: Int; y: Int }\n\
+         val p = #Point(1, 2)\n\
+         println(p.x + p.y)\n\
+         val xs = [1 2 3 4 5]\n\
+         println(xs.size())\n",
+    )
+    .expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "x86_64-pc-windows-msvc",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            exe_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&exe_path);
+    assert!(
+        build_output.status.success(),
+        "windows core-language cross build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+}
+
+/// Executes the generated `.exe` directly (this test only compiles
+/// and runs on a Windows CI host -- there is no WSL2-style interop
+/// path on `cfg(target_os = "windows")` runners, `Command::output`
+/// launches it natively) and asserts its stdout matches the
+/// evaluator's output byte-for-byte, mirroring
+/// `build_target_aarch64_apple_darwin_binary_runs`.
+#[cfg(target_os = "windows")]
+#[test]
+fn build_target_windows_x86_64_hello_runs() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_pe_hello_{stamp}.kl"));
+    let exe_path = dir.join(format!("klassic_pe_hello_{stamp}.exe"));
+    fs::write(
+        &source_path,
+        "println(\"hello from klassic on windows\")\nprintln(42)\n",
+    )
+    .expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "x86_64-pc-windows-msvc",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            exe_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build_output.status.success(),
+        "windows native build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+    let run_output = Command::new(&exe_path)
+        .output()
+        .expect("generated PE64 should execute");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&exe_path);
+    assert!(
+        run_output.status.success(),
+        "PE64 exited with {:?}\nstderr:\n{}",
+        run_output.status,
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run_output.stdout),
+        "hello from klassic on windows\n42\n"
+    );
+}
+
+/// Recursive `def` and deep call depth on the Windows target: fib(20)
+/// asserted against the well-known value (also matches the
+/// evaluator).
+#[cfg(target_os = "windows")]
+#[test]
+fn build_target_windows_x86_64_fib_runs() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_pe_fib_{stamp}.kl"));
+    let exe_path = dir.join(format!("klassic_pe_fib_{stamp}.exe"));
+    fs::write(
+        &source_path,
+        "def fib(n: Int): Int = if (n < 2) n else fib(n - 1) + fib(n - 2)\nprintln(fib(20))\n",
+    )
+    .expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "x86_64-pc-windows-msvc",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            exe_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build_output.status.success(),
+        "windows fib build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+    let run_output = Command::new(&exe_path)
+        .output()
+        .expect("generated PE64 should execute");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&exe_path);
+    assert!(
+        run_output.status.success(),
+        "PE64 exited with {:?}\nstderr:\n{}",
+        run_output.status,
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&run_output.stdout), "6765\n");
+}
+
+/// Monomorphic enum construction + `match` on the Windows target,
+/// asserted against the evaluator's output -- the same construct the
+/// aarch64 shared-middle-end incident (see
+/// `build_target_aarch64_apple_darwin_enum_cross_build`) was about.
+#[cfg(target_os = "windows")]
+#[test]
+fn build_target_windows_x86_64_enum_match_runs() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_pe_enum_{stamp}.kl"));
+    let exe_path = dir.join(format!("klassic_pe_enum_{stamp}.exe"));
+    fs::write(
+        &source_path,
+        "enum Shape { case Circle(radius: Int); case Square(side: Int) }\n\
+         def area(s: Shape): Int = s match { case Circle(r) => 3 * r * r; case Square(side) => side * side }\n\
+         println(area(Circle(2)))\n\
+         println(area(Square(3)))\n",
+    )
+    .expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "x86_64-pc-windows-msvc",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            exe_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build_output.status.success(),
+        "windows enum build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+    let run_output = Command::new(&exe_path)
+        .output()
+        .expect("generated PE64 should execute");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&exe_path);
+    assert!(
+        run_output.status.success(),
+        "PE64 exited with {:?}\nstderr:\n{}",
+        run_output.status,
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&run_output.stdout), "12\n9\n");
+}

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -27016,6 +27016,7 @@ fn build_without_target_produces_runnable_host_binary() {
 /// char-indexed substring/at, concat, equality, toString. The test
 /// compiles and links through the automatic cc path and compares
 /// against the evaluator's output.
+#[cfg(unix)]
 #[test]
 fn build_backend_c_strings_match_the_evaluator() {
     let cc_available = Command::new("cc")
@@ -27089,6 +27090,7 @@ fn build_backend_c_strings_match_the_evaluator() {
 /// runtime shim used `f64::to_string`, so a whole-number Double printed
 /// as `4` while the evaluator (and the direct native backend) printed
 /// `4.0`.
+#[cfg(unix)]
 #[test]
 fn build_backend_c_formats_doubles_like_evaluator() {
     let cc_available = Command::new("cc")
@@ -27164,6 +27166,7 @@ fn build_backend_c_formats_doubles_like_evaluator() {
 /// only on stdio/stdint; when a `cc` is available the test compiles
 /// and runs it and asserts evaluator-identical output. Unsupported
 /// constructs get source-located diagnostics.
+#[cfg(unix)]
 #[test]
 fn build_backend_c_emits_compilable_c() {
     let stamp = SystemTime::now()


### PR DESCRIPTION
## Summary

Promotes `x86_64-pc-windows-msvc` from a tier-2 "planned / portable-c" entry to a **tier-0 supported direct backend** — Klassic now cross-builds real Windows console executables from any host, with no external toolchain (no cc/link.exe), mirroring the aarch64-apple-darwin precedent. This is the second owner-ordered revision of the "no direct PE" roadmap rule; the revision is documented in `docs/roadmap-targets-stdlib.md`.

### Architecture: reuse the whole DirectX86_64 codegen

Unlike the Mach-O/aarch64 backend (new ISA → new codegen module), Windows x64 shares the ISA, the internal function ABI is self-defined (rbp-relative slots, no System V coupling), and every data reference is `mov imm64` + `Abs64` reloc — so the entire existing codegen (enums, generics, GC, closures, records, lists, strings, match) works on Windows unchanged. Only the OS boundary differs:

- **`crates/klassic-native/src/pe.rs`** (new): minimal unsigned PE32+ writer — fixed ImageBase, no `.reloc`, `.text`/`.rdata`/`.data`, hand-built `kernel32.dll` import directory/ILT/IAT (`GetStdHandle`, `WriteFile`, `ExitProcess`, `VirtualAlloc`).
- **Win64 shims** (`__win_init`/`__win_write`/`__win_mmap`/`__win_exit`), emitted only for Windows: self-aligning, full GP save/restore, 32-byte shadow space, `FF 15` calls through the IAT. They accept arguments in the same registers the Linux syscall staging already uses, so each of the 16 write/mmap/exit sites is a two-line branch; the Linux path is byte-for-byte unchanged.
- **Startup**: caches stdout/stderr handles, zeroes argc/argv/env slots, disables the getrlimit stack probe.
- **Everything else OS-shaped** (sleep, time, stdin, file, dir, env, args) fails with a clean span-aware diagnostic: `` `X` is not yet supported when targeting x86_64-pc-windows-msvc `` — backed by a compile-time panic tripwire in `syscall_number` so a missed gate can never produce a silently wrong binary. A real bypass (println/FileInput print-fusion fast paths) was found and closed during this work.

### Bugs found in the shared encoder

`store_ptr_disp32`/`load_ptr_disp32` were missing the SIB byte for `rsp`-based operands (latent — nothing used rsp/r12 as a base before the shims; r12 is still unused, so Linux output is unaffected).

### Verification

- **Real Windows 11 execution via WSL2 interop**: hello, fib, strings/interpolation, enums+match, records, lists, closures, a 100k-iteration GC-churn program, and a ~262k-node tree stress program — all stdout **byte-identical to the evaluator** (eval is the oracle).
- Ungated Linux tests: full PE structural validation (headers, alignments, import tables, section layout) + core-language cross-build guard + 9 gate-family diagnostics tests + positive control.
- `#[cfg(target_os = "windows")]` execution tests run on the new `test-windows` CI job (windows-latest), mirroring how test-macos executes the Mach-O backend.
- `cargo fmt --check` / `cargo clippy -D warnings` clean, **716 passed / 0 failed** locally (703 baseline + 13 new).

## Test plan

- [x] Local: full suite green, Linux backend byte-identical (R12 audit + existing 703 tests)
- [x] Local: Windows executables verified on real Windows 11 (WSL interop), differential vs evaluator
- [ ] CI: ubuntu + macos + **windows-latest** all green (windows job runs the gated execution tests; also first-ever `cargo test` of the whole workspace on Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)