### PR TITLE
chore: prepare the v0.4.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,13 @@
 # Tagging vX.Y.Z builds release binaries — a statically-linked Linux
 # binary (musl, so it runs on any x86_64 Linux without a Rust
-# toolchain) and macOS binaries for Apple Silicon and Intel — and
-# attaches them to a GitHub Release. Keep Cargo.toml's `version` in
-# sync with the tag so `klassic --version` matches the release.
+# toolchain), macOS binaries for Apple Silicon and Intel, and a
+# Windows x86_64 klassic.exe — and attaches them to a GitHub Release.
+# Keep Cargo.toml's `version` in sync with the tag so
+# `klassic --version` matches the release. The release body comes from
+# docs/release-notes/<tag>.md via the release-notes job (the asset
+# jobs deliberately do not generate notes: with several jobs updating
+# one release, generate_release_notes appended the changelog once per
+# job — v0.3.0's body has it twice).
 name: Release
 
 on:
@@ -53,7 +58,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: klassic-*.tar.gz
-          generate_release_notes: true
 
   # macOS: the evaluator, REPL, and C backend run on macOS as-is (the
   # direct ELF backend stays Linux-only). The arm64 runner also
@@ -96,4 +100,61 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: klassic-*.tar.gz
-          generate_release_notes: true
+
+  # Windows: the direct x86_64-pc-windows-msvc PE64 backend needs no
+  # external toolchain, so `klassic build` on Windows produces a
+  # native .exe out of the box. The C backend's host-link path is not
+  # wired for MSVC (find_runtime_staticlib looks for
+  # libklassic_runtime.a and link_c_program only searches
+  # cc/clang/gcc), so this job ships klassic.exe alone rather than a
+  # staticlib nothing can consume yet.
+  release-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Build runtime staticlib
+        # Kept for shape-parity with the other jobs; the C-backend
+        # link tests are #[cfg(unix)]-gated so it is not load-bearing
+        # on this runner today.
+        run: cargo build -p klassic-runtime
+
+      - name: Test
+        run: cargo test
+
+      - name: Build binary
+        run: cargo build --release --target x86_64-pc-windows-msvc
+
+      - name: Package
+        shell: pwsh
+        run: |
+          Copy-Item target\x86_64-pc-windows-msvc\release\klassic.exe klassic.exe
+          Compress-Archive -Path klassic.exe -DestinationPath "klassic-$env:GITHUB_REF_NAME-x86_64-pc-windows-msvc.zip"
+
+      - name: Create release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: klassic-*.zip
+
+  # Sets the curated release body exactly once, after every asset job
+  # has attached its files. Cutting a release therefore requires
+  # docs/release-notes/<tag>.md to exist — write it before tagging.
+  release-notes:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [release-linux, release-macos, release-windows]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set release body
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: docs/release-notes/${{ github.ref_name }}.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "klassic"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "klassic-eval",
  "klassic-native",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "klassic"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 default-run = "klassic"
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,16 @@ Rust. The implementation builds a native `klassic` executable with Cargo.
   `std.math`, `std.option`, `std.result`, `std.map`, `std.set`, `std.json`,
   `std.time`, and more
 - Native CLI and a REPL that echoes every value with its inferred type
-- Direct-to-ELF native compiler (no `cc`/`as`/`ld`) with by-pointer calling
-  conventions for enums and strings, a stack-overflow probe, and
-  compile-time-budgeted constant folding
+- Direct-to-native-executable compiler (no `cc`/`as`/`ld`) targeting Linux
+  x86_64 (ELF64), Apple Silicon macOS (ad-hoc-signed Mach-O arm64), and
+  Windows x86_64 (PE64), with by-pointer calling conventions for enums and
+  strings, a stack-overflow probe, and compile-time-budgeted constant folding
 - Portable C backend (`--backend c`) emitting a single C99 translation unit
   for a growing subset
 - Precise mark-and-sweep garbage collector with multi-segment heap growth and
   mmap-backed tables, exposed through 68 `__gc_*` debug builtins
 - Release automation: tagged pushes publish statically-linked Linux binaries
+  plus macOS (Apple Silicon and Intel) and Windows x86_64 binaries
 - Standalone Rust macro PEG subsystem
 
 ## Install
@@ -47,7 +49,7 @@ The installer detects your platform, downloads the latest
 [release](https://github.com/klassic/klassic/releases) into
 `~/.klassic/bin` (binary plus `libklassic_runtime.a` for the C
 backend), and verifies the install by running a Klassic program with
-it. Set `KLASSIC_VERSION=v0.3.0` to pin a release, `KLASSIC_HOME` to
+it. Set `KLASSIC_VERSION=v0.4.0` to pin a release, `KLASSIC_HOME` to
 change the install root. The Linux build is statically linked (musl)
 and runs on any x86_64 Linux.
 
@@ -59,11 +61,34 @@ outside its (growing) subset fall back to the portable C backend
 (the system `cc` links against the bundled runtime). Anything beyond
 both paths runs with `klassic program.kl`.
 
+On Windows, download `klassic-<version>-x86_64-pc-windows-msvc.zip`
+from the [releases page](https://github.com/klassic/klassic/releases),
+extract `klassic.exe`, and put it on `PATH`. The evaluator, REPL, and
+`klassic build` all work out of the box: `klassic build` on a Windows
+host targets `x86_64-pc-windows-msvc` automatically and the direct
+PE64 backend compiles with no external toolchain (no Visual Studio,
+MSVC, or WSL required). The Windows zip ships `klassic.exe` alone —
+`libklassic_runtime.a` is not bundled, so `--backend c` needs a
+source build with a C compiler available.
+
 Alternatively, build from source with Cargo:
 
 ```bash
 cargo install --git https://github.com/klassic/klassic
 ```
+
+### Platform matrix
+
+| | Evaluator / REPL | `klassic build` (as host) | `klassic build --target ...` (cross-build) |
+| --- | --- | --- | --- |
+| Linux x86_64 | yes | direct ELF64 (most complete) | `linux-x86_64` / `x86_64-unknown-linux-gnu` |
+| macOS arm64 (Apple Silicon) | yes | direct Mach-O arm64, portable-C fallback | `macos-aarch64` / `aarch64-apple-darwin` (from any host) |
+| macOS x86_64 (Intel) | yes | portable C backend (needs Xcode CLT's `cc`) | via portable C backend |
+| Windows x86_64 | yes | direct PE64 (core language plus full OS-builtin coverage; ANSI-only paths/env) | `windows-x86_64` / `x86_64-pc-windows-msvc` (from any host) |
+
+`klassic targets` prints the live matrix, including the still-planned
+tier 1/2 targets (`x86_64-unknown-linux-musl`,
+`aarch64-unknown-linux-gnu`, `wasm32-wasi`).
 
 ## Build And Test
 
@@ -107,10 +132,11 @@ klassic build path/to/program.kl -o program
 ```
 
 Pass `--target` to select a target explicitly — `linux-x86_64` /
-`x86_64-unknown-linux-gnu` (direct ELF) and `macos-aarch64` /
-`aarch64-apple-darwin` (direct signed Mach-O, cross-buildable from any
-host) are the implemented direct targets; `--target native` picks the
-host's. `klassic targets` lists the full matrix.
+`x86_64-unknown-linux-gnu` (direct ELF), `macos-aarch64` /
+`aarch64-apple-darwin` (direct signed Mach-O), and `windows-x86_64` /
+`x86_64-pc-windows-msvc` (direct PE64) are the implemented direct
+targets, all cross-buildable from any host; `--target native` picks
+the host's. `klassic targets` lists the full matrix.
 
 Emit portable C instead of an ELF executable:
 
@@ -158,7 +184,10 @@ language surface; Apple Silicon macOS (`macos-aarch64` /
 `aarch64-apple-darwin`) emits ad-hoc-signed Mach-O arm64 for a growing subset
 (Int/Bool/String expressions, locals, control flow, functions with recursion,
 string builtins, monomorphic enums and match, cons lists, records, sets with
-method dispatch). Linux x86_64 highlights:
+method dispatch); Windows x86_64 (`windows-x86_64` / `x86_64-pc-windows-msvc`)
+emits PE64 by reusing the entire Linux x86_64 codegen (only the OS boundary
+and container format differ), so it matches Linux x86_64's core-language
+coverage plus full OS-builtin coverage. Linux x86_64 highlights:
 
 - Core integer / boolean / string / list expressions, control flow, and
   recursive `def`s (including annotated `String` and `List<String>` parameters).
@@ -172,6 +201,11 @@ method dispatch). Linux x86_64 highlights:
   direct syscalls, with virtual filesystem tracking for static paths.
 - Source-located stderr diagnostics for runtime failures (`assert`,
   `assertResult`, `head([])`, negative `sleep`, FileOutput / Dir errors).
+
+The Windows target covers the same file / directory / process / environment /
+stdin / argv / time builtins through direct Win64 `kernel32.dll` import calls
+instead of raw syscalls, with one limitation: those calls are ANSI-only, so
+non-ASCII paths and environment values/keys are unsupported.
 
 Anything not yet supported fails at build time rather than falling back to the
 evaluator. See [`docs/native-coverage.md`](docs/native-coverage.md) for the

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -76,6 +76,9 @@ pub struct NativeTargetSpec {
     pub operating_system: NativeOperatingSystem,
     pub abi: NativeAbi,
     pub executable_format: NativeExecutableFormat,
+    /// Support tier as documented in docs/native-coverage.md: "0" is
+    /// the must-stay-green tier, "1" is supported but younger.
+    pub tier: &'static str,
 }
 
 const LINUX_X86_64_ALIASES: &[&str] = &["linux-x86_64", "x86_64-unknown-linux-gnu"];
@@ -100,6 +103,7 @@ const NATIVE_TARGET_SPECS: &[NativeTargetSpec] = &[
         operating_system: NativeOperatingSystem::Linux,
         abi: NativeAbi::Gnu,
         executable_format: NativeExecutableFormat::Elf64,
+        tier: "0",
     },
     NativeTargetSpec {
         target: NativeTarget::MacosAarch64,
@@ -112,6 +116,7 @@ const NATIVE_TARGET_SPECS: &[NativeTargetSpec] = &[
         operating_system: NativeOperatingSystem::MacOs,
         abi: NativeAbi::Apple,
         executable_format: NativeExecutableFormat::MachO64,
+        tier: "1",
     },
     // Reuses the entire DirectX86_64 (Linux) codegen: the generated
     // machine code is identical Win64-compatible x86_64 instructions,
@@ -130,6 +135,7 @@ const NATIVE_TARGET_SPECS: &[NativeTargetSpec] = &[
         operating_system: NativeOperatingSystem::Windows,
         abi: NativeAbi::Msvc,
         executable_format: NativeExecutableFormat::Pe64,
+        tier: "0",
     },
 ];
 
@@ -326,22 +332,22 @@ impl NativeTarget {
     pub fn target_matrix() -> String {
         let mut lines = Vec::new();
         lines.push(format!(
-            "{:<32}{:<14}{:<14}{:<6}{}",
+            "{:<32}{:<15}{:<14}{:<6}{}",
             "TARGET", "BACKEND", "ARTIFACT", "TIER", "STATUS"
         ));
         for spec in Self::supported_specs() {
             lines.push(format!(
-                "{:<32}{:<14}{:<14}{:<6}{}",
+                "{:<32}{:<15}{:<14}{:<6}{}",
                 spec.standard_triple,
                 spec.backend.name(),
                 "executable",
-                "0",
+                spec.tier,
                 "supported"
             ));
         }
         for planned in PLANNED_TARGETS {
             lines.push(format!(
-                "{:<32}{:<14}{:<14}{:<6}{}",
+                "{:<32}{:<15}{:<14}{:<6}{}",
                 planned.triple, planned.backend, planned.artifact, planned.tier, "planned"
             ));
         }
@@ -45027,6 +45033,50 @@ mod tests {
         assert_eq!(platform.stdin_fd(), 0);
         assert_eq!(platform.stdout_fd(), 1);
         assert_eq!(platform.stderr_fd(), 2);
+    }
+
+    #[test]
+    fn target_matrix_reports_documented_tiers_and_aligned_columns() {
+        // `klassic targets` used to hardcode tier "0" for every
+        // supported target (docs/native-coverage.md documents
+        // aarch64-apple-darwin as tier 1) and pad the backend column
+        // to exactly 14 chars, so the 14-char "direct-aarch64" ran
+        // straight into the artifact column.
+        let matrix = NativeTarget::target_matrix();
+        let mac_row = matrix
+            .lines()
+            .find(|line| line.starts_with("aarch64-apple-darwin"))
+            .expect("matrix should list aarch64-apple-darwin");
+        assert!(
+            mac_row.contains("direct-aarch64 "),
+            "backend column should be whitespace-separated: {mac_row}"
+        );
+        let columns: Vec<&str> = mac_row.split_whitespace().collect();
+        assert_eq!(
+            columns,
+            [
+                "aarch64-apple-darwin",
+                "direct-aarch64",
+                "executable",
+                "1",
+                "supported"
+            ]
+        );
+        let windows_row = matrix
+            .lines()
+            .find(|line| line.starts_with("x86_64-pc-windows-msvc"))
+            .expect("matrix should list x86_64-pc-windows-msvc");
+        let columns: Vec<&str> = windows_row.split_whitespace().collect();
+        assert_eq!(
+            columns,
+            [
+                "x86_64-pc-windows-msvc",
+                "direct-x86_64",
+                "executable",
+                "0",
+                "supported"
+            ]
+        );
     }
 
     #[test]

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -890,32 +890,22 @@ cargo run -- -e "1 + 2"
   hand-maintained match arm, so adding a new imported function is a
   three-line change (a variant, an `ALL` entry, a `name()` arm) that
   never touches `pe.rs`. Verified end-to-end under WSL2 binfmt
-  built generically over the full `ImportSymbol::ALL` list (originally
-  just `GetStdHandle`/`WriteFile`/`ExitProcess`/`VirtualAlloc`, now
-  also the directory-family imports described below) from a single
-  `kernel32.dll` descriptor, with a fixed `ImageBase` and no `.reloc`
-  section (mirrors the "no external toolchain" property of the ELF
-  and Mach-O writers); adding a new import is purely mechanical (one
-  enum variant, one `ALL` entry, one `name()` arm — `iat_index` is
-  derived from position in `ALL`, and `pe.rs` needs no changes).
-  Verified end-to-end under WSL2 binfmt
   interop (`./program.exe` launches the real Windows loader from
   Linux) against hello-world, recursive `def`s, string/enum/record/list
   operations, closures, and a GC-churn stress program, all matching
   the evaluator's output byte-for-byte.
 
-  Every builtin whose native codegen would otherwise reach that
-  `syscall_number` tripwire on Windows is gated at its own `compile_*`
-  entry point (`if self.is_windows { return Err(...) }`, before any
-  codegen for that builtin runs) unless it has its own Win64 shim:
-  `StandardInput#all`/`#lines`, the whole `FileOutput#`/`FileInput#`
-  family, the whole `Dir#` family, `Environment#vars`/`#get`/`#exists`,
-  and `CommandLine#args` each raise a `` `Feature` is not yet
-  supported when targeting x86_64-pc-windows-msvc `` diagnostic
-  instead of panicking. `sleep`, `stopwatch`, and `Time#nowMillis` are
-  no longer gated: `compile_sleep` stages the millisecond count into
-  rdi and calls the `emit_win_sleep_runtime` shim, which moves it into
-  ecx and calls `Sleep` directly (no seconds/nanos split needed, unlike
+  Every native-codegen path that could otherwise reach the
+  `syscall_number` tripwire on Windows now has its own Win64 shim, so
+  the tripwire is unreachable in practice; the `unsupported_on_target`
+  diagnostic helper that used to raise a `` `Feature` is not yet
+  supported when targeting x86_64-pc-windows-msvc `` error for
+  not-yet-implemented builtins was removed once the last gate was
+  replaced (it is referenced only in a comment now). `sleep`,
+  `stopwatch`, and `Time#nowMillis` were the first to gain real
+  codegen: `compile_sleep` stages the millisecond count into `rdi` and
+  calls the `emit_win_sleep_runtime` shim, which moves it into `ecx`
+  and calls `Sleep` directly (no seconds/nanos split needed, unlike
   Linux's `nanosleep`); `compile_time_now_millis` calls
   `emit_win_time_now_millis_runtime`, which wraps
   `GetSystemTimeAsFileTime` and converts its 100ns-tick FILETIME output
@@ -926,28 +916,20 @@ cargo run -- -e "1 + 2"
   `emit_win_qpf_runtime` (wrapping `QueryPerformanceFrequency`) and
   computes `elapsed_ticks * 1000 / frequency`. All three shims follow
   the same save-every-register/self-aligning-`rsp` pattern as the
-  original four Win64 shims. `Environment#*` and `CommandLine#args`
-  don't reach a raw syscall at
-  `syscall_number` tripwire on Windows is now gated at its own
-  `compile_*` entry point (`if self.is_windows { return Err(...) }`,
-  before any codegen for that builtin runs): `sleep`, `stopwatch`,
-  `Time#nowMillis`, `StandardInput#all`/`#lines`, the whole
-  `FileOutput#`/`FileInput#` family, `Dir#home`/`#list`/`#listFull`,
-  `Environment#vars`/`#get`/`#exists`, and `CommandLine#args` each
-  raise a `` `Feature` is not yet supported when targeting
-  x86_64-pc-windows-msvc `` diagnostic instead of panicking.
+  original four Win64 shims (`__win_write`/`__win_mmap`/`__win_exit`/
+  `__win_init`).
 
   The rest of the `Dir#` family (`#mkdir`/`#mkdirs`/`#delete`/`#move`/
-  `#copy`/`#current`/`#exists`/`#isDirectory`/`#isFile`/`#temp`) is
-  un-gated and backed by seven new Win64 shims built on the same
-  save-registers/align-stack/epilogue scaffold as `__win_write`:
+  `#copy`/`#current`/`#exists`/`#isDirectory`/`#isFile`/`#temp`/
+  `#list`/`#listFull`/`#home`) is backed by Win64 shims built on the
+  same save-registers/align-stack/epilogue scaffold as `__win_write`:
   `__win_mkdir`/`__win_rmdir`/`__win_move`/`__win_copy_file` wrap
   `CreateDirectoryA`/`RemoveDirectoryA`/`MoveFileExA`/`CopyFileA`
   (the last replacing the Linux open/`sendfile`-loop/close sequence
   with one call) and share a `GetLastError()`-translating BOOL-result
   normalizer that maps `ERROR_FILE_NOT_FOUND`/`ERROR_PATH_NOT_FOUND`
   to `-errno_no_entry()` and `ERROR_ALREADY_EXISTS`/`ERROR_FILE_EXISTS`
-  to `-errno_exists()` (both now real Windows sentinels, `-2`/`-17`,
+  to `-errno_exists()` (both real Windows sentinels, `-2`/`-17`,
   rather than the placeholder `0` every other
   `WINDOWS_X86_64_PLATFORM_CONSTANTS` field carries) so the reused
   Linux `emit_runtime_error_if_rax_negative[_except_errno]` call sites
@@ -964,98 +946,102 @@ cargo run -- -e "1 + 2"
   value and silently defeat every `cmp rax,0;jge ok`-style caller),
   backing `Dir#exists`/`#isDirectory`/`#isFile`'s shared
   `emit_runtime_path_exists_label`/`emit_runtime_path_type_check_label`
-  helpers. Two related, non-codegen fixes shipped alongside these
-  shims: `emit_dir_mkdirs_label`'s runtime path-prefix scanner gained a
-  parallel `\`-handling block (Windows paths may use either separator)
-  that restores the original separator byte rather than hardcoding
-  `/`; and `compile_dir_exists`/`_is_directory`/`_is_file` now force
-  the runtime (non-folded) path check whenever `self.is_windows`,
-  since their existing compile-time constant fold for a
-  statically-known path argument queries the *compiling host's*
+  helpers. `Dir#list`/`#listFull` use a `FindFirstFileA`/
+  `FindNextFileA`/`FindClose` loop that mirrors the Linux `getdents64`
+  output contract (newline buffer, dot-entry skip, `listFull` prefix,
+  shared sort pass), with the same 65536-byte listing cap as Linux.
+  `StandardInput#all`/`#lines` read through a `ReadFile` shim against a
+  stdin handle cached at startup. Two related, non-codegen fixes ship
+  alongside these shims: `emit_dir_mkdirs_label`'s runtime path-prefix
+  scanner gained a parallel `\`-handling block (Windows paths may use
+  either separator) that restores the original separator byte rather
+  than hardcoding `/`; and `compile_dir_exists`/`_is_directory`/
+  `_is_file` force the runtime (non-folded) path check whenever
+  `self.is_windows`, since their existing compile-time constant fold
+  for a statically-known path argument queries the *compiling host's*
   filesystem — correct for a same-target build, silently wrong for a
-  Windows cross-build. Every path in this family reuses the existing
-  ANSI (`A`-suffixed) kernel32 functions, so non-ASCII paths remain
-  best-effort/undefined until a UTF-8-to-UTF-16LE `W`-function pass is
-  added.
-  `Environment#*` and `CommandLine#args` don't reach a raw syscall at
-  all — they walk the `environment_base`/`command_line_argc`/
-  `syscall_number` tripwire on Windows was originally gated at its own
-  `compile_*` entry point (`if self.is_windows { return Err(...) }`,
-  before any codegen for that builtin runs), raising a `` `Feature` is
-  not yet supported when targeting x86_64-pc-windows-msvc `` diagnostic
-  instead of panicking. As of the un-gating work described below, only
-  `sleep`, `stopwatch`, `Time#nowMillis`, `StandardInput#all`/`#lines`,
-  most of the `Dir#` family (`current`/`temp`/`exists`/`isDirectory`/
-  `isFile`/`mkdir`/`mkdirs`/`list`/`listFull`/`delete`/`copy`/`move`)
-  still raise that diagnostic; `Dir#home`, `Environment#vars`/`#get`/
-  `#exists`, `CommandLine#args`, and the whole `FileOutput#`/
-  `FileInput#` family no longer do. `Environment#*` and
-  `CommandLine#args` never reached a raw syscall in the first place —
-  they walk the `environment_base`/`command_line_argc`/
-  `command_line_argv1_base` slots `emit_store_command_line_state`
-  used to leave zeroed on Windows — so an ungated build would have
-  silently compiled a binary that always observed an empty
-  environment/argument list rather than failing to build; they were
-  gated for that "wrong answer, not a crash" reason instead of the
-  syscall-tripwire reason. `emit_print_expr_fragment`'s
-  `println(FileInput#all(...))` / `println(FileInput#lines(...))` /
-  `println(FileInput#open(path, s => s.readLines()))` print-fusion fast
-  paths stream a file straight to the target fd without going through
-  `compile_file_input_all`/`compile_file_input_lines`; each fast path's
-  own `!self.is_windows` guard still skips it on Windows even now that
-  the underlying builtins are Windows-safe (the fast paths themselves
-  still call the raw-syscall-only `emit_file_stream_to_fd_path_label`),
-  falling through to the ordinary (now Windows-safe) call dispatch
-  instead. `thread { ... }` needed no gate of its own: a queued thread
-  body is compiled into the tail of `main` via the same `compile_expr`
-  dispatch as any other call site (no real OS thread, no syscall of its
-  own), so a thread body that touches a still-gated builtin is already
-  caught transitively.
+  Windows cross-build.
 
-  Two of the originally-gated families above are now un-gated.
-  `emit_store_command_line_state`'s Windows branch synthesizes the Linux
-  `argv`/`envp` layout at startup instead of leaving it zeroed:
-  `GetEnvironmentStringsA`'s flat block is walked once
-  into a synthesized `char*` pointer array (`environment_base`, never freed
-  — its entries point directly into the still-live `GetEnvironmentStringsA`
-  block, mirroring the GC heap's own "never free" policy), and
-  `GetCommandLineA`'s single ANSI string is hand-tokenized by a two-state
-  (in-quotes / not) FSA into a NUL-separated buffer plus a matching pointer
-  array (`command_line_argc`/`command_line_argv1_base`). The tokenizer
-  deliberately does not implement `CommandLineToArgvW`'s `""`-unescaping or
-  backslash-escaping rules — backslash is always literal — so a quoted
-  Windows path ending in a backslash before its closing quote does not
-  tokenize identically to the real CRT. Both slots keep the exact shape
-  every existing `emit_command_line_args`/`emit_environment_*`/
-  `emit_find_environment_*` consumer already assumes, so `CommandLine#args`,
-  `Environment#vars`/`#get`/`#exists`, and (via a `USERPROFILE`-instead-of-
-  `HOME` key swap) `Dir#home` are un-gated with no changes to those
-  consumers. Separately, `FileOutput#write`/`#append`/`#writeLines`/
-  `#exists`/`#delete` and `FileInput#all`/`#readAll`/`#lines`/`#readLines`
-  are un-gated by branching their `Open`/`Read`/`Write`/`Close`/`Unlink`/
-  `Access` syscall sites to new Win64 shims: `win_create_file` (wraps
-  `CreateFileA`, selecting `GENERIC_READ`+`OPEN_EXISTING` /
-  `GENERIC_WRITE`+`CREATE_ALWAYS` / `FILE_APPEND_DATA`+`OPEN_ALWAYS` from a
-  small selector carried in the target's `open_read_flags`/
-  `open_write_flags` constants), `win_read` and `win_write_handle` (twins of
-  `win_write` wrapping `ReadFile`/`WriteFile` against a raw file `HANDLE`
-  rather than `win_write`'s cached-stdout/stderr selector), `win_close_handle`
-  (wraps `CloseHandle`), `win_delete_file` (wraps `DeleteFileA`, translating
-  a `GetLastError()` failure via `emit_win_translate_last_error_to_errno`
-  so `ERROR_FILE_NOT_FOUND`/`ERROR_PATH_NOT_FOUND` map to the same
-  `errno_no_entry` sentinel the Linux `Unlink` path already tolerates), and
-  `win_get_file_attributes` (wraps `GetFileAttributesA`; its
-  `INVALID_FILE_ATTRIBUTES` sentinel zero-extends to a *positive* 64-bit
-  value, so the shim compares against the exact 64-bit constant rather than
-  a sign-extended `-1`). All paths use the kernel32 "A" (ANSI) functions
-  reusing the existing UTF-8 path-staging code as-is, so non-ASCII paths
-  and environment values are unsupported on this target for now. Two
-  `compile_*` entry points (`FileOutput#exists`, `FileInput#all`/`#lines`)
-  also fold a statically-known-constant path's existence/content from the
-  *compiling host's* filesystem at compile time as an optimization; that
-  fold is forced off whenever `self.is_windows`, since a Windows build's
-  path only makes sense to check against the eventual Windows target's
-  filesystem at runtime, not the Linux/macOS build machine's.
+  `Environment#vars`/`#get`/`#exists` and `CommandLine#args` never
+  reached a raw syscall in the first place — they walk the
+  `environment_base`/`command_line_argc`/`command_line_argv1_base`
+  slots that `emit_store_command_line_state` used to leave zeroed on
+  Windows, so an ungated build would have silently compiled a binary
+  that always observed an empty environment/argument list rather than
+  failing to build; they were gated for that "wrong answer, not a
+  crash" reason rather than the syscall-tripwire reason.
+  `emit_store_command_line_state`'s Windows branch now synthesizes
+  that layout at startup instead: `GetEnvironmentStringsA`'s flat
+  block is walked once into a synthesized `char*` pointer array
+  (`environment_base`, never freed — its entries point directly into
+  the still-live `GetEnvironmentStringsA` block, mirroring the GC
+  heap's own "never free" policy), and `GetCommandLineA`'s single ANSI
+  string is hand-tokenized by a two-state (in-quotes / not) FSA into a
+  NUL-separated buffer plus a matching pointer array
+  (`command_line_argc`/`command_line_argv1_base`). The tokenizer
+  deliberately does not implement `CommandLineToArgvW`'s
+  `""`-unescaping or backslash-escaping rules — backslash is always
+  literal — so a quoted Windows path ending in a backslash before its
+  closing quote does not tokenize identically to the real CRT. Both
+  slots keep the exact shape every existing
+  `emit_command_line_args`/`emit_environment_*`/
+  `emit_find_environment_*` consumer already assumed, so
+  `CommandLine#args`, `Environment#vars`/`#get`/`#exists`, and (via a
+  `USERPROFILE`-instead-of-`HOME` key swap) `Dir#home` needed no
+  further changes to those consumers. Single-key `Environment#get`/
+  `#exists` lookups additionally go through a `GetEnvironmentVariableA`
+  shim so the OS resolves the name — Windows stores variables with
+  OS-native casing (`Path=`, not `PATH=`) and resolves them
+  case-insensitively, which a byte-for-byte envp-array walk does not;
+  `Environment#vars` keeps the block walk since it only enumerates.
+
+  `FileOutput#write`/`#append`/`#writeLines`/`#exists`/`#delete` and
+  `FileInput#all`/`#readAll`/`#lines`/`#readLines` (`std.file`) branch
+  their `Open`/`Read`/`Write`/`Close`/`Unlink`/`Access` syscall sites
+  to Win64 shims: `win_create_file` (wraps `CreateFileA`, selecting
+  `GENERIC_READ`+`OPEN_EXISTING` / `GENERIC_WRITE`+`CREATE_ALWAYS` /
+  `FILE_APPEND_DATA`+`OPEN_ALWAYS` from a small selector carried in
+  the target's `open_read_flags`/`open_write_flags` constants),
+  `win_read` and `win_write_handle` (twins of `win_write` wrapping
+  `ReadFile`/`WriteFile` against a raw file `HANDLE` rather than
+  `win_write`'s cached-stdout/stderr selector), `win_close_handle`
+  (wraps `CloseHandle`), `win_delete_file` (wraps `DeleteFileA`,
+  translating a `GetLastError()` failure via
+  `emit_win_translate_last_error_to_errno` so
+  `ERROR_FILE_NOT_FOUND`/`ERROR_PATH_NOT_FOUND` map to the same
+  `errno_no_entry` sentinel the Linux `Unlink` path already tolerates),
+  and `win_get_file_attributes` (wraps `GetFileAttributesA`; its
+  `INVALID_FILE_ATTRIBUTES` sentinel zero-extends to a *positive*
+  64-bit value, so the shim compares against the exact 64-bit constant
+  rather than a sign-extended `-1`). Two `compile_*` entry points
+  (`FileOutput#exists`, `FileInput#all`/`#lines`) also fold a
+  statically-known-constant path's existence/content from the
+  *compiling host's* filesystem at compile time as an optimization;
+  that fold is forced off whenever `self.is_windows`, since a Windows
+  build's path only makes sense to check against the eventual Windows
+  target's filesystem at runtime, not the Linux/macOS build machine's.
+  `emit_print_expr_fragment`'s `println(FileInput#all(...))`/
+  `println(FileInput#lines(...))`/
+  `println(FileInput#open(path, s => s.readLines()))` print-fusion
+  fast paths stream a file straight to the target fd without going
+  through `compile_file_input_all`/`compile_file_input_lines`; each
+  fast path's own `!self.is_windows` guard still skips it on Windows
+  (the fast paths themselves still call the raw-syscall-only
+  `emit_file_stream_to_fd_path_label`), falling through to the
+  ordinary (Windows-safe) call dispatch instead — so those `println`
+  calls still work on Windows, just through the general path rather
+  than the fused fast path.
+
+  All of the shims above use only the kernel32 "A" (ANSI) functions,
+  reusing the existing UTF-8 path-staging code as-is, so non-ASCII
+  paths and environment values/keys are unsupported (best-effort /
+  undefined) on this target — the one documented Windows limitation.
+  `thread { ... }` needs no gate of its own: a queued thread body is
+  compiled into the tail of `main` via the same `compile_expr`
+  dispatch as any other call site (no real OS thread, no syscall of
+  its own). `Process#run`/`#nrun` (process spawning) has no
+  native-backend implementation on any target yet, so there is
+  nothing Windows-specific to gate there.
 
   The native runtime owns a dedicated GC heap that is separate from the
   static `.data` buffers used by the rest of the codegen. At program

--- a/docs/book/src/cookbook/hello.md
+++ b/docs/book/src/cookbook/hello.md
@@ -10,8 +10,9 @@ println("Hello, World!")
 ```
 
 The simplest possible program. The string lives in the binary's
-`.data` section; the native compiler emits a single `write` syscall
-plus a newline.
+data section; the native compiler emits a single write to stdout (a
+`write` syscall on Linux/macOS, a `WriteFile` call on Windows) plus a
+newline.
 
 ## With interpolation
 

--- a/docs/book/src/gc/why.md
+++ b/docs/book/src/gc/why.md
@@ -1,15 +1,17 @@
 # Why a GC?
 
-Klassic compiles directly to ELF without `libc`, so it cannot lean on
-`malloc` / `free` from the system. At the same time, real programs
-need values whose lifetime extends past the stack frame that built
-them: a string returned from `String#concat`, a list grown inside a
-loop, a dictionary that records counts.
+Klassic compiles directly to a native executable (ELF64 on Linux,
+Mach-O arm64 on macOS, PE64 on Windows) without `libc`, so it cannot
+lean on `malloc` / `free` from the system. At the same time, real
+programs need values whose lifetime extends past the stack frame that
+built them: a string returned from `String#concat`, a list grown
+inside a loop, a dictionary that records counts.
 
 The native compiler embeds its own precise mark-and-sweep collector
 to give those values a managed home. Concretely:
 
-- The runtime starts with a 1 MiB heap (`mmap`'d at startup).
+- The runtime starts with a 1 MiB heap (`mmap`'d at startup on Linux
+  and macOS; `VirtualAlloc`'d on Windows).
 - When even a post-collection retry can't satisfy a request, the
   allocator `mmap`s another 1 MiB segment. Up to 64 segments
   total — `64 MiB` — before the program exits with

--- a/docs/book/src/getting-started/hello-world.md
+++ b/docs/book/src/getting-started/hello-world.md
@@ -28,7 +28,7 @@ klassic hello.kl
 `klassic <path>` and `klassic -f <path>` are equivalent — both run
 the program through the evaluator.
 
-## Compile to a native ELF
+## Compile to a native executable
 
 ```bash
 klassic build hello.kl -o hello
@@ -36,9 +36,16 @@ klassic build hello.kl -o hello
 # Hello, World!
 ```
 
-The native compiler emits a Linux x86_64 ELF that talks directly to
-the kernel through syscalls. There is no `libc` dependency, so the
-resulting binary is a few KiB and starts essentially instantly.
+A target-less `build` compiles for the detected host, writing the
+executable container itself with no external toolchain: a direct ELF64
+on Linux x86_64, an ad-hoc-signed Mach-O arm64 on Apple Silicon macOS,
+or a PE64 on Windows x86_64 (`klassic build hello.kl -o hello.exe`).
+None of them depend on `libc`, so the resulting binary is a few KiB
+and starts essentially instantly. See
+[Building Executables](../native/building.md) for the full host/target
+matrix.
+
+On Linux:
 
 ```bash
 file hello

--- a/docs/book/src/getting-started/install.md
+++ b/docs/book/src/getting-started/install.md
@@ -25,11 +25,33 @@ Two environment variables tune the installer:
 
 | Variable | Effect |
 | --- | --- |
-| `KLASSIC_VERSION=v0.3.0` | Pin a specific release instead of the latest |
+| `KLASSIC_VERSION=v0.4.0` | Pin a specific release instead of the latest |
 | `KLASSIC_HOME=/opt/klassic` | Change the install root (binaries go to `$KLASSIC_HOME/bin`) |
 
 The Linux build is statically linked (musl) and runs on any x86_64
 Linux. The macOS builds run on macOS 11+.
+
+## Windows
+
+Download the `klassic-vX.Y.Z-x86_64-pc-windows-msvc.zip` asset from
+the latest [release](https://github.com/klassic/klassic/releases),
+extract it, and put the folder containing `klassic.exe` on your `PATH`
+(for example, via *System Properties → Environment Variables*, or
+`setx PATH "%PATH%;C:\klassic"` in an elevated prompt). Then confirm it
+works from PowerShell or `cmd.exe`:
+
+```bat
+klassic --version
+klassic -e "1 + 2"
+```
+
+Windows x86_64 is a tier-0 target with its own direct PE64 backend —
+no Visual Studio, MSVC toolchain, or WSL required to run the evaluator,
+REPL, or `klassic build`. The Windows release zip ships `klassic.exe`
+alone (unlike the Linux/macOS archives, it does not bundle
+`libklassic_runtime.a`), so `--backend c` is not available from the
+downloaded binary; use the direct PE64 backend (the default on
+Windows) for native builds.
 
 ## What works where
 
@@ -38,6 +60,7 @@ Linux. The macOS builds run on macOS 11+.
 | Linux x86_64 | ✅ | ✅ direct ELF64 (most complete) |
 | macOS arm64 (Apple Silicon) | ✅ | ✅ direct signed Mach-O, portable-C fallback |
 | macOS x86_64 | ✅ | ✅ portable C backend (needs Xcode CLT's `cc`) |
+| Windows x86_64 | ✅ | ✅ direct PE64 (core language plus full OS-builtin coverage; ANSI-only paths/env) |
 | anywhere Rust runs | ✅ | — |
 
 ## Build from source

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -3,15 +3,17 @@
   <h1 class="kl-wordmark">Forged straight<br>into <em>machine code</em>.</h1>
   <p class="kl-tagline">
     Klassic is a statically typed object-functional language whose
-    compiler writes executables byte by byte — ELF on Linux, ad-hoc-signed
-    Mach-O on Apple Silicon — with no <code>cc</code>, <code>as</code>,
-    <code>ld</code>, or <code>codesign</code> anywhere in the loop.
+    compiler writes executables byte by byte — ELF on Linux,
+    ad-hoc-signed Mach-O on Apple Silicon, PE64 on Windows — with no
+    <code>cc</code>, <code>as</code>, <code>ld</code>,
+    <code>codesign</code>, or <code>link.exe</code> anywhere in the
+    loop.
   </p>
   <ul class="kl-chips">
     <li>Hindley–Milner inference</li>
     <li>ADTs + match</li>
     <li>precise GC</li>
-    <li>linux-x86_64 · macos-aarch64</li>
+    <li>linux · macos · windows</li>
     <li>zero toolchain</li>
   </ul>
 </div>
@@ -19,23 +21,29 @@
 <div class="kl-terminal">
   <div class="kl-terminal-bar">
     <span></span><span></span><span></span>
-    <em class="kl-terminal-title">klassic — 80×12</em>
+    <em class="kl-terminal-title">klassic — 80×14</em>
   </div>
   <pre><code><span class="kl-prompt">$</span> curl -fsSL https://raw.githubusercontent.com/klassic/klassic/main/install.sh | sh
-<span class="kl-dim">installed: klassic 0.3.0 -&gt; ~/.klassic/bin</span>
+<span class="kl-dim">installed: klassic 0.4.0 -&gt; ~/.klassic/bin</span>
 <span class="kl-prompt">$</span> cat fib.kl
 <span class="kl-out">def fib(n: Int): Int = if (n &lt; 2) n else fib(n - 1) + fib(n - 2)
 println(fib(25))</span>
 <span class="kl-prompt">$</span> klassic build fib.kl -o fib && ./fib
-<span class="kl-out">75025</span></code></pre>
+<span class="kl-out">75025</span>
+<span class="kl-prompt">$</span> klassic --target x86_64-pc-windows-msvc build fib.kl -o fib.exe
+<span class="kl-prompt">$</span> file fib fib.exe
+<span class="kl-out">fib:     ELF 64-bit LSB executable, x86-64, statically linked
+fib.exe: PE32+ executable (console) x86-64, for MS Windows</span></code></pre>
 </div>
 
-The same `build` command targets the detected host: a direct ELF64
+The same `build` command targets the detected host — a direct ELF64
 writer on Linux x86_64, a direct Mach-O arm64 writer (including the
-embedded ad-hoc code signature Apple Silicon requires) on macOS.
-Programs the young Mach-O backend cannot lower yet fall back
-transparently to the portable C backend, and everything runs through
-the evaluator for instant iteration.
+embedded ad-hoc code signature Apple Silicon requires) on macOS, a
+direct PE64 writer on Windows x86_64 — and `--target` cross-builds any
+of the three from any machine, as the transcript above shows. Programs
+the young Mach-O backend cannot lower yet fall back transparently to
+the portable C backend, and everything runs through the evaluator for
+instant iteration.
 
 ## Why Klassic?
 
@@ -53,13 +61,14 @@ the evaluator for instant iteration.
     <h3>No toolchain, anywhere</h3>
     <p>The compiler emits machine code and the executable container
     itself: ELF64 via direct syscalls on Linux, signed Mach-O arm64 via
-    <code>svc #0x80</code> on macOS. Sub-10&nbsp;KiB binaries,
-    sub-millisecond startup.</p>
+    <code>svc #0x80</code> on macOS, PE64 calling
+    <code>kernel32.dll</code> through a hand-built import table on
+    Windows. Sub-10&nbsp;KiB binaries, sub-millisecond startup.</p>
   </div>
   <div class="kl-card">
     <span class="kl-card-glyph">memory</span>
     <h3>A real garbage collector</h3>
-    <p>Native Linux binaries embed a precise mark-and-sweep collector
+    <p>Native binaries embed a precise mark-and-sweep collector
     with a growable multi-segment heap — strings, lists, maps, records,
     and enums all live on it.</p>
   </div>
@@ -68,7 +77,7 @@ the evaluator for instant iteration.
     <h3>Enums and match, compiled</h3>
     <p><code>enum Tree { case Leaf(v: Int); case Branch(l: Tree, r: Tree) }</code>
     — construction, nested patterns, guards, and recursive functions
-    over them compile natively on both targets.</p>
+    over them compile natively on all three targets.</p>
   </div>
   <div class="kl-card">
     <span class="kl-card-glyph">stdlib</span>
@@ -120,8 +129,8 @@ foreach (name in ["alice", "bob"]) {
   functions, records, type classes, …).
 - 🍳 **Cookbook** — six runnable recipes that solve real scripting
   tasks (filter, word count, calculator, …).
-- ⚙️ **Native Compilation** — producing standalone executables on
-  Linux and Apple Silicon.
+- ⚙️ **Native Compilation** — producing standalone executables for
+  Linux, Apple Silicon, and Windows.
 - 🧠 **The GC Heap** — why the runtime has its own collector, how to
   use heap-backed strings / lists / maps, and a reference for every
   `__gc_*` debug builtin.
@@ -130,10 +139,13 @@ foreach (name in ["alice", "bob"]) {
 
 ## Status
 
-Klassic is alive and shipping features in small commits. Two direct
-native backends are implemented — Linux x86_64 (the most complete) and
-Apple Silicon macOS (growing fast, with a portable-C fallback) — and
-anything the native compilers cannot lower fails with a source-located
-diagnostic instead of silently falling back to the evaluator. Releases
-ship as static binaries for Linux and both macOS architectures; the
-installer verifies itself by running a Klassic program on your machine.
+Klassic is alive and shipping features in small commits. Three direct
+native backends are implemented — Linux x86_64 (the most complete),
+Windows x86_64 (sharing the same codegen, down to file, directory,
+environment, and stdin support), and Apple Silicon macOS (growing
+fast, with a portable-C fallback) — and anything the native compilers
+cannot lower fails with a source-located diagnostic instead of
+silently falling back to the evaluator. Releases ship as static
+binaries for Linux, both macOS architectures, and Windows; the
+installer verifies itself by running a Klassic program on your
+machine.

--- a/docs/book/src/native/building.md
+++ b/docs/book/src/native/building.md
@@ -17,13 +17,16 @@ A target-less `build` compiles for the **detected host**:
 | --- | --- | --- |
 | Linux x86_64 | direct ELF writer (most complete) | ELF64 talking to the kernel via raw syscalls |
 | macOS arm64 | direct Mach-O writer, portable-C fallback | ad-hoc-signed Mach-O arm64 via `svc #0x80` |
+| Windows x86_64 | direct PE64 writer | PE64 talking to the kernel via Win64 `kernel32.dll` import calls |
 | other hosts | portable C backend | executable linked with the system `cc` |
 
 To pick a target explicitly, pass `--target` with a canonical name or
-triple — `linux-x86_64` / `x86_64-unknown-linux-gnu` and
-`macos-aarch64` / `aarch64-apple-darwin` are the implemented direct
-targets, and `--target native` selects the host's. The Mach-O target
-cross-builds from any host, embedded code signature included.
+triple — `linux-x86_64` / `x86_64-unknown-linux-gnu`,
+`macos-aarch64` / `aarch64-apple-darwin`, and `windows-x86_64` /
+`x86_64-pc-windows-msvc` are the implemented direct targets, and
+`--target native` selects the host's. The Mach-O and PE64 targets both
+cross-build from any host (the Mach-O writer embeds the code signature
+itself; the PE64 writer needs no signature at all).
 `klassic targets` prints the full matrix alongside planned targets.
 
 On Apple Silicon, programs outside the Mach-O backend's growing subset
@@ -56,6 +59,16 @@ expressions, locals, `if` / `while`, annotated functions with
 recursion, the string builtins, monomorphic enums and `match`, cons
 lists, and records — and the portable C backend catches what it
 cannot.
+
+On Windows x86_64, the direct PE64 backend reuses the entire Linux
+x86_64 codegen (the generated machine code is already Win64-ABI
+compatible) and swaps in Win64 `kernel32.dll` import calls at the OS
+boundary, so it covers the same core language plus the full OS-builtin
+surface: file and directory I/O, environment variables, command-line
+arguments, stdin, `sleep`, `stopwatch`, and `Time#nowMillis`. The one
+Windows-specific limitation is that those OS calls go through the
+ANSI (`A`-suffixed) Win32 functions, so non-ASCII paths and
+environment values/keys are unsupported.
 
 See [Native Compiler Coverage](../reference/native-coverage.md) for
 the exhaustive matrix.

--- a/docs/book/src/native/concurrency.md
+++ b/docs/book/src/native/concurrency.md
@@ -32,8 +32,8 @@ sleep(500)   // milliseconds
 ```
 
 Both literal integer arguments and runtime integer values work. The
-native code lowers to `nanosleep`. Negative arguments emit a
-source-located diagnostic and exit non-zero.
+native code lowers to `nanosleep` (Windows target: `Sleep`). Negative
+arguments emit a source-located diagnostic and exit non-zero.
 
 ## Stopwatch
 
@@ -46,7 +46,8 @@ println("took #{elapsed} ms")
 
 `stopwatch` accepts a literal `() => ...` lambda or a saved lambda
 value, runs the body, and returns the elapsed milliseconds as an
-`Int`. The native code lowers to `clock_gettime(CLOCK_MONOTONIC)`.
+`Int`. The native code lowers to `clock_gettime(CLOCK_MONOTONIC)`
+(Windows target: `QueryPerformanceCounter` / `QueryPerformanceFrequency`).
 
 ## Wall-clock time
 
@@ -57,9 +58,11 @@ println("epoch ms: #{nowMs}")
 
 `Time#nowMillis()` returns wall-clock milliseconds since the UNIX
 epoch. Same surface in eval and native — the native code lowers to
-`clock_gettime(CLOCK_REALTIME)`. Use `stopwatch` for "how long did
-this take", and `Time#nowMillis` for "what time is it right now"
-(timestamps, log lines, deadlines).
+`clock_gettime(CLOCK_REALTIME)` (Windows target:
+`GetSystemTimeAsFileTime`, converted from its 100ns-tick FILETIME
+epoch to unix millis). Use `stopwatch` for "how long did this take",
+and `Time#nowMillis` for "what time is it right now" (timestamps, log
+lines, deadlines).
 
 ## Integer exponentiation
 

--- a/docs/book/src/native/file-io.md
+++ b/docs/book/src/native/file-io.md
@@ -1,7 +1,13 @@
 # File and Directory I/O
 
-Native binaries talk directly to the kernel through `open`, `read`,
-`write`, `unlink`, `mkdir`, `getdents`, and friends.
+Native binaries talk directly to the OS: raw syscalls (`open`, `read`,
+`write`, `unlink`, `mkdir`, `getdents`, and friends) on Linux and
+macOS, or the equivalent Win64 `kernel32.dll` calls (`CreateFileA`,
+`ReadFile`, `WriteFile`, `DeleteFileA`, `CreateDirectoryA`,
+`FindFirstFileA`, and friends) on the Windows target. The language
+surface below is identical on every target; the one Windows-specific
+caveat is that those calls are ANSI-only, so non-ASCII paths are
+unsupported.
 
 ## Reading
 
@@ -66,9 +72,9 @@ if (Dir#exists("/tmp/klassic-demo")) {
 | `Dir#list(path)` | Entries (no parent path prefix) |
 | `Dir#listFull(path)` | Entries with the directory prefix |
 | `Dir#copy(src, dst)`, `Dir#move(src, dst)` | Recursive |
-| `Dir#current()` | `getcwd` |
-| `Dir#home()` | `$HOME` |
-| `Dir#temp()` | `$TMPDIR`, falling back to `/tmp` |
+| `Dir#current()` | `getcwd` (Windows: `GetCurrentDirectoryA`) |
+| `Dir#home()` | `$HOME` (Windows: `%USERPROFILE%`) |
+| `Dir#temp()` | `$TMPDIR`, falling back to `/tmp` (Windows: `GetTempPathA`) |
 
 ## Callback style
 

--- a/docs/book/src/native/process.md
+++ b/docs/book/src/native/process.md
@@ -66,6 +66,11 @@ Aliases:
 - `hasEnv(name)` for `Environment#exists`
 - `env()` for `Environment#vars`
 
+On the Windows target, `Environment#get` / `Environment#exists` resolve
+names case-insensitively (matching Windows' own semantics — the OS
+stores `Path`, not `PATH`), while on Linux and macOS lookups are
+case-sensitive.
+
 ## Sample CLI tool
 
 ```kl

--- a/docs/book/src/reference/architecture.md
+++ b/docs/book/src/reference/architecture.md
@@ -19,7 +19,7 @@ klassic-types      (Hindley-Milner inference + records + type classes + proofs)
    ↓
 klassic-eval       (evaluator + builtins + REPL)
    ↓ (only for `klassic build`)
-klassic-native     (Linux x86_64 codegen + ELF writer)
+klassic-native     (x86_64 codegen + ELF64 / Mach-O arm64 / PE64 writers)
 ```
 
 ## Crates
@@ -31,7 +31,7 @@ klassic-native     (Linux x86_64 codegen + ELF writer)
 | `klassic-rewrite` | Placeholder desugaring and normalization. |
 | `klassic-types` | Type checking, type classes, proof checks. |
 | `klassic-eval` | Evaluator, runtime builtins, REPL state. |
-| `klassic-native` | x86_64 codegen and ELF64 writer. |
+| `klassic-native` | x86_64/arm64 codegen and the ELF64, Mach-O arm64, and PE64 writers. |
 | `klassic-runtime` | Shared runtime crate scaffold (work in progress). |
 | `klassic-macro-peg` | Standalone Rust macro PEG implementation. |
 
@@ -41,7 +41,9 @@ klassic-native     (Linux x86_64 codegen + ELF writer)
 pipeline and lowers a growing subset of the resulting AST directly
 to machine code:
 
-- Direct syscall I/O — no `libc`, `cc`, `as`, or `ld` involvement.
+- Direct OS-level I/O with no `libc`, `cc`, `as`, `ld`, or `codesign`
+  involvement — raw syscalls on Linux and macOS, Win64 `kernel32.dll`
+  import calls on Windows.
 - Precise mark-and-sweep GC with multi-segment heap growth (see
   [Why a GC?](../gc/why.md)).
 - Fixed-buffer representations for runtime strings / lists / records

--- a/docs/book/src/reference/native-coverage.md
+++ b/docs/book/src/reference/native-coverage.md
@@ -1,13 +1,22 @@
 # Native Compiler Coverage
 
-The native compiler lowers a growing slice of the language to ELF. The current
-Linux x86_64 target is selectable as `linux-x86_64`,
-`x86_64-unknown-linux-gnu`, or `native` on a matching host.
+The native compiler lowers a growing slice of the language directly to
+machine code for three tier-0 targets: direct ELF64 for Linux x86_64
+(`linux-x86_64` / `x86_64-unknown-linux-gnu`), direct ad-hoc-signed
+Mach-O arm64 for Apple Silicon macOS (`macos-aarch64` /
+`aarch64-apple-darwin`), and direct PE64 for Windows x86_64
+(`windows-x86_64` / `x86_64-pc-windows-msvc`). A target-less `build`
+compiles for the detected host — including Windows hosts, which now
+default to the direct PE64 backend. `klassic targets` lists the full
+matrix, including the still-planned tier 1/2 targets.
 The exhaustive feature matrix lives in
 [`docs/native-coverage.md`](https://github.com/klassic/klassic/blob/main/docs/native-coverage.md)
 in the source tree — broken down by section (core surface, function
 calls, static folding, strings, records, runtime lists, file I/O,
-process / environment / streams).
+process / environment / streams) plus a target matrix with the
+per-target status and known limitations (for example, the Windows
+target's OS-builtin coverage is ANSI-only — non-ASCII paths and
+environment values/keys are unsupported).
 
 Anything not yet supported fails at build time with a source-located
 diagnostic; there is no silent fallback to the evaluator.
@@ -39,7 +48,10 @@ diagnostic; there is no silent fallback to the evaluator.
   lists and string-keyed maps expose the same string-specific path through
   `__gc_list_ptr_get_string` and `__gc_smap_get_string`.
 - Linux file / directory / process / environment / stdin / argv
-  builtins via direct syscalls.
+  builtins via direct syscalls; the same builtin families are also
+  fully covered on the Windows target via direct Win64 `kernel32.dll`
+  import calls (ANSI-only: non-ASCII paths and environment
+  values/keys are unsupported on Windows).
 - Source-located stderr diagnostics for runtime failures (`assert`,
   `assertResult`, `head([])`, negative `sleep`, FileOutput / Dir
   errors).

--- a/docs/native-coverage.md
+++ b/docs/native-coverage.md
@@ -588,7 +588,7 @@ lands. See `docs/roadmap-targets-stdlib.md` for the wider rationale.
 | `wasm32-wasi`                  | wasm module emitter    | wasm-module   | 2    | planned     |
 | `x86_64-apple-darwin`          | portable C backend     | executable    | 2    | planned     |
 | `aarch64-apple-darwin`         | direct Mach-O writer   | executable    | 1    | supported (small subset, growing) |
-| `x86_64-pc-windows-msvc`       | direct PE64 writer (reuses DirectX86_64 codegen) | executable | 0 | supported (core language: arithmetic, if/while, recursive def, strings, enums/match, records, lists, closures, GC) |
+| `x86_64-pc-windows-msvc`       | direct PE64 writer (reuses DirectX86_64 codegen) | executable | 0 | supported (core language plus full OS-builtin coverage: file/dir/stdin/env/args/time; ANSI-only paths and environment values/keys) |
 
 Rules:
 
@@ -609,73 +609,63 @@ Rules:
   container format (PE64, see `crates/klassic-native/src/pe.rs`)
   differ. `TargetPlatform::syscall_number` still panics unconditionally
   for the Windows target as a deliberate invariant tripwire, but every
-  native-codegen path that could reach it is gated first unless it has
-  its own Win64 shim. `sleep`, `stopwatch`, and `Time#nowMillis`
-  (`std.time`) are no longer gated (W1-c): `sleep` wraps `Sleep` and
-  `Time#nowMillis` wraps `GetSystemTimeAsFileTime` (converting its
-  100ns-tick FILETIME output to unix epoch millis with the well-known
-  `116_444_736_000_000_000` 1601/1970 epoch offset), while `stopwatch`
-  snapshots `QueryPerformanceCounter` before and after the timed body
-  and divides the tick delta by `QueryPerformanceFrequency` to get
-  elapsed milliseconds -- see `emit_win_sleep_runtime`,
-  `emit_win_time_now_millis_runtime`, `emit_win_qpc_runtime`,
-  `emit_win_qpf_runtime`, and `emit_win_elapsed_millis_qpc` in
-  `crates/klassic-native/src/lib.rs`. The remaining gated paths --
-  `StandardInput#all`/`StandardInput#lines` (`stdin()`/`stdinLines()`),
-  the `FileOutput#`/`FileInput#` family including `std.file` and the
-  `println(FileInput#all(...))`/`println(FileInput#lines(...))`
-  print-fusion fast paths, the `Dir#` family including `std.dir`,
+  native-codegen path that could reach it now has its own Win64 shim, so
+  the tripwire is unreachable in practice: the `unsupported_on_target`
+  diagnostic helper that used to gate unimplemented Windows builtins is
+  now dead code (it is referenced only in a comment). Windows has full
+  OS-builtin coverage: `sleep`/`stopwatch`/`Time#nowMillis` (`std.time`)
+  wrap `Sleep`, `QueryPerformanceCounter`/`QueryPerformanceFrequency`,
+  and `GetSystemTimeAsFileTime` (converting its 100ns-tick FILETIME
+  output to unix epoch millis with the well-known
+  `116_444_736_000_000_000` 1601/1970 epoch offset) -- see
+  `emit_win_sleep_runtime`, `emit_win_time_now_millis_runtime`,
+  `emit_win_qpc_runtime`, `emit_win_qpf_runtime`, and
+  `emit_win_elapsed_millis_qpc` in `crates/klassic-native/src/lib.rs`.
+  `StandardInput#all`/`StandardInput#lines` (`stdin()`/`stdinLines()`)
+  read through a `ReadFile` shim against a stdin handle cached at
+  startup. The whole `Dir#` family (`current`/`temp`/`exists`/
+  `isDirectory`/`isFile`/`mkdir`/`mkdirs`/`list`/`listFull`/`delete`/
+  `copy`/`move`/`home`, including `std.dir`) goes through
+  `CreateDirectoryA`/`RemoveDirectoryA`/`MoveFileExA`/`CopyFileA`/
+  `GetCurrentDirectoryA`/`GetTempPathA`/`GetFileAttributesA` shims, plus
+  a `FindFirstFileA`/`FindNextFileA`/`FindClose` loop for `list`/
+  `listFull` that mirrors the Linux `getdents64` output contract.
   `Environment#vars`/`#get`/`#exists` (`std.env`, and the `env()`/
-  `getEnv()`/`hasEnv()` prelude aliases), and `CommandLine#args`
-  (`args()`, `std.cli`, `std.process`) -- all fail to build for
-  `x86_64-pc-windows-msvc` with a
-  for the Windows target as a deliberate invariant tripwire, but as of
-  W1-b every native-codegen path that could reach it was gated first;
-  since then, two of those families have been un-gated with real Win64
-  shim implementations instead (see below). `sleep`, `stopwatch`,
-  `Time#nowMillis` (`std.time`), `StandardInput#all`/`StandardInput#lines`
-  (`stdin()`/`stdinLines()`), and most of the `Dir#` family (`current`/
-  `temp`/`exists`/`isDirectory`/`isFile`/`mkdir`/`mkdirs`/`list`/
-  `listFull`/`delete`/`copy`/`move`, including `std.dir`) still fail to
-  build for `x86_64-pc-windows-msvc` with a
-  `` `Feature` is not yet supported when targeting x86_64-pc-windows-msvc ``
-  diagnostic instead of reaching the panic. `thread { ... }` needs no
-  gate of its own -- a queued thread body is spliced into the tail of
-  `main` and compiled through the same per-builtin gates as any other
-  call site, so an OS-touching thread body is still caught, and a
-  thread body that stays inside the core language still builds.
-  Process spawning (`Process#run`/`nrun`) has no native-backend
-  implementation on any target yet, so there is nothing Windows-specific
-  to gate there. See `tests/cli_smoke.rs`'s
-  `build_target_windows_x86_64_gates_*` tests for the still-gated
-  coverage and `build_target_windows_x86_64_supports_*` /
-  `build_target_windows_x86_64_sleep_and_stopwatch_run` /
-  `build_target_windows_x86_64_time_now_millis_runs` /
-  `build_target_windows_x86_64_format_iso_of_now_millis_runs` for the
-  sleep/stopwatch/time coverage.
-  coverage and `build_target_windows_x86_64_supports_*` for the
-  now-supported coverage.
-
-  `Environment#vars`/`#get`/`#exists` (`std.env`, and the `env()`/
-  `getEnv()`/`hasEnv()` prelude aliases), `CommandLine#args` (`args()`,
-  `std.cli`, `std.process`), and `Dir#home` no longer reach that
-  syscall-tripwire gate: `emit_store_command_line_state`'s Windows
-  branch now synthesizes the Linux `argv`/`envp` slot layout at startup
-  from `GetCommandLineA` (hand-tokenized) and `GetEnvironmentStringsA`
-  (walked into a synthesized pointer array) instead of leaving those
-  slots zeroed, so the existing envp-scan/argv-walk consumers work
-  unmodified (`Dir#home` reuses the same envp scan, keyed on
-  `USERPROFILE` instead of `HOME`). The whole `FileOutput#`/`FileInput#`
+  `getEnv()`/`hasEnv()` prelude aliases) and `CommandLine#args`
+  (`args()`, `std.cli`, `std.process`) no longer leave their backing
+  slots zeroed: `emit_store_command_line_state`'s Windows branch
+  synthesizes the Linux `argv`/`envp` slot layout at startup from
+  `GetCommandLineA` (hand-tokenized) and `GetEnvironmentStringsA`
+  (walked into a synthesized pointer array), so the existing
+  envp-scan/argv-walk consumers work unmodified (`Dir#home` reuses the
+  same envp scan, keyed on `USERPROFILE` instead of `HOME`); single-key
+  `Environment#get`/`#exists` lookups additionally go through a
+  `GetEnvironmentVariableA` shim so name resolution matches Windows'
+  case-insensitive semantics. The whole `FileOutput#`/`FileInput#`
   family (`write`/`append`/`writeLines`/`exists`/`delete`,
   `all`/`readAll`/`lines`/`readLines`, `std.file`, and the
   `println(FileInput#all(...))`/`println(FileInput#lines(...))`
-  print-fusion fast paths) is also un-gated: their `Open`/`Read`/
-  `Write`/`Close`/`Unlink`/`Access` syscall sites now branch to new
-  `CreateFileA`/`ReadFile`/`WriteFile`/`CloseHandle`/`DeleteFileA`/
-  `GetFileAttributesA`-backed Win64 shims. Both un-gated slices use only
-  the kernel32 "A" (ANSI) functions, reusing the existing UTF-8
-  path-staging code as-is, so non-ASCII paths and environment
-  values/keys are unsupported (best-effort/undefined) on this target.
+  print-fusion fast paths) goes through `CreateFileA`/`ReadFile`/
+  `WriteFile`/`CloseHandle`/`DeleteFileA`/`GetFileAttributesA`-backed
+  shims. All of the above use only the kernel32 "A" (ANSI) functions,
+  reusing the existing UTF-8 path-staging code as-is, so non-ASCII
+  paths and environment values/keys are unsupported (best-effort /
+  undefined) on this target -- the one documented Windows limitation.
+  `thread { ... }` needs no gate of its own -- a queued thread body is
+  spliced into the tail of `main` and compiled through the same
+  per-builtin paths as any other call site. Process spawning
+  (`Process#run`/`nrun`) has no native-backend implementation on any
+  target yet. See `tests/cli_smoke.rs`'s `build_target_windows_x86_64_supports_*`,
+  `build_target_windows_x86_64_sleep_and_stopwatch_run`,
+  `build_target_windows_x86_64_time_now_millis_runs`,
+  `build_target_windows_x86_64_format_iso_of_now_millis_runs`,
+  `build_target_windows_x86_64_stdin_all_runs`,
+  `build_target_windows_x86_64_dir_list_runs`,
+  `build_target_windows_x86_64_dir_runs`,
+  `build_target_windows_x86_64_command_line_args_runs`,
+  `build_target_windows_x86_64_environment_runs`,
+  `build_target_windows_x86_64_dir_home_runs`, and
+  `build_target_windows_x86_64_file_io_runs` for the coverage.
 - An unsupported target must produce a `TargetSpec`-style diagnostic,
   not a panic.
 

--- a/docs/release-notes/v0.4.0.md
+++ b/docs/release-notes/v0.4.0.md
@@ -1,0 +1,104 @@
+## Klassic 0.4.0
+
+Klassic 0.4.0 is the first release where `klassic build` can produce a
+real Windows executable — from Linux, macOS, *or* Windows — with zero
+external toolchain (no `cc`, no `link.exe`, no cross-compiler). It
+reuses the direct machine-code writers introduced for Linux (ELF64) and
+Apple Silicon (Mach-O), now joined by a direct PE64 backend for
+`x86_64-pc-windows-msvc`. Around it, this release is also a large
+correctness pass: 66 bug-fix commits close type-checker soundness
+holes, native-codegen miscompiles (variable capture/shadowing bugs,
+enum equality, buffer-offset reuse across calls), and dozens of
+parser/diagnostic sharp edges, alongside stdlib completeness work
+(`std.list`/`string`/`math`/`time`/`option`/`result`/`map`/`set`) and
+continued native-compiler coverage growth on the Linux and Apple
+Silicon backends.
+
+### Headline: direct PE64 backend for Windows (`x86_64-pc-windows-msvc`)
+
+- **Direct PE64 backend (#532)** — reuses the entire Linux
+  `DirectX86_64` code generator (the machine code is already
+  Win64-ABI-compatible); only the OS boundary (Win64 import-call shims)
+  and the container format (a minimal unsigned PE32+ writer with a
+  hand-built `kernel32.dll` import table) differ. No linker, no `cc`,
+  no Windows SDK — cross-builds work from any host via
+  `--target x86_64-pc-windows-msvc` / `windows-x86_64`, and
+  `klassic build` on a Windows host defaults to this backend.
+- **Full OS-builtin coverage on Windows (#533)** — `sleep`,
+  `stopwatch`, `Time#nowMillis`, the full `Dir#` family (create,
+  delete, move, copy, list, attributes, home, temp), `FileInput`/
+  `FileOutput`, `StandardInput`, `CommandLine#args`, and environment
+  variables (resolved case-insensitively, matching Windows semantics).
+  Verified end-to-end on real Windows 11; every `test-programs/`
+  program produces evaluator-identical output on Windows. Known
+  limitation: paths and environment values are ANSI-only in this
+  release (non-ASCII paths await a W-function pass).
+
+### Language and native-compiler features
+
+- Structural native equality for enum values (#523)
+- String ordering with the comparison operators (#516)
+- Hex, scientific, and underscore-separated number literals (#514)
+- Trailing commas in calls, parameter lists, and lambdas (#468)
+- Stateful interpolation lexer for arbitrary-depth string holes (#464)
+- Unreachable-match-arm reporting for duplicate constructors (#462) and
+  repeated literal arms (#527); Boolean match exhaustiveness (#526)
+- Type-class-constrained arithmetic for generic numeric code (#451)
+- Native Map/Set coverage on Linux x86_64: `put`/`remove`/`keys`/
+  `values`/`getOrElse`, `Set` `add`/`remove`/`toList`/`union`/
+  `intersect`/`subtract` (#504–#513)
+- Stdlib/user-module namespacing in native inlining (#449); enum method
+  dispatch through bindings and chains (#510)
+- Apple Silicon backend growth: cons lists, records, Double arithmetic,
+  sets and method-call dispatch (M7–M10)
+- Stdlib completeness wave: `std.list`/`string`/`math`/`time`/`option`/
+  `result`/`map`/`set` (#437–#448), `Process#run` (#442), recoverable
+  parsing (#441), `format`/`padStart`/`padEnd` (#440), clean stdlib
+  names (`filter`/`fold`/`flatMap`/`orElse`/`count`), and `none` as a
+  polymorphic value
+
+### Fixes
+
+**Type-checker soundness:** instance-method signature and body checks
+(#496, #497), curried over-application (#495), distinct type variables
+per constraint (#494), constraints through indirect bindings (#493),
+extension-method receiver type arguments (#492), bare type parameters
+as type variables (#489–#491), structural-record width subtyping
+(#488), nominal record annotations (#487), match-pattern checks against
+the scrutinee enum (#475, #499, #500), argument-order and
+element/value-type checks for higher-order and collection methods
+(#452, #454–#456, #466, #498).
+
+**Native-codegen miscompiles:** inner bindings shadowing an outer
+static value (#531), transitively-captured outer variables (#502),
+shadowed lambda params in returned closures (#484), recursive capture
+of a mutable global refused instead of miscompiled (#486), native enum
+equality refused-then-implemented structurally (#477, #523, #524),
+per-call buffer-offset resets (#480, #485), re-entrant interpolation
+holes (#503, #508), transitive stdlib import order (#509), integer
+overflow traps and clean division-by-zero errors matching the
+evaluator, C-backend double formatting (#525), record constructors in
+space-separated list literals (#530), duplicate map-literal keys
+(#481).
+
+**Parser and diagnostics:** clearer errors for `import foo.*`, variant
+fields, and wildcard imports (#478); readable unresolved type variables
+(#469); named types/fields in opaque diagnostics (#471); spans pointing
+at the value or arm body instead of keywords (#461, #473); missing
+brace reporting (#465); thin-arrow annotations accepted (#459);
+pluralized and constructor-aware arity errors (#472).
+
+**Stdlib correctness:** `.toString()` on every numeric and collection
+type (#528, #529), `lines()` phantom trailing line (#470), negative
+indices in `at`/`substring` clamped everywhere (#467), `isOdd`
+negatives, `sortBy` stability, `chunk` guard, pre-1970 `formatIso`,
+`parseIso` fraction scaling, aliased module imports in every form.
+
+### Documentation
+
+Native-coverage chapters for cleanup clauses, the proof surface, type
+classes, extension methods, and enum/match (#515, #517–#522); The
+Klassic Book gained a landing page and fully-runnable cookbook/tour;
+platform docs now cover all three targets.
+
+**Full Changelog**: https://github.com/klassic/klassic/compare/v0.3.0...v0.4.0

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -5,27 +5,38 @@ Releases are fully automated by `.github/workflows/release.yml`.
 ## Cutting a release
 
 1. Bump `version` in the root `Cargo.toml` so `klassic --version`
-   matches the tag, and commit it.
-2. Tag and push:
+   matches the tag (run `cargo build` once so `Cargo.lock` follows),
+   and sweep the handful of prose spots that carry the version:
+   `README.md`, `docs/book/src/getting-started/install.md`, and
+   `docs/book/src/introduction.md` (the 0.3.0 bump missed the book
+   files because nothing syncs them automatically).
+2. Write the release body at `docs/release-notes/<tag>.md` — the
+   `release-notes` workflow job sets it on the GitHub Release and
+   fails if the file is missing.
+3. Tag and push:
 
    ```bash
-   git tag v0.3.0
-   git push origin v0.3.0
+   git tag v0.4.0
+   git push origin v0.4.0
    ```
 
-The workflow runs the full test suite on Linux and macOS, builds a
-statically-linked `x86_64-unknown-linux-musl` binary (runs on any
-x86_64 Linux with no shared-library dependencies) plus macOS binaries
-for `aarch64-apple-darwin` and `x86_64-apple-darwin`, and attaches
-`klassic-<tag>-<target>.tar.gz` for each to a GitHub Release with
-generated notes.
+The workflow runs the full test suite on Linux, macOS, and Windows,
+builds a statically-linked `x86_64-unknown-linux-musl` binary (runs on
+any x86_64 Linux with no shared-library dependencies), macOS binaries
+for `aarch64-apple-darwin` and `x86_64-apple-darwin`, and a Windows
+`x86_64-pc-windows-msvc` executable, then attaches
+`klassic-<tag>-<target>.tar.gz` (`.zip` on Windows) for each to a
+GitHub Release whose body is the curated notes file.
 
-Users install releases with the one-liner (`install.sh` at the repo
-root, served raw from `main`):
+Users on Linux/macOS install releases with the one-liner (`install.sh`
+at the repo root, served raw from `main`):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/klassic/klassic/main/install.sh | sh
 ```
+
+Windows users download `klassic-<tag>-x86_64-pc-windows-msvc.zip` from
+the GitHub Release, extract `klassic.exe`, and put it on `PATH`.
 
 ## Dry run
 

--- a/docs/roadmap-targets-stdlib.md
+++ b/docs/roadmap-targets-stdlib.md
@@ -97,14 +97,21 @@ Targets are tracked as tiers; status lives in
 - **Tier 0 (direct PE64)** — `x86_64-pc-windows-msvc`: reuses the
   entire `DirectX86_64` (Linux) codegen as-is (the generated x86_64
   machine code is already Win64-ABI-compatible) and only swaps the OS
-  boundary (a handful of Win64 `kernel32.dll` import-call shims
-  replacing bare Linux `syscall` instructions at the `write`/`mmap`/
-  `exit` sites) and the container format (a minimal unsigned PE64
-  writer, `crates/klassic-native/src/pe.rs`, no external toolchain).
-  Non-core-language syscalls are not yet gated for Windows and remain
-  a follow-up slice (see `docs/native-coverage.md`'s target-matrix
-  notes) — reaching one from a Windows build is a deliberate
-  compile-time panic, not a silently wrong binary.
+  boundary (Win64 `kernel32.dll` import-call shims replacing bare
+  Linux `syscall` instructions) and the container format (a minimal
+  unsigned PE64 writer, `crates/klassic-native/src/pe.rs`, no external
+  toolchain). Windows now has full OS-builtin coverage: the core
+  language, `sleep`/`stopwatch`/`Time#nowMillis`, stdin, the whole
+  `FileOutput#`/`FileInput#` family, the whole `Dir#` family,
+  `Environment#`, and `CommandLine#args` all compile and run on this
+  target (see `docs/native-coverage.md`'s target-matrix notes for the
+  full builtin-by-builtin breakdown). Every builtin that could reach
+  `TargetPlatform::syscall_number`'s deliberate panic tripwire now has
+  its own Win64 shim instead, so the tripwire is unreachable in
+  practice. The one remaining limitation is that those shims use only
+  the kernel32 "A" (ANSI) functions, so non-ASCII paths and
+  environment values/keys are unsupported (best-effort/undefined) on
+  this target.
 
 The original key rule here ("no Mach-O / PE direct syscall paths") was
 revised twice. On 2026-06-11: macOS arm64 is important enough to


### PR DESCRIPTION
## Summary

Everything needed to cut v0.4.0 — the first release with the Windows PE64 target.

- **Version**: 0.4.0 (Cargo.toml + lock; `klassic --version` verified). The bump checklist in `docs/releasing.md` now includes the book files the 0.3.0 bump missed.
- **Toolchain**: `release.yml` gains a `release-windows` job (ships `klassic-<tag>-x86_64-pc-windows-msvc.zip` containing `klassic.exe`; no staticlib — the C backend's MSVC link path is unwired) and a `release-notes` job that sets the curated body from `docs/release-notes/<tag>.md` exactly once. This also fixes a real v0.3.0 defect: every asset job ran `generate_release_notes: true` against the same release, so the changelog was appended once per job (v0.3.0's body has it twice).
- **Release notes**: `docs/release-notes/v0.4.0.md` — curated coverage of the 147 commits since v0.3.0.
- **Documentation**: three-target sweep across README (platform matrix, Windows install), The Klassic Book (landing page redesigned around a cross-build transcript showing ELF and PE64 emitted side by side from one machine; install/building/file-io/process/concurrency/architecture/GC chapters), and consistency fixes in docs/native-coverage.md + docs/architecture-rust.md (contradictory leftover "still gated" claims consolidated).
- **CLI fix**: `klassic targets` reported tier 0 for every supported target (docs document aarch64-apple-darwin as tier 1) and the 14-char `direct-aarch64` collided with its column width, printing `direct-aarch64executable`. Tier now lives on `NativeTargetSpec`; TDD'd with a failing test first.

## Stability evidence

- 719 tests green locally; fmt/clippy clean; mdbook builds with zero warnings.
- Windows differential sweep: all 53 `test-programs/` produce evaluator-identical output executed on real Windows 11 (two apparent mismatches investigated and explained: stdout/stderr interleaving in the harness, and the intentional compile-time-fold divergence for host filesystem probes on cross-builds).
- Every doc example added or changed was executed; native-build examples were actually built (`file` output in the landing transcript is quoted from real artifacts).

## Test plan

- [x] Local gates + differential sweep
- [ ] CI green (ubuntu / macos / windows)
- [ ] `release.yml` dry run on this branch (workflow_dispatch — builds and packages all four jobs without publishing)
- [ ] After merge: tag `v0.4.0`, verify 4 assets + curated body (no duplicate changelog), install.sh end-to-end, and run the released `klassic.exe` on real Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)