### PR TITLE
ci: prove cross-built binaries run on their real target OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,217 @@ jobs:
 
       - name: Test
         run: cargo test
+
+  # --------------------------------------------------------------------
+  # Cross-execution guarantee.
+  #
+  # `test-macos` / `test-windows` above prove "a binary built ON that OS
+  # FOR that OS runs correctly there" (their build-and-run tests are
+  # cfg-gated to the matching host). They say nothing about a binary
+  # that was *cross-built on Linux* for `x86_64-pc-windows-msvc` or
+  # `aarch64-apple-darwin` -- which is the normal way klassic-native
+  # produces those binaries in practice, since the direct backends need
+  # no host `cc`/`as`/`ld`. These three jobs close that gap: `cross-build`
+  # (ubuntu-latest) evaluates each program in tests/cross-exec/*.kl to
+  # pin down its expected stdout, builds+runs the Linux-native binary
+  # immediately as the Linux leg of the guarantee, then cross-builds the
+  # Windows and macOS binaries and uploads them as artifacts;
+  # `cross-exec-windows` / `cross-exec-macos` download those binaries and
+  # actually execute them on the target OS, diffing stdout against the
+  # evaluator's output.
+  #
+  # aarch64-apple-darwin note: the direct Mach-O backend is younger than
+  # the shared x86_64 backend and does not implement every construct yet
+  # -- notably the OS-builtin modules (File/Dir/Environment/Time) and
+  # string interpolation. Cross-building for macOS is therefore
+  # best-effort per program: one that the backend can't build yet is
+  # logged and left out of the macOS bundle rather than failing the job,
+  # so this stays a real regression guard for whatever the backend
+  # *does* support today without blocking on a known, pre-existing
+  # coverage gap. Windows (which recently gained full OS-builtin
+  # coverage) and Linux have no such carve-out: every program in
+  # tests/cross-exec/ is required to build there, and to execute
+  # correctly on Linux.
+  cross-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build klassic
+        run: cargo build
+
+      - name: Build and verify cross-exec fixtures
+        run: |
+          set -uo pipefail
+          bin="$PWD/target/debug/klassic"
+          mkdir -p cross-exec-out/windows cross-exec-out/macos
+          status=0
+
+          for src in tests/cross-exec/*.kl; do
+            name=$(basename "$src" .kl)
+            echo "=== $name ==="
+
+            # The evaluator is the oracle every backend must match.
+            if ! "$bin" "$src" > "cross-exec-out/windows/$name.expected"; then
+              echo "FAIL: evaluator failed for $name"
+              status=1
+              continue
+            fi
+            cp "cross-exec-out/windows/$name.expected" "cross-exec-out/macos/$name.expected"
+
+            # Linux leg of the guarantee: build for the host target and
+            # run it immediately, right here -- no second runner needed.
+            if ! "$bin" --target x86_64-unknown-linux-gnu build "$src" -o "/tmp/$name.linux"; then
+              echo "FAIL: Linux native build failed for $name"
+              status=1
+              continue
+            fi
+            chmod +x "/tmp/$name.linux"
+            if ! (cd /tmp && "/tmp/$name.linux" >"/tmp/$name.linux.out"); then
+              echo "FAIL: Linux native run failed for $name"
+              status=1
+              continue
+            fi
+            if ! diff -u "cross-exec-out/windows/$name.expected" "/tmp/$name.linux.out"; then
+              echo "FAIL: Linux-native output mismatch for $name"
+              status=1
+              continue
+            fi
+            echo "  linux: build + run matches the evaluator"
+
+            # Windows: full OS-builtin coverage, so every program here
+            # is required to cross-build.
+            if ! "$bin" --target x86_64-pc-windows-msvc build "$src" -o "cross-exec-out/windows/$name.exe"; then
+              echo "FAIL: Windows cross-build failed for $name"
+              status=1
+              continue
+            fi
+            echo "  windows: cross-built"
+
+            # macOS: best-effort (see job comment above).
+            if "$bin" --target aarch64-apple-darwin build "$src" -o "cross-exec-out/macos/$name.macho" 2>"/tmp/$name.macos.err"; then
+              echo "  macos: cross-built"
+            else
+              echo "  macos: skipped (not supported yet by the aarch64-apple-darwin backend)"
+              sed 's/^/    /' "/tmp/$name.macos.err"
+              rm -f "cross-exec-out/macos/$name.expected" "cross-exec-out/macos/$name.macho"
+            fi
+          done
+
+          exit "$status"
+
+      - name: Upload Windows cross-exec bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: cross-exec-windows
+          path: cross-exec-out/windows
+
+      - name: Upload macOS cross-exec bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: cross-exec-macos
+          path: cross-exec-out/macos
+
+  cross-exec-windows:
+    needs: cross-build
+    runs-on: windows-latest
+    steps:
+      - name: Download cross-exec bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: cross-exec-windows
+          path: cross-exec-out
+
+      - name: Run each cross-built program and diff against the evaluator
+        shell: pwsh
+        run: |
+          $failed = $false
+          $checked = 0
+          Get-ChildItem -Path cross-exec-out -Filter *.exe | ForEach-Object {
+            $checked++
+            $exe = $_.FullName
+            $name = $_.BaseName
+            Write-Host "=== $name ==="
+            $expectedPath = Join-Path "cross-exec-out" "$name.expected"
+            if (-not (Test-Path $expectedPath)) {
+              Write-Host "FAIL: no .expected file found for $name"
+              $failed = $true
+              return
+            }
+            $actualRaw = & $exe | Out-String
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "FAIL: $name exited with code $LASTEXITCODE on Windows"
+              $failed = $true
+              return
+            }
+            $actual = ($actualRaw -replace "`r`n", "`n").TrimEnd("`n")
+            $expected = ((Get-Content -Raw -Path $expectedPath) -replace "`r`n", "`n").TrimEnd("`n")
+            if ($actual -ne $expected) {
+              Write-Host "FAIL: output mismatch for $name on Windows"
+              Write-Host "--- expected ---"
+              Write-Host $expected
+              Write-Host "--- actual ---"
+              Write-Host $actual
+              $failed = $true
+            } else {
+              Write-Host "$name matches"
+            }
+          }
+          if ($checked -eq 0) {
+            Write-Host "FAIL: no .exe binaries found in the cross-exec-windows artifact"
+            $failed = $true
+          }
+          if ($failed) {
+            exit 1
+          }
+
+  cross-exec-macos:
+    needs: cross-build
+    runs-on: macos-latest
+    steps:
+      - name: Show runner architecture
+        run: uname -m  # must be arm64; the Mach-O binaries here are arm64
+
+      - name: Download cross-exec bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: cross-exec-macos
+          path: cross-exec-out
+
+      - name: Run each cross-built program and diff against the evaluator
+        run: |
+          set -uo pipefail
+          shopt -s nullglob
+          binaries=(cross-exec-out/*.macho)
+          if [ ${#binaries[@]} -eq 0 ]; then
+            echo "FAIL: no .macho binaries found in the cross-exec-macos artifact"
+            exit 1
+          fi
+          failed=0
+          for bin in "${binaries[@]}"; do
+            name=$(basename "$bin" .macho)
+            echo "=== $name ==="
+            chmod +x "$bin"
+            expected="cross-exec-out/$name.expected"
+            if [ ! -f "$expected" ]; then
+              echo "FAIL: no .expected file found for $name"
+              failed=1
+              continue
+            fi
+            if ! "$bin" >"/tmp/$name.macos.out"; then
+              echo "FAIL: $name exited non-zero on macOS"
+              failed=1
+              continue
+            fi
+            if ! diff -u "$expected" "/tmp/$name.macos.out"; then
+              echo "FAIL: output mismatch for $name on macOS"
+              failed=1
+              continue
+            fi
+            echo "$name matches"
+          done
+          exit "$failed"

--- a/tests/cross-exec/01-hello-strings.kl
+++ b/tests/cross-exec/01-hello-strings.kl
@@ -1,0 +1,21 @@
+// Cross-exec guarantee: hello world + string interpolation + string ops.
+// Output must be byte-identical whether this program is run by the
+// evaluator, a Linux-native binary, a cross-built Windows binary, or a
+// cross-built macOS binary.
+val name = "Klassic"
+val version = 4
+val greeting = "Hello, #{name} v#{version}!"
+println(greeting)
+println(toUpperCase(greeting))
+println(toLowerCase(greeting))
+println(length(greeting))
+println(substring(greeting, 0, 5))
+println(replaceAll(greeting, "l", "L"))
+println(reverse("klassic"))
+println(startsWith(greeting, "Hello"))
+println(endsWith(greeting, "!"))
+val parts = split("alpha,beta,gamma", ",")
+println(parts)
+println(parts.join("-"))
+println(trim("  padded  "))
+println("sum=#{1 + 2}, product=#{3 * 4}")

--- a/tests/cross-exec/02-fib-arith.kl
+++ b/tests/cross-exec/02-fib-arith.kl
@@ -1,0 +1,34 @@
+// Cross-exec guarantee: recursion + arithmetic + comparison operators.
+// Klassic has no `%` infix operator (`%` is the map/set literal
+// prefix), so modulus is spelled out explicitly. Parameters are
+// annotated: the native compiler inlines unannotated recursive
+// functions at each call site, and a recursive call whose argument is
+// itself a call to another unannotated function (like `gcd` calling
+// `mod`) is not supported by that inlining path yet.
+def mod(n: Int, m: Int): Int = n - (n / m) * m
+
+def fib(n: Int): Int = if(n < 2) n else fib(n - 1) + fib(n - 2)
+
+mutable i = 0
+while(i <= 15) {
+  println(fib(i))
+  i = i + 1
+}
+
+def gcd(a: Int, b: Int): Int = if(b == 0) a else gcd(b, mod(a, b))
+println(gcd(48, 18))
+println(gcd(17, 5))
+
+val x = 7
+val y = 3
+println(x + y)
+println(x - y)
+println(x * y)
+println(x / y)
+println(mod(x, y))
+println(x > y)
+println(x < y)
+println(x >= 7)
+println(x <= 6)
+println(x == 7)
+println(x != y)

--- a/tests/cross-exec/03-enum-record-gc.kl
+++ b/tests/cross-exec/03-enum-record-gc.kl
@@ -1,0 +1,47 @@
+// Cross-exec guarantee: enum + match, nominal records, lists, and a
+// modest GC-churn loop (20k allocations of enums + records) that
+// produces a deterministic checksum instead of anything timing- or
+// address-dependent.
+enum Shape { case Circle(radius: Int); case Rectangle(width: Int, height: Int) }
+
+record Counter {
+  total: Int
+  count: Int
+}
+
+// Klassic has no `%` infix operator (`%` is the map/set literal
+// prefix), so modulus is spelled out explicitly.
+def mod(n: Int, m: Int): Int = n - (n / m) * m
+
+def area(s: Shape): Int = s match {
+  case Circle(r) => r * r * 3
+  case Rectangle(w, h) => w * h
+}
+
+// List-of-enum literals are a known native-codegen gap (see
+// docs/architecture-rust.md), so the enum values themselves stay in
+// plain `val`s and only their derived `Int` areas go into a list.
+// `map`/`foldLeft` (higher-order builtin calls) are avoided too: the
+// aarch64-apple-darwin backend does not implement them yet, so the
+// same reduction is spelled out by hand to keep this program buildable
+// on every cross-exec target.
+val c1 = Circle(2)
+val r1 = Rectangle(3, 4)
+val c2 = Circle(5)
+val a1 = area(c1)
+val a2 = area(r1)
+val a3 = area(c2)
+val areas = [a1, a2, a3]
+println(areas)
+println(size(areas))
+println(a1 + a2 + a3)
+
+mutable acc = #Counter(0, 0)
+mutable i = 0
+while(i < 20000) {
+  val s = if(mod(i, 2) == 0) Circle(mod(i, 7)) else Rectangle(mod(i, 5), mod(i, 3))
+  acc = #Counter(acc.total + area(s), acc.count + 1)
+  i = i + 1
+}
+println(acc.total)
+println(acc.count)

--- a/tests/cross-exec/04-file-roundtrip.kl
+++ b/tests/cross-exec/04-file-roundtrip.kl
@@ -1,0 +1,16 @@
+// Cross-exec guarantee: FileOutput/FileInput round-trip using a
+// relative path in whatever cwd the runner gives us. Only booleans
+// and file content (never a path) are printed, and the file is
+// cleaned up at the end so repeated runs are idempotent.
+val path = "kl_cross_exec_roundtrip.txt"
+
+println(FileOutput#exists(path))
+FileOutput#write(path, "line one")
+println(FileOutput#exists(path))
+println(FileInput#all(path))
+
+FileOutput#append(path, "\nline two")
+println(FileInput#all(path))
+
+FileOutput#delete(path)
+println(FileOutput#exists(path))

--- a/tests/cross-exec/05-dir-ops.kl
+++ b/tests/cross-exec/05-dir-ops.kl
@@ -1,0 +1,32 @@
+// Cross-exec guarantee: Dir mkdir/mkdirs/exists/isDirectory/move/delete,
+// all reported as booleans only (never a path or directory listing) so
+// output is identical across OSes. Cleans up after itself.
+//
+// Deliberately avoids checking `isDirectory` on a nested child path
+// immediately after moving its parent directory: the native compiler's
+// path-tracking for `Dir#move` does not currently propagate renames to
+// previously created child entries, which is an existing, narrow
+// native-codegen gap unrelated to the OS-execution guarantee this
+// suite checks. Each directory used here is moved/deleted as a whole,
+// independent unit instead.
+val base = "kl_cross_exec_dir_base"
+val extra = "kl_cross_exec_dir_extra"
+val moved = "kl_cross_exec_dir_moved"
+
+println(Dir#exists(base))
+Dir#mkdir(base)
+println(Dir#exists(base))
+println(Dir#isDirectory(base))
+
+Dir#mkdirs(extra)
+println(Dir#isDirectory(extra))
+
+Dir#move(base, moved)
+println(Dir#exists(base))
+println(Dir#isDirectory(moved))
+
+Dir#delete(moved)
+println(Dir#exists(moved))
+
+Dir#delete(extra)
+println(Dir#exists(extra))

--- a/tests/cross-exec/06-env-time.kl
+++ b/tests/cross-exec/06-env-time.kl
@@ -1,0 +1,12 @@
+// Cross-exec guarantee: Environment / Time, reported only as
+// deterministic booleans. Never print raw env values or timestamps,
+// since those legitimately differ across OSes and CI runs.
+println(Environment#exists("PATH"))
+println(Environment#exists("KL_CROSS_EXEC_DEFINITELY_NOT_SET_XYZ_123"))
+
+println(Time#nowMillis() > 1700000000000)
+println(Time#nowMillis() > 0)
+
+val a = Time#nowMillis()
+val b = Time#nowMillis()
+println(b >= a)


### PR DESCRIPTION
## Summary

Adds the guarantee コウタ asked for: **binaries cross-built on one OS demonstrably run on their real target OS, on every push**.

- `tests/cross-exec/`: six deterministic programs (strings/interpolation, recursion/arithmetic, enum+records+GC churn, file round-trip, dir ops, env/time as booleans) whose stdout is OS-independent.
- `cross-build` (ubuntu): generates expected output via the evaluator (the oracle), executes the Linux-native leg in-job, cross-builds the Windows and macOS legs, uploads artifacts.
- `cross-exec-windows` / `cross-exec-macos`: download and execute the cross-built binaries on the real OS, diffing stdout byte-for-byte.
- Windows/Linux legs: strict 6/6. macOS leg: best-effort per program (the aarch64 backend has no OS-builtin coverage yet — 2/6 cross-build today; backend growth is picked up automatically).

## Verification

- All six programs: evaluator output == Linux-native execution == **real Windows 11 execution of the cross-built .exe** (verified locally via WSL interop before this PR; CI repeats it on genuine runners).
- YAML validated; existing jobs untouched; no Rust changes; full suite green.

Found along the way (not fixed here): `Dir#isDirectory` misreports on a nested path immediately after `Dir#move` of its parent (native path-tracking staleness; filesystem state itself is correct) — backlogged.

## Test plan

- [ ] CI: the three new jobs run green (cross-exec-windows executes 6 binaries, cross-exec-macos executes 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)