### PR TITLE
feat: one-line PowerShell installer for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,14 @@ Linux (x86_64) or macOS:
 curl -fsSL https://raw.githubusercontent.com/klassic/klassic/main/install.sh | sh
 ```
 
-Windows: download `klassic-<version>-x86_64-pc-windows-msvc.zip` from
-the [releases](https://github.com/klassic/klassic/releases), extract
-`klassic.exe`, put it on `PATH`.
+Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/klassic/klassic/main/install.ps1 | iex
+```
+
+(or grab the zip from the
+[releases](https://github.com/klassic/klassic/releases) by hand.)
 
 From source: `cargo install --git https://github.com/klassic/klassic`
 

--- a/docs/book/src/getting-started/install.md
+++ b/docs/book/src/getting-started/install.md
@@ -33,11 +33,22 @@ Linux. The macOS builds run on macOS 11+.
 
 ## Windows
 
-Download the `klassic-vX.Y.Z-x86_64-pc-windows-msvc.zip` asset from
-the latest [release](https://github.com/klassic/klassic/releases),
-extract it, and put the folder containing `klassic.exe` on your `PATH`
-(for example, via *System Properties → Environment Variables*, or
-`setx PATH "%PATH%;C:\klassic"` in an elevated prompt). Then confirm it
+One line, in PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/klassic/klassic/main/install.ps1 | iex
+```
+
+The installer downloads the latest release into `%USERPROFILE%\.klassic\bin`,
+verifies it by running a Klassic program, and prints the one-liner that
+adds it to your user `PATH`. Set `KLASSIC_VERSION` to pin a tag,
+`KLASSIC_HOME` to change the install root — the same knobs as the Unix
+installer.
+
+Prefer doing it by hand? Download the
+`klassic-vX.Y.Z-x86_64-pc-windows-msvc.zip` asset from the latest
+[release](https://github.com/klassic/klassic/releases), extract it, and
+put the folder containing `klassic.exe` on your `PATH`. Then confirm it
 works from PowerShell or `cmd.exe`:
 
 ```bat

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,57 @@
+# Klassic installer for Windows:
+#
+#   irm https://raw.githubusercontent.com/klassic/klassic/main/install.ps1 | iex
+#
+# Downloads the latest release klassic.exe into ~\.klassic\bin. Set
+# KLASSIC_VERSION to pin a tag, KLASSIC_HOME to change the install
+# root. Mirrors install.sh, including the dogfooding smoke test: the
+# freshly installed compiler verifies itself by running a Klassic
+# program.
+$ErrorActionPreference = "Stop"
+
+$repo = "klassic/klassic"
+$root = if ($env:KLASSIC_HOME) { $env:KLASSIC_HOME } else { Join-Path $env:USERPROFILE ".klassic" }
+$installDir = Join-Path $root "bin"
+
+if ([System.Environment]::Is64BitOperatingSystem -eq $false) {
+    throw "no prebuilt binary for 32-bit Windows (try: cargo install --git https://github.com/$repo)"
+}
+
+$tag = $env:KLASSIC_VERSION
+if (-not $tag) {
+    $tag = (Invoke-RestMethod "https://api.github.com/repos/$repo/releases/latest").tag_name
+}
+if (-not $tag) {
+    throw "could not determine the latest release tag"
+}
+
+$asset = "klassic-$tag-x86_64-pc-windows-msvc.zip"
+$url = "https://github.com/$repo/releases/download/$tag/$asset"
+Write-Host "downloading klassic $tag (x86_64-pc-windows-msvc)..."
+New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+$zip = Join-Path $env:TEMP "klassic-install-$PID.zip"
+Invoke-WebRequest $url -OutFile $zip
+Expand-Archive -Path $zip -DestinationPath $installDir -Force
+Remove-Item $zip
+
+# Dogfooding smoke: the freshly installed compiler verifies itself by
+# running a Klassic program. A probe file (not -e) sidesteps Windows
+# PowerShell 5.1's native-argument quote mangling.
+$klassic = Join-Path $installDir "klassic.exe"
+$probe = Join-Path $env:TEMP "klassic-install-probe-$PID.kl"
+Set-Content -Path $probe -Value 'println("klassic " + "is " + "alive")' -Encoding Ascii
+$alive = & $klassic $probe
+Remove-Item $probe
+if ($alive -ne "klassic is alive") {
+    throw "installed klassic.exe failed its self-check (got: $alive)"
+}
+
+$version = & $klassic --version
+Write-Host "installed: $version -> $installDir"
+
+$onPath = ($env:Path -split ";") -contains $installDir
+if (-not $onPath) {
+    Write-Host ""
+    Write-Host "add it to your PATH (persists for your user):"
+    Write-Host "  [Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';$installDir', 'User')"
+}


### PR DESCRIPTION
## Summary

コウタ's ask: Windows installs should feel like Claude Code's `irm https://claude.ai/install.ps1 | iex`. Now they do:

```powershell
irm https://raw.githubusercontent.com/klassic/klassic/main/install.ps1 | iex
```

- `install.ps1` mirrors `install.sh` exactly: latest-release resolution (`KLASSIC_VERSION` pins, `KLASSIC_HOME` relocates), download+extract into `~\.klassic\bin`, a dogfooding self-check that runs a real Klassic program, and a user-`PATH` hint.
- Self-check uses a probe file instead of `-e` — Windows PowerShell 5.1 mangles embedded double quotes in native arguments (hit during verification).
- README and the Book's install page lead with the one-liner; the manual zip path stays as the fallback.

## Test plan

- [x] Executed on real Windows 11 PowerShell (5.1) against the live v0.4.0 release: download → extract → self-check ("klassic is alive") → `installed: klassic 0.4.0 -> ...` → PATH hint
- [x] mdbook builds clean
- [ ] CI green; after merge, verify the real `irm <raw URL> | iex` path end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)