### PR TITLE
fix: track descendant paths across Dir#move in native builds

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -25581,6 +25581,70 @@ impl NativeCodeGenerator {
         Ok(NativeValue::Unit)
     }
 
+    /// After a directory move, every tracked path underneath the moved
+    /// source has physically moved with it. Rewriting only the exact
+    /// source->target key left descendants keyed under the stale prefix,
+    /// so `Dir#isDirectory` constant-folded to the pre-move world.
+    fn move_virtual_descendants(&mut self, source: &str, target: &str) {
+        let source_prefix = format!("{source}/");
+        let target_prefix = format!("{target}/");
+        let moved_dirs: Vec<String> = self
+            .virtual_dirs
+            .iter()
+            .filter(|path| path.starts_with(&source_prefix))
+            .cloned()
+            .collect();
+        for old in moved_dirs {
+            self.virtual_dirs.remove(&old);
+            let renamed = format!("{target_prefix}{}", &old[source_prefix.len()..]);
+            self.unknown_virtual_paths.remove(&renamed);
+            self.virtual_dirs.insert(renamed);
+        }
+        let moved_files: Vec<String> = self
+            .virtual_files
+            .keys()
+            .filter(|path| path.starts_with(&source_prefix))
+            .cloned()
+            .collect();
+        for old in moved_files {
+            if let Some(content) = self.virtual_files.remove(&old) {
+                let renamed = format!("{target_prefix}{}", &old[source_prefix.len()..]);
+                self.unknown_virtual_paths.remove(&renamed);
+                self.virtual_files.insert(renamed, content);
+            }
+        }
+        let moved_unknown: Vec<String> = self
+            .unknown_virtual_paths
+            .iter()
+            .filter(|path| path.starts_with(&source_prefix))
+            .cloned()
+            .collect();
+        for old in moved_unknown {
+            self.unknown_virtual_paths.remove(&old);
+            self.unknown_virtual_paths
+                .insert(format!("{target_prefix}{}", &old[source_prefix.len()..]));
+        }
+    }
+
+    /// Conservative variant for moves where only one endpoint is
+    /// statically known: descendants of that endpoint become unknown
+    /// (their new location cannot be computed at compile time).
+    fn forget_virtual_descendants(&mut self, root: &str) {
+        let prefix = format!("{root}/");
+        let stale: Vec<String> = self
+            .virtual_dirs
+            .iter()
+            .chain(self.virtual_files.keys())
+            .filter(|path| path.starts_with(&prefix))
+            .cloned()
+            .collect();
+        for path in stale {
+            self.virtual_dirs.remove(&path);
+            self.virtual_files.remove(&path);
+            self.unknown_virtual_paths.insert(path);
+        }
+    }
+
     fn compile_dir_move(
         &mut self,
         arguments: &[Expr],
@@ -25596,11 +25660,13 @@ impl NativeCodeGenerator {
                 self.compile_path_argument_to_label(&arguments[1], span, "Dir#move")?;
             self.emit_dir_move_labels(source_label, target_label, span, "Dir#move");
             if let Some(source) = source {
+                self.forget_virtual_descendants(&source);
                 self.virtual_files.remove(&source);
                 self.virtual_dirs.remove(&source);
                 self.unknown_virtual_paths.insert(source);
             }
             if let Some(target) = target {
+                self.forget_virtual_descendants(&target);
                 self.virtual_files.remove(&target);
                 self.virtual_dirs.remove(&target);
                 self.unknown_virtual_paths.insert(target);
@@ -25614,6 +25680,10 @@ impl NativeCodeGenerator {
         let moved_file = self.virtual_files.remove(&source);
         let moved_dir = self.virtual_dirs.remove(&source);
         self.emit_dir_move(&source, &target, span, "Dir#move");
+        // Whatever previously lived under the target is gone; the
+        // source's subtree is now the target's subtree.
+        self.forget_virtual_descendants(&target);
+        self.move_virtual_descendants(&source, &target);
         if let Some(content) = moved_file {
             self.virtual_files.insert(target.clone(), content);
             self.unknown_virtual_paths.remove(&source);

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -283,6 +283,58 @@ fn arithmetic_typeclass_rejects_bad_operands() {
 /// in a single program — matching the evaluator.
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[test]
+fn native_dir_move_tracks_descendant_paths() {
+    // Issue #539: `Dir#move` swapped only the exact source->target key
+    // in the compile-time virtual filesystem state, so a child created
+    // under the source before the move kept its stale key -- and
+    // `Dir#isDirectory` constant-folded to the pre-move world (old
+    // path true, new path false; the evaluator says the opposite).
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic_dirmove_{stamp}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic_dirmove_{stamp}.bin"));
+    let work_dir = std::env::temp_dir().join(format!("klassic_dirmove_{stamp}.work"));
+    fs::create_dir(&work_dir).expect("work dir should create");
+    fs::write(
+        &source_path,
+        "Dir#mkdir(\"mvbase\")\nDir#mkdir(\"mvbase/x\")\nDir#move(\"mvbase\", \"mvmoved\")\nprintln(Dir#isDirectory(\"mvbase/x\"))\nprintln(Dir#isDirectory(\"mvmoved/x\"))\nDir#delete(\"mvmoved/x\")\nDir#delete(\"mvmoved\")\n",
+    )
+    .expect("source should write");
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            output_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build.status.success(),
+        "dir-move program should build natively\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .current_dir(&work_dir)
+        .output()
+        .expect("binary should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+    let _ = fs::remove_dir_all(&work_dir);
+    assert!(
+        run.status.success(),
+        "dir-move program should run\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    // The evaluator (oracle) prints false (old child path is gone)
+    // then true (the child moved with its parent).
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "false\ntrue\n");
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
 fn native_generic_arithmetic_monomorphizes() {
     let stamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)


### PR DESCRIPTION
## Summary

Fixes #539. `compile_dir_move` swapped only the exact source→target key in the compile-time virtual filesystem state; descendants stayed keyed under the stale prefix, so `Dir#isDirectory("moved/x")` after `Dir#move("base", "moved")` constant-folded to the **inverse** of the evaluator (native printed `true/false`, oracle says `false/true`) — a silent miscompile that `tests/cross-exec/05-dir-ops.kl` had to route around.

- Static branch: propagate every descendant across all three tracking sets (dirs / files-with-content / unknown), clearing stale unknown markers left by the overwritten target subtree (propagation preferred over invalidation so `Dir#list`'s `ensure_virtual_dir_state_known` doesn't start hard-erroring on moved subtrees).
- Runtime-string branch: conservatively forget descendants of statically-known endpoints.
- TDD: regression test written first (RED: `true/false`), fix, GREEN against the evaluator's `false/true`.

## Test plan

- [x] New linux-gated regression test `native_dir_move_tracks_descendant_paths` (hermetic work dir)
- [x] 720 tests green locally, fmt/clippy clean
- [x] Same program verified on real Windows 11 (`false/true`, exit 0) — the tracking serves the PE64 target too
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)