### PR TITLE
test: guard the Dir#move descendant shape in the cross-exec suite

### DIFF
--- a/tests/cross-exec/05-dir-ops.kl
+++ b/tests/cross-exec/05-dir-ops.kl
@@ -1,14 +1,8 @@
 // Cross-exec guarantee: Dir mkdir/mkdirs/exists/isDirectory/move/delete,
 // all reported as booleans only (never a path or directory listing) so
-// output is identical across OSes. Cleans up after itself.
-//
-// Deliberately avoids checking `isDirectory` on a nested child path
-// immediately after moving its parent directory: the native compiler's
-// path-tracking for `Dir#move` does not currently propagate renames to
-// previously created child entries, which is an existing, narrow
-// native-codegen gap unrelated to the OS-execution guarantee this
-// suite checks. Each directory used here is moved/deleted as a whole,
-// independent unit instead.
+// output is identical across OSes. Cleans up after itself. Includes
+// the move-then-check-nested-child shape that used to be a native
+// path-tracking miscompile (#539/#540) so the suite now guards it.
 val base = "kl_cross_exec_dir_base"
 val extra = "kl_cross_exec_dir_extra"
 val moved = "kl_cross_exec_dir_moved"
@@ -21,10 +15,16 @@ println(Dir#isDirectory(base))
 Dir#mkdirs(extra)
 println(Dir#isDirectory(extra))
 
+Dir#mkdir("kl_cross_exec_dir_base/child")
+println(Dir#isDirectory("kl_cross_exec_dir_base/child"))
+
 Dir#move(base, moved)
 println(Dir#exists(base))
 println(Dir#isDirectory(moved))
+println(Dir#isDirectory("kl_cross_exec_dir_base/child"))
+println(Dir#isDirectory("kl_cross_exec_dir_moved/child"))
 
+Dir#delete("kl_cross_exec_dir_moved/child")
 Dir#delete(moved)
 println(Dir#exists(moved))
 


### PR DESCRIPTION
## Summary

Follow-up to #540: `tests/cross-exec/05-dir-ops.kl` had to route around the Dir#move descendant-tracking miscompile; now that it's fixed, the suite exercises the exact previously-broken shape (mkdir a child, move the parent, assert `isDirectory` is false at the old child path and true at the new one) so the cross-exec jobs guard it on every push.

Verified locally: evaluator == Linux native == real Windows 11 execution, byte-identical (`false true true true true false true false true false false`). aarch64 still excludes this program via the best-effort macOS bundle until M15 (#538) lands — at which point it starts guarding macOS automatically.

## Test plan

- [x] eval / Linux-native / real-Windows outputs identical
- [x] cli_smoke green locally
- [ ] CI green (cross-exec-windows executes the strengthened program)

🤖 Generated with [Claude Code](https://claude.com/claude-code)