### PR TITLE
fix: trap i64::MIN negation and division by -1 in native builds

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -6728,6 +6728,13 @@ impl NativeCodeGenerator {
             }
             (UnaryOp::Minus, NativeValue::Int) => {
                 self.asm.neg_reg(Reg::Rax);
+                // `neg` sets OF exactly when the operand is i64::MIN,
+                // whose negation is unrepresentable; the evaluator
+                // reports this as a checked-arithmetic error.
+                let ok = self.asm.create_text_label();
+                self.asm.jcc_label(Condition::NoOverflow, ok);
+                self.emit_runtime_error(span, "integer overflow in unary negation");
+                self.asm.bind_text_label(ok);
                 Ok(NativeValue::Int)
             }
             (UnaryOp::Minus, NativeValue::StaticFloat { bits }) => Ok(NativeValue::StaticFloat {
@@ -7121,6 +7128,18 @@ impl NativeCodeGenerator {
                 self.asm.jcc_label(Condition::NotEqual, nonzero);
                 self.emit_runtime_error(span, "division by zero");
                 self.asm.bind_text_label(nonzero);
+                // i64::MIN / -1 overflows (the quotient is
+                // unrepresentable) and a bare `idiv` raises SIGFPE for
+                // it, just like division by zero; the evaluator
+                // reports `integer overflow`.
+                let do_divide = self.asm.create_text_label();
+                self.asm.cmp_reg_imm8(Reg::Rbx, -1);
+                self.asm.jcc_label(Condition::NotEqual, do_divide);
+                self.asm.mov_imm64(Reg::R10, i64::MIN as u64);
+                self.asm.cmp_reg_reg(Reg::Rax, Reg::R10);
+                self.asm.jcc_label(Condition::NotEqual, do_divide);
+                self.emit_runtime_error(span, "integer overflow");
+                self.asm.bind_text_label(do_divide);
                 self.asm.cqo();
                 self.asm.idiv_reg(Reg::Rbx);
             }

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -25215,6 +25215,93 @@ fn native_integer_overflow_is_a_clean_error() {
     );
 }
 
+/// Dividing i64::MIN by -1 overflows (the quotient is unrepresentable):
+/// the evaluator reports a clean `integer overflow`; the bare idiv used
+/// to raise SIGFPE (exit 136) with no diagnostic at all.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_min_int_division_by_minus_one_is_a_clean_error() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic_divmin_{stamp}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic_divmin_{stamp}.bin"));
+    fs::write(&source_path, "println((-9223372036854775807 - 1) / -1)\n")
+        .expect("source should write");
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            output_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build.status.success(),
+        "division program should build\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+    assert_eq!(run.status.code(), Some(1), "expected a clean exit-1 error");
+    assert!(
+        String::from_utf8_lossy(&run.stderr).contains("integer overflow"),
+        "expected `integer overflow` on stderr, got:\nstdout:{}\nstderr:{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+}
+
+/// Negating i64::MIN overflows: the evaluator reports `integer overflow
+/// in unary negation`; native used to wrap silently and print
+/// -9223372036854775808.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_min_int_negation_is_a_clean_error() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic_negmin_{stamp}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic_negmin_{stamp}.bin"));
+    fs::write(
+        &source_path,
+        "val x = -9223372036854775807 - 1\nprintln(-x)\n",
+    )
+    .expect("source should write");
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            output_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build.status.success(),
+        "negation program should build\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+    assert_eq!(run.status.code(), Some(1), "expected a clean exit-1 error");
+    assert!(
+        String::from_utf8_lossy(&run.stderr).contains("integer overflow in unary negation"),
+        "expected `integer overflow in unary negation` on stderr, got:\nstdout:{}\nstderr:{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+}
+
 /// An unannotated parameter the body uses as a String (here passed to
 /// the String-only `length`) now compiles natively: its native type is
 /// inferred from body usage as a heap string instead of defaulting to


### PR DESCRIPTION
## Summary

Two checked-arithmetic holes found by tonight's 277-probe differential hunt (eval as oracle), both at the i64::MIN edge the earlier add/sub/imul overflow traps missed:

| program | evaluator | native before | native after |
|---|---|---|---|
| `println((-9223372036854775807 - 1) / -1)` | `integer overflow`, exit 1 | **SIGFPE, exit 136, no output** | matches evaluator |
| `val x = -9223372036854775807 - 1; println(-x)` | `integer overflow in unary negation`, exit 1 | **silently printed `-9223372036854775808`** | matches evaluator |

- Division: after the existing zero-divisor guard, also guard `divisor == -1 && dividend == i64::MIN` (idiv raises #DE for it exactly like /0).
- Negation: x86 `neg` sets OF precisely when the operand is i64::MIN — same jno-check pattern the binary ops already use.
- TDD: regression tests written first (RED: SIGFPE / silent wrap), then the fix (GREEN). 722 tests green.
- Verified on real Windows 11: both programs produce the clean source-located diagnostics (shared codegen).

## Test plan

- [x] Two linux-gated regression tests asserting exit 1 + exact messages
- [x] Full suite green locally (722), fmt/clippy clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)