### PR TITLE
fix: resolve shared enum constructor names deterministically

### DIFF
--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 
 use klassic_span::{Diagnostic, DiagnosticKind, Severity, Span};
@@ -108,6 +108,19 @@ struct RecordSchema {
 struct EnumSchema {
     type_params: Vec<String>,
     variants: Vec<(String, Vec<Type>)>,
+    /// Process-wide monotonic registration order (see
+    /// `next_enum_declaration_order`), used to deterministically
+    /// resolve a bare constructor name shared by two enums in favour
+    /// of the more recently declared one — mirroring the ordinary
+    /// scope-shadowing rule already used for the constructor's own
+    /// binding (`declare_poly` simply overwrites the prior entry).
+    /// A `HashMap` iteration order is NOT usable for this: it is
+    /// re-randomised every process (`RandomState`), which previously
+    /// made programs that shadow a prelude constructor (e.g. a user
+    /// `enum Opt { case None; .. }` next to the prelude's `Option`)
+    /// typecheck successfully or fail with a bogus "type mismatch"
+    /// depending on the run.
+    declared_at: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -185,6 +198,27 @@ thread_local! {
     /// the caller.
     static USER_EXTENSION_METHODS: RefCell<HashMap<(String, String), StoredType>> =
         RefCell::new(HashMap::new());
+    /// Backing counter for `next_enum_declaration_order`. Deliberately
+    /// never reset by `clear_user_enum_schemas` (or anything else): it
+    /// only needs to keep growing so that any two `EnumSchema`s ever
+    /// alive at once compare in the order they were declared, even
+    /// across the `USER_ENUM_SCHEMAS` export/import round trip that
+    /// happens between successive top-level typechecks (REPL
+    /// statements, module compilation units, etc.) in the same
+    /// process/thread.
+    static ENUM_DECLARATION_ORDER: Cell<u64> = const { Cell::new(0) };
+}
+
+/// Hand out a fresh, process-thread-monotonic sequence number for an
+/// enum declaration, used to break ties deterministically when a
+/// constructor name (e.g. `None`) is shared by more than one visible
+/// enum. See the `declared_at` field of `EnumSchema`.
+fn next_enum_declaration_order() -> u64 {
+    ENUM_DECLARATION_ORDER.with(|counter| {
+        let order = counter.get();
+        counter.set(order + 1);
+        order
+    })
 }
 
 fn normalise_receiver_annotation(annotation: &TypeAnnotation) -> String {
@@ -4398,6 +4432,7 @@ impl TypeChecker {
             EnumSchema {
                 type_params: type_params.clone(),
                 variants: schema_variants.clone(),
+                declared_at: next_enum_declaration_order(),
             },
         );
         // Each constructor is a polymorphic function into the enum
@@ -4688,17 +4723,38 @@ impl TypeChecker {
         ))
     }
 
+    /// Resolve a bare constructor name (no scrutinee enum to pin it to)
+    /// against every enum currently in scope. When more than one enum
+    /// declares a variant of this name — most commonly a user enum
+    /// reusing a prelude name like `Some`/`None`/`Ok`/`Err` — the most
+    /// recently declared enum wins, by `EnumSchema::declared_at`. This
+    /// is a deliberate shadowing rule (user declarations, which are
+    /// always registered after the prelude's, shadow the prelude; a
+    /// later user enum shadows an earlier one), not an artifact of
+    /// `HashMap` iteration: iterating `self.enum_schemas` directly for
+    /// the first structural match was the actual bug (`RandomState`
+    /// reseeds every process, so the answer flipped run to run — see
+    /// issue #542). Ties (which `declared_at` cannot produce, since it
+    /// is a strictly increasing counter) would be broken by enum name
+    /// for full determinism, but are unreachable in practice.
     fn enum_variant_schema(&self, variant: &str) -> Option<(String, Vec<String>, Vec<Type>)> {
-        for (enum_name, schema) in &self.enum_schemas {
-            if let Some((_, fields)) = schema.variants.iter().find(|(name, _)| name == variant) {
-                return Some((
+        self.enum_schemas
+            .iter()
+            .filter_map(|(enum_name, schema)| {
+                schema
+                    .variants
+                    .iter()
+                    .find(|(name, _)| name == variant)
+                    .map(|(_, fields)| (enum_name, schema, fields))
+            })
+            .max_by_key(|(enum_name, schema, _)| (schema.declared_at, enum_name.as_str()))
+            .map(|(enum_name, schema, fields)| {
+                (
                     enum_name.clone(),
                     schema.type_params.clone(),
                     fields.clone(),
-                ));
-            }
-        }
-        None
+                )
+            })
     }
 
     fn infer_extension_declaration(
@@ -7136,7 +7192,7 @@ mod tests {
     use klassic_span::SourceFile;
     use klassic_syntax::parse_source;
 
-    use super::typecheck_program;
+    use super::{EnumSchema, Type, TypeChecker, next_enum_declaration_order, typecheck_program};
 
     #[test]
     fn accepts_basic_function_annotations() {
@@ -7436,6 +7492,87 @@ mod tests {
             error
                 .message
                 .contains("proof body does not establish declared proposition")
+        );
+    }
+
+    /// Regression test for issue #542: `enum_variant_schema` used to pick
+    /// among enums sharing a variant name by iterating `enum_schemas`
+    /// (a `HashMap`), whose order is re-randomised every process. That
+    /// made a program with both the prelude's `Option` and a user enum
+    /// declaring `None` typecheck or fail nondeterministically depending
+    /// on which enum the hash-order iteration happened to reach first.
+    /// This test bypasses the (already-deterministic, hash-order-blind)
+    /// program-level entry points and exercises the private resolution
+    /// method directly, so a regression here can't hide behind a lucky
+    /// hash seed the way a single end-to-end run could.
+    #[test]
+    fn enum_variant_schema_prefers_the_more_recently_declared_enum() {
+        let mut checker = TypeChecker::default();
+        let option_variants = vec![
+            ("Some".to_string(), vec![Type::Generic("a".to_string())]),
+            ("None".to_string(), Vec::new()),
+        ];
+        checker.enum_schemas.insert(
+            "Option".to_string(),
+            EnumSchema {
+                type_params: vec!["a".to_string()],
+                variants: option_variants.clone(),
+                declared_at: next_enum_declaration_order(),
+            },
+        );
+        // A user `enum Opt` is always registered strictly after the
+        // prelude's `Option` (the prelude is installed first; user
+        // source is typechecked afterwards), so it must win.
+        checker.enum_schemas.insert(
+            "Opt".to_string(),
+            EnumSchema {
+                type_params: vec!["a".to_string()],
+                variants: option_variants,
+                declared_at: next_enum_declaration_order(),
+            },
+        );
+        let (enum_name, _type_params, _fields) = checker
+            .enum_variant_schema("None")
+            .expect("`None` should resolve against one of the two registered enums");
+        assert_eq!(
+            enum_name, "Opt",
+            "a later-declared user enum must shadow an earlier one (here, the prelude's Option) \
+             for a shared bare constructor name"
+        );
+
+        // Insertion order into the `HashMap` must not matter — only
+        // `declared_at` does. Re-run with a fresh checker where `Opt` is
+        // inserted into the map before `Option`, but still declared
+        // (via `next_enum_declaration_order`) after it.
+        let mut checker = TypeChecker::default();
+        let opt_variants = vec![
+            ("Some".to_string(), vec![Type::Generic("a".to_string())]),
+            ("None".to_string(), Vec::new()),
+        ];
+        let option_order = next_enum_declaration_order();
+        let opt_order = next_enum_declaration_order();
+        checker.enum_schemas.insert(
+            "Opt".to_string(),
+            EnumSchema {
+                type_params: vec!["a".to_string()],
+                variants: opt_variants.clone(),
+                declared_at: opt_order,
+            },
+        );
+        checker.enum_schemas.insert(
+            "Option".to_string(),
+            EnumSchema {
+                type_params: vec!["a".to_string()],
+                variants: opt_variants,
+                declared_at: option_order,
+            },
+        );
+        let (enum_name, _type_params, _fields) = checker
+            .enum_variant_schema("None")
+            .expect("`None` should resolve against one of the two registered enums");
+        assert_eq!(
+            enum_name, "Opt",
+            "resolution must follow declaration recency, not HashMap insertion order"
         );
     }
 }

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -923,6 +923,65 @@ fn stdlib_enum_type_annotations_resolve() {
     );
 }
 
+/// Regression test for issue #542 (evaluator typechecker nondeterminism).
+/// The bundled `std.option` module — which declares `enum Option<a> {
+/// case Some(v: a); case None }` — is evaluated into every session
+/// unconditionally (`prepare_evaluator` walks `STDLIB_MODULES` before
+/// running user code), regardless of whether the program writes `import
+/// std.option`. So a user enum that reuses the `Some` / `None` variant
+/// names — here `Opt`, exactly as in the minimized issue repro — always
+/// has a real competing `Option` schema to contend with. `check`'s
+/// parameter is unannotated, so at the match arms `o`'s type is still a
+/// bare type variable and constructor resolution falls back to the
+/// (formerly `HashMap`-order-dependent) "no scrutinee to pin against"
+/// path. Before the fix this failed nondeterministically — observed
+/// ~35% of the time in a 30-run loop — with "type mismatch: Option<'a>
+/// is not compatible with Opt<'a>"; the user's later declaration must
+/// deterministically shadow the prelude's.
+#[test]
+fn user_enum_shadows_implicit_stdlib_option_for_unannotated_match() {
+    let output = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "enum Opt<a> { case Some(v: a); case None }\n\
+             def check(o) = o match { case None => 0; case Some(v) => 1 }\n\
+             println(check(None))",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        output.status.success(),
+        "a user enum reusing Some/None must shadow the implicit stdlib Option\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "0\n()\n");
+}
+
+/// Task 4c companion to the shadowing test above: when there is no
+/// conflicting user enum, `std.option`'s own `Some` / `None` must keep
+/// resolving correctly through the very same unannotated-match code
+/// path — the shadowing fix must not regress the ordinary case where
+/// there is nothing to shadow.
+#[test]
+fn stdlib_option_still_resolves_through_unannotated_match_without_a_conflicting_enum() {
+    let output = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "import std.option.{Some, None}\n\
+             def unwrap(o) = o match { case None => -1; case Some(v) => v }\n\
+             println(unwrap(Some(42)))\n\
+             println(unwrap(None))",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        output.status.success(),
+        "std.option's Some/None should still resolve without a conflicting enum\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "42\n-1\n()\n");
+}
+
 /// A match arm whose constructor an earlier unguarded, irrefutably-bound
 /// arm already matches is reported as unreachable — but a refutable
 /// earlier payload (`case S(1)`) does not close the variant, and guards

--- a/tests/language_regressions.rs
+++ b/tests/language_regressions.rs
@@ -797,6 +797,72 @@ fn match_resolves_constructors_against_the_scrutinee_enum() {
     );
 }
 
+/// Pins the exact minimized reproduction from issue #542: a user enum
+/// with an unannotated match scrutinee inside a generic function. `o`
+/// has NO type annotation, so at the point the match arms are checked
+/// the scrutinee is still a bare type variable, not a known
+/// `Type::Enum`. That forces the resolver down the "no scrutinee to pin
+/// against" path (`TypeChecker::enum_variant_schema`), which — before
+/// the fix — picked among enums sharing the `None` / `Some` names by
+/// iterating a `HashMap` whose order is re-randomised every process.
+/// `evaluate_text` alone (no bundled stdlib) only has this one enum
+/// registered, so it cannot reproduce the flakiness by itself; see
+/// `later_user_enum_shadows_an_earlier_user_enum_with_the_same_variant_names`
+/// below and `enum_variant_schema_prefers_the_more_recently_declared_enum` in
+/// `klassic-types` for tests that put two competing enums in
+/// `enum_schemas` and so exercise the actual HashMap-order hazard, and
+/// the fix's CLI-level 30x-loop verification (which does load the real
+/// stdlib `Option`) for empirical coverage of the flakiness itself.
+#[test]
+fn user_enum_constructor_resolves_deterministically_against_unannotated_scrutinee() {
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "enum Opt<a> { case Some(v: a); case None }\n\
+             def check(o) = o match { case None => 0; case Some(v) => 1 }\n\
+             check(None)",
+        )
+        .unwrap(),
+        Value::Int(0)
+    );
+}
+
+/// Two user enums sharing the `Some` / `None` variant names, both
+/// registered in the same typecheck pass, is exactly the shape that
+/// exposed the `HashMap`-iteration-order bug: both entries land in the
+/// same `enum_schemas` map, and the pre-fix blind lookup returned
+/// whichever the hasher visited first. The declared shadowing rule is
+/// "most recently declared wins" — mirroring the deterministic,
+/// scope-based shadowing that already applied to the constructor's own
+/// binding (`Some`/`None` as plain identifiers) even before this fix.
+/// `Second` is declared after `First`, so `Second` must win for both
+/// the unannotated match arm and the literal constructor call.
+#[test]
+fn later_user_enum_shadows_an_earlier_user_enum_with_the_same_variant_names() {
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "enum First<a> { case Some(v: a); case None }\n\
+             enum Second<a> { case Some(v: a); case None }\n\
+             def check(o) = o match { case None => 0; case Some(v) => 1 }\n\
+             check(None)",
+        )
+        .unwrap(),
+        Value::Int(0)
+    );
+    assert_eq!(
+        evaluate_text(
+            "<expr>",
+            "enum First<a> { case Some(v: a); case None }\n\
+             enum Second<a> { case Some(v: a); case None }\n\
+             def check(o) = o match { case None => 0; case Some(v) => 1 }\n\
+             check(Some(9))",
+        )
+        .unwrap(),
+        Value::Int(1)
+    );
+}
+
 #[test]
 fn record_specs_are_covered_more_directly() {
     assert_eq!(


### PR DESCRIPTION
## Summary

Fixes #542 — the **nondeterministic typechecker** found by tonight's differential hunt. A program declaring `enum Opt<a> { case Some(v: a); case None }` failed ~half of all process invocations with `type mismatch: Option<'a> is not compatible with Opt<'a>` and succeeded on the rest, byte-identical input, while native was always correct.

**Root cause**: when a match constructor can't be pinned to a concrete scrutinee enum (unannotated generic parameter), `enum_variant_schema` fell back to a linear scan over the `enum_schemas` HashMap — per-process-random iteration order decided whether the user's `Opt` or the always-registered stdlib `Option` won. The call site's literal `None` meanwhile resolved deterministically via scope shadowing, so the two halves of inference raced each other.

**Fix**: `EnumSchema` records a monotonic declaration counter; resolution picks the most recently declared candidate. Semantics: user enums shadow the implicit prelude, later user enums shadow earlier ones — the same last-write-wins rule the constructor value bindings already follow.

**Verification**: 30x loop of the minimized repro — pre-fix 11/30 spurious failures, post-fix 0/30 (independently re-run by the orchestrator). Unit test on the resolver, two language-regression tests, two e2e CLI tests (collision + no-collision control). 725 tests green, fmt/clippy clean.

## Test plan

- [x] 30x determinism loop (agent + orchestrator independently)
- [x] Full suite green locally (725)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)