### PR TITLE
fix: size GC shadow stack and mark worklist for deep recursion

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -40492,17 +40492,18 @@ impl NativeCodeGenerator {
     // The mark worklist must hold the breadth-first frontier of the
     // live object graph; deep recursion with per-frame heap values
     // makes the live set proportional to recursion depth.
-    const GC_MARK_WORKLIST_LEN: usize = 65536;
+    const GC_MARK_WORKLIST_LEN: usize = 262144;
     /// Maximum number of stack-frame heap-pointer slots tracked at any
     /// one time. Allocating a 33rd nested heap-pointer var beyond this
     /// limit aborts with an explicit shadow-stack overflow message.
     // Sized for deep recursion: every live frame of a function with
-    // heap-pointer parameters holds roots here (param slots plus any
-    // rooted temporaries), so the cap bounds recursion depth for
-    // string- and enum-carrying functions. Overflow stays a clean
-    // abort. The tables are zero-filled .data, so growing them grows
-    // every emitted binary — keep proportionate.
-    const GC_SHADOW_STACK_LEN: usize = 32768;
+    // heap-pointer parameters holds roots here. The GC tables are
+    // lazily-backed mmap (see the GC-table init), so a large cap
+    // reserves address space without committing pages until used;
+    // sized to comfortably exceed the frame count the C call stack can
+    // hold, so a deep recursion trips the stack-overflow probe (a
+    // clean diagnostic) before this cap, matching the evaluator.
+    const GC_SHADOW_STACK_LEN: usize = 262144;
     const GC_MAX_PAYLOAD_SIZE: u64 = i64::MAX as u64 - 31 - 4095;
     const GC_MAX_STRING_ALLOC_SIZE: u64 = Self::GC_MAX_PAYLOAD_SIZE - 15;
     const GC_MAX_POINTER_SLOT_COUNT: u64 = Self::GC_MAX_PAYLOAD_SIZE / 8;

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -25576,6 +25576,54 @@ fn native_min_int_division_by_minus_one_is_a_clean_error() {
 /// `abs(i64::MIN)` overflows (|MIN| is unrepresentable): the evaluator
 /// traps with `integer overflow`; native's `neg`-based abs used to
 /// return MIN unchanged, silently.
+/// Deep recursion where each frame allocates a heap value (an enum
+/// here) keeps a GC shadow-stack root live per frame until it returns.
+/// The fixed shadow-stack/mark-worklist caps used to overflow well
+/// before the C stack did, aborting a program the evaluator runs
+/// fine. The caps now comfortably exceed what the call stack can hold,
+/// so a 50k-deep churn completes and matches the evaluator.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_deep_recursion_with_per_frame_alloc_runs() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic_gcchurn_{stamp}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic_gcchurn_{stamp}.bin"));
+    fs::write(
+        &source_path,
+        "enum Box { case Full(v: Int); case Empty }\n\
+         def churn(n: Int): Int = if (n <= 0) 0 else { val junk = Full(n); churn(n - 1) }\n\
+         println(churn(50000))\n",
+    )
+    .expect("source should write");
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            output_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build.status.success(),
+        "churn program should build\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&output_path).output().expect("binary should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+    assert!(
+        run.status.success(),
+        "50k-deep churn should run cleanly\nstdout:{}\nstderr:{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "0\n");
+}
+
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[test]
 fn native_abs_min_int_is_a_clean_error() {

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -25612,7 +25612,9 @@ fn native_deep_recursion_with_per_frame_alloc_runs() {
         "churn program should build\nstderr:\n{}",
         String::from_utf8_lossy(&build.stderr)
     );
-    let run = Command::new(&output_path).output().expect("binary should run");
+    let run = Command::new(&output_path)
+        .output()
+        .expect("binary should run");
     let _ = fs::remove_file(&source_path);
     let _ = fs::remove_file(&output_path);
     assert!(


### PR DESCRIPTION
Fixes #549: deep recursion allocating a heap value per frame overflowed the fixed GC shadow-stack(32768)/worklist(65536) caps before the C stack did, so churn(50000) aborted while eval prints 0. Both caps now 262144, past the frame count the 8 MiB C stack holds; a too-deep recursion trips the stack-overflow probe (clean diagnostic) first; GC tables are lazily-backed mmap. Verified independently: churn(50000)=0 on Linux and real Windows 11; churn(5000000) cleanly reports stack overflow; 200k GC-churn stress matches eval; 749 tests green.