### PR TITLE
chore: prepare the v0.5.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "klassic"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "klassic-eval",
  "klassic-native",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "klassic"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 default-run = "klassic"
 

--- a/docs/book/src/getting-started/install.md
+++ b/docs/book/src/getting-started/install.md
@@ -25,7 +25,7 @@ Two environment variables tune the installer:
 
 | Variable | Effect |
 | --- | --- |
-| `KLASSIC_VERSION=v0.4.0` | Pin a specific release instead of the latest |
+| `KLASSIC_VERSION=v0.5.0` | Pin a specific release instead of the latest |
 | `KLASSIC_HOME=/opt/klassic` | Change the install root (binaries go to `$KLASSIC_HOME/bin`) |
 
 The Linux build is statically linked (musl) and runs on any x86_64

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -24,7 +24,7 @@
     <em class="kl-terminal-title">klassic — 80×14</em>
   </div>
   <pre><code><span class="kl-prompt">$</span> curl -fsSL https://raw.githubusercontent.com/klassic/klassic/main/install.sh | sh
-<span class="kl-dim">installed: klassic 0.4.0 -&gt; ~/.klassic/bin</span>
+<span class="kl-dim">installed: klassic 0.5.0 -&gt; ~/.klassic/bin</span>
 <span class="kl-prompt">$</span> cat fib.kl
 <span class="kl-out">def fib(n: Int): Int = if (n &lt; 2) n else fib(n - 1) + fib(n - 2)
 println(fib(25))</span>

--- a/docs/release-notes/v0.5.0.md
+++ b/docs/release-notes/v0.5.0.md
@@ -1,0 +1,66 @@
+## Klassic 0.5.0
+
+Klassic 0.5.0 teaches the native backend to compile enums carrying
+`Double`/`Float` payloads, clears a wave of native-codegen silent
+miscompiles surfaced by differential testing the native compiler
+against the evaluator, and adds a one-line PowerShell installer so
+Windows users can install with a single command. The correctness work
+is the bulk of the release: every fix below either eliminates a case
+where a native build silently disagreed with the evaluator, or turns a
+previously miscompiled construct into a clean, source-located
+diagnostic.
+
+### Native language coverage
+
+- **Double payloads in monomorphic native enums (#550)** — the native
+  backend now compiles enums whose cases hold `Double`/`Float` values.
+  The README's own `enum Shape { case Circle(r: Double); case Rect(w:
+  Double, h: Double) }` builds and runs with output identical to the
+  evaluator, including whole-number interpolation such as
+  `"a #{w}x#{h} box"`. Formatting a fractional value stays a clean
+  diagnostic for now, pending a runtime float formatter.
+
+### Fixes: silent miscompiles
+
+Found by a differential hunt that ran native builds against the
+evaluator as an oracle:
+
+- **Trap `i64::MIN` negation and division by `-1` in native builds
+  (#544)** — these overflow cases now trap instead of wrapping to a
+  wrong value.
+- **Trap `abs` of `i64::MIN` (#547)** — the one input where `abs`
+  cannot return a representable result now traps rather than returning
+  a negative number.
+- **Refuse closures capturing loop variables that escape the loop
+  (#546)** — a closure that captured a loop variable and outlived the
+  loop is rejected at build time instead of miscompiled.
+- **Refuse escaping closures returned from `.map`/`.foldLeft` lambdas
+  (#551)** — closures returned out of `.map`/`.foldLeft` lambda bodies
+  are now refused with a diagnostic rather than compiled to code that
+  reads freed frame state.
+- **Size the GC shadow stack and mark worklist for deep recursion
+  (#552)** — per-frame allocation no longer overflows the GC's
+  bookkeeping before the C stack itself does.
+- **Track descendant paths across `Dir#move` in native builds
+  (#540)** — the compile-time virtual directory tracker followed a
+  moved directory but lost its descendants, a silent miscompile now
+  fixed; the cross-exec suite guards the descendant shape (#541).
+
+### Fixes: other
+
+- **Resolve shared enum constructor names deterministically (#545)** —
+  a user enum that reused `Some`/`None` failed to compile roughly half
+  the time due to nondeterministic constructor-name resolution in the
+  typechecker; resolution is now deterministic.
+
+### Tooling and docs
+
+- **One-line PowerShell installer for Windows (#537)** — install with
+  `irm https://raw.githubusercontent.com/klassic/klassic/main/install.ps1 | iex`.
+- **Cut the README down to an entry point (#536)** — the README is now
+  a concise landing page that points at The Klassic Book.
+- **Prove cross-built binaries run on their real target OS (#535)** —
+  new cross-exec CI jobs execute cross-built binaries on the target OS
+  they were built for, not just on the build host.
+
+**Full Changelog**: https://github.com/klassic/klassic/compare/v0.4.0...v0.5.0

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -16,8 +16,8 @@ Releases are fully automated by `.github/workflows/release.yml`.
 3. Tag and push:
 
    ```bash
-   git tag v0.4.0
-   git push origin v0.4.0
+   git tag v0.5.0
+   git push origin v0.5.0
    ```
 
 The workflow runs the full test suite on Linux, macOS, and Windows,


### PR DESCRIPTION
Version bump 0.4.0 to 0.5.0, version-string sweep, and curated release notes (docs/release-notes/v0.5.0.md). Headline: native Double-payload enums (#550), silent-miscompile eliminations from differential testing (#544/#546/#547/#551/#552), deterministic constructor resolution (#545), and the Windows one-line installer (#537). Tag and dry-run driven from main after merge.