### PR TITLE
chore: prepare the v0.6.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "klassic"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "klassic-eval",
  "klassic-native",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "klassic"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 default-run = "klassic"
 

--- a/docs/book/src/getting-started/install.md
+++ b/docs/book/src/getting-started/install.md
@@ -25,7 +25,7 @@ Two environment variables tune the installer:
 
 | Variable | Effect |
 | --- | --- |
-| `KLASSIC_VERSION=v0.5.0` | Pin a specific release instead of the latest |
+| `KLASSIC_VERSION=v0.6.0` | Pin a specific release instead of the latest |
 | `KLASSIC_HOME=/opt/klassic` | Change the install root (binaries go to `$KLASSIC_HOME/bin`) |
 
 The Linux build is statically linked (musl) and runs on any x86_64

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -24,7 +24,7 @@
     <em class="kl-terminal-title">klassic — 80×14</em>
   </div>
   <pre><code><span class="kl-prompt">$</span> curl -fsSL https://raw.githubusercontent.com/klassic/klassic/main/install.sh | sh
-<span class="kl-dim">installed: klassic 0.5.0 -&gt; ~/.klassic/bin</span>
+<span class="kl-dim">installed: klassic 0.6.0 -&gt; ~/.klassic/bin</span>
 <span class="kl-prompt">$</span> cat fib.kl
 <span class="kl-out">def fib(n: Int): Int = if (n &lt; 2) n else fib(n - 1) + fib(n - 2)
 println(fib(25))</span>

--- a/docs/release-notes/v0.6.0.md
+++ b/docs/release-notes/v0.6.0.md
@@ -1,0 +1,23 @@
+## Klassic 0.6.0
+
+Klassic 0.6.0 completes the Double-payload story v0.5.0 started: native
+enums can now print and interpolate fractional Double values, not just
+whole numbers, closing the last gap in the README's own `Shape`
+example.
+
+### Native language coverage
+
+- **Format exact binary-fraction Doubles at runtime (#554)** — the
+  native backend links no external runtime, so runtime float
+  formatting has to be emitted as machine code. Doubles whose value is
+  an exact finite binary fraction (`2.5`, `3.25`, `0.5`, `0.125`, ...)
+  have a finite exact decimal expansion that equals Rust's
+  shortest-round-trip output, so no Ryu/Grisu implementation is
+  needed: the routine recovers the mantissa/exponent and computes the
+  exact digits directly, bounded so it can never disagree with the
+  evaluator. `Rect(2.5, 3.25)` now prints `a 2.5x3.25 box`, matching
+  the evaluator exactly. Values whose exact expansion doesn't fit
+  those bounds (`0.1`, `0.3`, `123.456`, NaN, Infinity) keep the
+  existing clean diagnostic rather than emitting wrong digits.
+
+**Full Changelog**: https://github.com/klassic/klassic/compare/v0.5.0...v0.6.0

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -16,8 +16,8 @@ Releases are fully automated by `.github/workflows/release.yml`.
 3. Tag and push:
 
    ```bash
-   git tag v0.5.0
-   git push origin v0.5.0
+   git tag v0.6.0
+   git push origin v0.6.0
    ```
 
 The workflow runs the full test suite on Linux, macOS, and Windows,


### PR DESCRIPTION
Version bump 0.5.0 to 0.6.0, version-string sweep, and curated release notes (docs/release-notes/v0.6.0.md). Headline: exact binary-fraction Double formatting at runtime (#554) — the README Shape example now formats fractional values (2.5, 3.25) matching the evaluator. Tag and dry-run driven from main after merge.