### PR TITLE
chore: prepare the v0.7.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "klassic"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "klassic-eval",
  "klassic-native",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "klassic"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 default-run = "klassic"
 

--- a/docs/book/src/getting-started/install.md
+++ b/docs/book/src/getting-started/install.md
@@ -25,7 +25,7 @@ Two environment variables tune the installer:
 
 | Variable | Effect |
 | --- | --- |
-| `KLASSIC_VERSION=v0.6.0` | Pin a specific release instead of the latest |
+| `KLASSIC_VERSION=v0.7.0` | Pin a specific release instead of the latest |
 | `KLASSIC_HOME=/opt/klassic` | Change the install root (binaries go to `$KLASSIC_HOME/bin`) |
 
 The Linux build is statically linked (musl) and runs on any x86_64

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -24,7 +24,7 @@
     <em class="kl-terminal-title">klassic — 80×14</em>
   </div>
   <pre><code><span class="kl-prompt">$</span> curl -fsSL https://raw.githubusercontent.com/klassic/klassic/main/install.sh | sh
-<span class="kl-dim">installed: klassic 0.6.0 -&gt; ~/.klassic/bin</span>
+<span class="kl-dim">installed: klassic 0.7.0 -&gt; ~/.klassic/bin</span>
 <span class="kl-prompt">$</span> cat fib.kl
 <span class="kl-out">def fib(n: Int): Int = if (n &lt; 2) n else fib(n - 1) + fib(n - 2)
 println(fib(25))</span>

--- a/docs/release-notes/v0.7.0.md
+++ b/docs/release-notes/v0.7.0.md
@@ -1,0 +1,38 @@
+## Klassic 0.7.0
+
+Klassic 0.7.0 removes the low-level `__gc_*` debug builtins
+(`__gc_string`, `__gc_list_int`, `__gc_smap_set`, and 65 others) from
+the language surface. Klassic has automatic garbage collection, so
+forcing ordinary code to reach for a raw heap-pointer API to build a
+string, list, or map dynamically was a design wart -- the cookbook's
+word-count and calculator recipes, and several Book tutorial pages,
+even presented them as the normal way to do it.
+
+### Language
+
+- **Remove low-level GC primitives from the language surface (#556,
+  #557)** -- referencing `__gc_alloc`, `__gc_list_ptr_*`,
+  `__gc_smap_*`, or any of the other 68 debug builtins from `.kl`
+  source is now an "undefined variable" error, identically on the
+  evaluator and native paths. Eleven of the 68 remain as
+  compiler-internal-only dispatch tags that the native backend's
+  enum-lowering desugar pass still synthesizes directly (never
+  reachable from parsed source); the other 57 -- along with their
+  ~4,400 lines of native-backend implementation and evaluator
+  dispatch -- are deleted outright. Ordinary `String`, `List<T>`, and
+  `Map<K, V>` values remain the only way to build heap-backed data;
+  the GC manages all of them without any explicit API.
+
+### Documentation
+
+- The Book's "The GC Heap" chapter (six pages presenting the debug
+  builtins as ordinary API) is removed, along with the cookbook
+  detours that used them (Hello World's heap-string variant,
+  Uppercase filter's heap-string variant). The word-count and
+  calculator recipes are rewritten against `Map<String, Int>` /
+  `List<String>` and re-verified end to end. Developer-facing
+  implementation notes (`architecture-rust.md`, `native-coverage.md`,
+  `implementation-notes.md`) are updated to describe only the eleven
+  remaining internal primitives.
+
+**Full Changelog**: https://github.com/klassic/klassic/compare/v0.6.0...v0.7.0

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -16,8 +16,8 @@ Releases are fully automated by `.github/workflows/release.yml`.
 3. Tag and push:
 
    ```bash
-   git tag v0.6.0
-   git push origin v0.6.0
+   git tag v0.7.0
+   git push origin v0.7.0
    ```
 
 The workflow runs the full test suite on Linux, macOS, and Windows,


### PR DESCRIPTION
Version bump 0.6.0 to 0.7.0, version-string sweep, and curated release notes (docs/release-notes/v0.7.0.md). Headline: removal of the low-level __gc_* debug builtins from the language surface (#556, #557). Tag and dry-run driven from main after merge.