### PR TITLE
feat: adopt Darwin's syscall carry-flag convention (#538 M11)

### DIFF
--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -23,6 +23,8 @@ use crate::macho::{self, DataFixup};
 
 const SYS_EXIT: u16 = 1;
 const SYS_WRITE: u16 = 4;
+/// Darwin `access(path, mode)`. `mode = 0` (`F_OK`) checks existence.
+const SYS_ACCESS: u16 = 33;
 /// Darwin `mmap`. Heap segments come straight from the kernel.
 const SYS_MMAP: u16 = 197;
 const STDOUT_FD: u64 = 1;
@@ -81,6 +83,11 @@ const FP: u32 = 29;
 enum Cond {
     Eq = 0,
     Ne = 1,
+    /// Carry clear. Darwin's `svc #0x80` convention signals a
+    /// *successful* syscall this way (carry set = failure, x0 holds
+    /// the positive errno) — the mirror image of Linux's
+    /// negative-rax convention.
+    Cc = 3,
     /// After `fcmp`: strictly less, unordered fails — the float `<`.
     Mi = 4,
     /// After `fcmp`: less-or-equal, unordered fails — the float `<=`.
@@ -347,6 +354,17 @@ impl Assembler {
         offset
     }
 
+    /// Intern a NUL-terminated C string — the shape every Darwin
+    /// path-taking syscall (`access`, and later `open`/`unlink`/...)
+    /// requires, distinct from `intern_string_object`'s length-prefixed
+    /// Klassic string layout.
+    fn intern_nul_terminated(&mut self, text: &str) -> usize {
+        let offset = self.rodata.len();
+        self.rodata.extend_from_slice(text.as_bytes());
+        self.rodata.push(0);
+        offset
+    }
+
     /// write(fd, <rodata bytes>, len) — clobbers x0/x1/x2/x16.
     fn emit_write_rodata(&mut self, fd: u64, bytes: &[u8]) {
         let data_offset = self.intern_rodata(bytes);
@@ -355,6 +373,15 @@ impl Assembler {
         self.mov_imm64(Reg::X2, bytes.len() as u64);
         self.mov_imm64(Reg::X16, u64::from(SYS_WRITE));
         self.svc_0x80();
+    }
+
+    /// `x0 = 1` if the preceding Darwin syscall succeeded (carry
+    /// clear), `0` otherwise — the qword-per-value sentinel `Dir#exists`
+    /// and friends return instead of aborting. Darwin's `svc #0x80`
+    /// carry-flag convention is the mirror image of Linux's
+    /// negative-rax convention (see issue #538, M11).
+    fn cset_syscall_succeeded(&mut self) {
+        self.cset(Reg::X0, Cond::Cc);
     }
 
     fn emit_exit(&mut self, status: u64) {
@@ -1910,6 +1937,28 @@ impl Emitter {
                     .emit_write_rodata(STDERR_FD, b"klassic: match: no pattern matched\n");
                 self.asm.emit_exit(1);
                 Ok(Some(ValueType::Never))
+            }
+            // `access(path, F_OK)`: the carry flag (Cond::Cc = success)
+            // becomes the Bool result directly — the first user of the
+            // M11 syscall-failure convention (issue #538).
+            ("Dir#exists", 1) | ("FileOutput#exists", 1) => {
+                let Expr::String {
+                    value,
+                    span: str_span,
+                } = &arguments[0]
+                else {
+                    return Err(unsupported(arguments[0].span(), "a non-literal path"));
+                };
+                if value.contains("#{") {
+                    return Err(unsupported(*str_span, "string interpolation"));
+                }
+                let path_offset = self.asm.intern_nul_terminated(value);
+                self.asm.load_rodata_address(Reg::X0, path_offset);
+                self.asm.mov_imm64(Reg::X1, 0); // F_OK
+                self.asm.mov_imm64(Reg::X16, u64::from(SYS_ACCESS));
+                self.asm.svc_0x80();
+                self.asm.cset_syscall_succeeded();
+                Ok(Some(ValueType::Bool))
             }
             _ => Ok(None),
         }

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -867,6 +867,18 @@ cargo run -- -e "1 + 2"
   backend for programs outside the direct subset; Linux x86_64 keeps
   the full-featured direct ELF backend with no fallback.
 
+  M11 (issue #538) adds `Cond::Cc` (carry clear), the AArch64
+  condition Darwin's `svc #0x80` sets on syscall success — the mirror
+  image of Linux's negative-rax convention. `Dir#exists` /
+  `FileOutput#exists` are its first user: `access(path, F_OK)`
+  followed by `cset x0, cc` turns the syscall's carry flag directly
+  into the `Bool` result, no branch needed. The remaining M11 plan
+  (M12 string interpolation, M13 string builtin parity, M14 file I/O,
+  M15 directory ops, M16 environment/time) still needs the carry-set
+  (failure) half for abort-on-error paths; that arm is added only once
+  a caller actually needs it, to avoid dead-code churn between now and
+  then.
+
   `x86_64-pc-windows-msvc` (`--target x86_64-pc-windows-msvc` /
   `windows-x86_64`) is the one target that does *not* get its own
   codegen module: it reuses the entire `DirectX86_64` (Linux) code

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -22325,6 +22325,100 @@ fn build_target_aarch64_apple_darwin_string_builtins_run() {
     );
 }
 
+/// Regression guard on any host: `Dir#exists`/`FileOutput#exists`
+/// must cross-build for aarch64-apple-darwin. This is the first user
+/// of the M11 Darwin-syscall-failure convention (issue #538): the
+/// carry flag after `access`'s `svc #0x80` becomes the Bool result
+/// directly via `Cond::Cc`.
+#[test]
+fn build_target_aarch64_apple_darwin_dir_exists_cross_build() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_macho_exists_xbuild_{stamp}.kl"));
+    let bin_path = dir.join(format!("klassic_macho_exists_xbuild_{stamp}.bin"));
+    fs::write(
+        &source_path,
+        "println(Dir#exists(\"/tmp\"))\n\
+         println(FileOutput#exists(\"/tmp\"))\n\
+         println(Dir#exists(\"/definitely-not-a-real-path-xyz\"))\n",
+    )
+    .expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "aarch64-apple-darwin",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&bin_path);
+    assert!(
+        build_output.status.success(),
+        "darwin Dir#exists cross build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+}
+
+/// M11 acceptance test: `Dir#exists`/`FileOutput#exists` actually run
+/// on an Apple Silicon mac, driving Darwin's `access` syscall through
+/// the new carry-flag-to-Bool convention.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn build_target_aarch64_apple_darwin_dir_exists_runs() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_macho_exists_run_{stamp}.kl"));
+    let bin_path = dir.join(format!("klassic_macho_exists_run_{stamp}.bin"));
+    fs::write(
+        &source_path,
+        "println(Dir#exists(\"/tmp\"))\n\
+         println(FileOutput#exists(\"/tmp\"))\n\
+         println(Dir#exists(\"/definitely-not-a-real-path-xyz\"))\n",
+    )
+    .expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "aarch64-apple-darwin",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build_output.status.success(),
+        "darwin Dir#exists build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+    let run_output = Command::new(&bin_path)
+        .output()
+        .expect("generated Mach-O should execute");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&bin_path);
+    assert!(
+        run_output.status.success(),
+        "Mach-O exited with {:?}\nstderr:\n{}",
+        run_output.status,
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run_output.stdout),
+        "true\ntrue\nfalse\n"
+    );
+}
+
 /// On Apple Silicon a target-less `build` detects the host: programs
 /// inside the direct subset get the toolchain-free Mach-O backend
 /// (no libSystem linkage), and programs outside it silently fall


### PR DESCRIPTION
## Summary

M11 of issue #538's aarch64-apple-darwin parity plan: Darwin arm64 signals a failed syscall via the carry flag after `svc #0x80` (x0 = positive errno when CS), the mirror image of Linux's negative-rax convention the x86_64 backend already handles.

- Adds `Cond::Cc` (carry clear = success) to the aarch64 backend's condition-code enum, wired through the existing `cset`/`branch` machinery — no new instruction encodings needed.
- First user: `Dir#exists`/`FileOutput#exists` compile to `access(path, F_OK)` followed by `cset x0, cc`, turning the syscall's carry flag directly into the `Bool` result.
- `Cond::Cs` (carry set = failure) and an abort-on-failure helper are intentionally left out — no M11-era caller needs them yet, and unused dead code would fail `clippy -D warnings`. They'll land with whichever later milestone (M14 file I/O, M15 dir ops) first needs to bail out of a failed syscall.

## Verification

- `Dir#exists("/tmp")` / `FileOutput#exists("/tmp")` → `true`, a nonexistent path → `false`, matching the evaluator exactly.
- Cross-built for `aarch64-apple-darwin` from this (Linux) host — Mach-O structure verified.
- Execution asserted by a new macOS-CI-gated test (`build_target_aarch64_apple_darwin_dir_exists_runs`); an ungated cross-build test runs on every host.
- 666 tests green, fmt/clippy clean.

## Test plan

- [x] `Dir#exists`/`FileOutput#exists` verified against the evaluator
- [x] aarch64 cross-build structural check (any host)
- [x] 666 tests green, fmt/clippy clean
- [ ] CI green (including macOS execution test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)