### PR TITLE
fix: attribute runtime errors to the module they came from (#450)

### DIFF
--- a/crates/klassic-eval/src/lib.rs
+++ b/crates/klassic-eval/src/lib.rs
@@ -87,6 +87,7 @@ struct ThreadFunctionSnapshot {
     constraints: Vec<TypeClassConstraint>,
     body: Expr,
     env: ThreadEnvironmentSnapshot,
+    source: Option<Arc<SourceFile>>,
 }
 
 thread_local! {
@@ -116,10 +117,25 @@ thread_local! {
     /// entries pointing at the same Arc reuse the same `Rc` and we
     /// don't re-walk the same snapshot tree N times.
     static FUNCTION_RESTORE_CACHE: RefCell<HashMap<*const ThreadFunctionSnapshot, Rc<FunctionValue>>> = RefCell::new(HashMap::new());
+
+    /// The `SourceFile` `evaluate_text_typed` is currently evaluating.
+    /// Every `FunctionValue` created while it's set is tagged with a
+    /// clone, so a runtime error raised inside that def's body later
+    /// (from a different call site, possibly in a different module)
+    /// can be rendered against the module it actually came from
+    /// instead of whatever file happens to be evaluating when the
+    /// error surfaces (issue #450).
+    static CURRENT_SOURCE: RefCell<Option<Arc<SourceFile>>> = const { RefCell::new(None) };
 }
 
 fn clear_function_snapshot_cache() {
     FUNCTION_SNAPSHOT_CACHE.with(|cache| cache.borrow_mut().clear());
+}
+
+/// The `SourceFile` currently being evaluated, if any — see
+/// `CURRENT_SOURCE`.
+fn current_source() -> Option<Arc<SourceFile>> {
+    CURRENT_SOURCE.with(|cell| cell.borrow().clone())
 }
 
 fn clear_function_restore_cache() {
@@ -162,7 +178,7 @@ type ThreadInstanceDictionaries = HashMap<String, Vec<ThreadInstanceDictionaryEn
 
 #[derive(Clone, Debug)]
 pub struct EvaluationError {
-    pub source: SourceFile,
+    pub source: Arc<SourceFile>,
     pub diagnostic: Diagnostic,
 }
 
@@ -174,7 +190,7 @@ impl EvaluationError {
 
 impl fmt::Display for EvaluationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.diagnostic.render(&self.source))
+        write!(f, "{}", self.diagnostic.render_with_fallback(&self.source))
     }
 }
 
@@ -262,6 +278,7 @@ fn snapshot_value_for_thread(value: &Value) -> ThreadValueSnapshot {
                 constraints: function.constraints.clone(),
                 body: function.body.clone(),
                 env,
+                source: function.source.clone(),
             });
             FUNCTION_SNAPSHOT_CACHE.with(|cache| {
                 cache.borrow_mut().insert(ptr, Arc::clone(&snapshot));
@@ -353,6 +370,7 @@ fn restore_thread_value(snapshot: ThreadValueSnapshot) -> Value {
                 constraints: inner.constraints,
                 body: inner.body,
                 env: restore_thread_environment(inner.env),
+                source: inner.source,
             });
             FUNCTION_RESTORE_CACHE.with(|cache| {
                 cache.borrow_mut().insert(key, Rc::clone(&rc));
@@ -652,6 +670,7 @@ fn register_extension_methods(expr: &Expr, environment: &Environment) {
             constraints: constraints.clone(),
             body: (**body).clone(),
             env: environment.clone(),
+            source: current_source(),
         }));
         USER_EXTENSION_METHODS.with(|registry| {
             registry
@@ -910,7 +929,24 @@ impl Evaluator {
         name: &str,
         text: &str,
     ) -> Result<(Value, String), EvaluationError> {
-        let source = SourceFile::new(name, text);
+        let source = Arc::new(SourceFile::new(name, text));
+        // Every `FunctionValue` created below is tagged with this
+        // source (see `current_source`), so a runtime error raised
+        // later inside its body renders against the module it was
+        // actually declared in (issue #450). Restore the previous
+        // value on the way out rather than unconditionally clearing
+        // it, in case of (currently nonexistent, but cheap to guard
+        // against) nested `evaluate_text_typed` calls.
+        let previous_source = CURRENT_SOURCE.with(|cell| cell.borrow().clone());
+        CURRENT_SOURCE.with(|cell| *cell.borrow_mut() = Some(source.clone()));
+        struct RestoreSource(Option<Arc<SourceFile>>);
+        impl Drop for RestoreSource {
+            fn drop(&mut self) {
+                CURRENT_SOURCE.with(|cell| *cell.borrow_mut() = self.0.take());
+            }
+        }
+        let _restore_source = RestoreSource(previous_source);
+
         let expr = parse_source(&source).map_err(|diagnostic| EvaluationError {
             source: source.clone(),
             diagnostic,
@@ -983,6 +1019,7 @@ fn type_diagnostic(span: Span, message: String) -> Diagnostic {
         span: Some(span),
         message,
         incomplete_input: false,
+        source: None,
     }
 }
 
@@ -1121,6 +1158,7 @@ fn eval_expr_inner(
                 constraints: Vec::new(),
                 body: (*proposition.clone()),
                 env: environment.clone(),
+                source: current_source(),
             }));
             placeholder.borrow_mut().set_value(function);
             Ok(Value::Unit)
@@ -1167,6 +1205,7 @@ fn eval_expr_inner(
                 constraints: constraints.clone(),
                 body: (*body.clone()),
                 env: environment.clone(),
+                source: current_source(),
             }));
             placeholder.borrow_mut().set_value(function);
             Ok(Value::Unit)
@@ -1182,6 +1221,7 @@ fn eval_expr_inner(
             constraints: Vec::new(),
             body: (*body.clone()),
             env: environment.clone(),
+            source: current_source(),
         }))),
         Expr::Assign { name, value, span } => {
             let evaluated = eval_expr(value, environment, state)?;
@@ -1703,6 +1743,7 @@ fn define_instance(
             constraints: constraints.clone(),
             body: (*body.clone()),
             env: environment.clone(),
+            source: current_source(),
         }));
         entries.push((name.clone(), function));
     }
@@ -2028,6 +2069,7 @@ fn partially_apply_callable(
                 constraints: function.constraints.clone(),
                 body: function.body.clone(),
                 env: partial_env,
+                source: function.source.clone(),
             })))
         }
         Value::BuiltinFunction(function) => {
@@ -2079,7 +2121,20 @@ fn invoke_user_function(
     let mut state = EvaluationState::default();
     let result = eval_expr(&function.body, &mut call_env, &mut state);
     call_env.pop_scope();
-    result
+    // The innermost failure (e.g. a builtin call deep inside this
+    // def's body) doesn't know which module it came from. Tag it with
+    // this function's own source the first time it crosses a function
+    // boundary, so it renders against the module the def actually
+    // lives in rather than whichever file is evaluating at the top
+    // level (issue #450). A diagnostic that already has a source came
+    // from a still-deeper call — leave it alone so the tag reflects
+    // the innermost def, not every frame it unwound through.
+    result.map_err(|mut diagnostic| {
+        if diagnostic.source.is_none() {
+            diagnostic.source = function.source.clone();
+        }
+        diagnostic
+    })
 }
 
 fn bind_constraint_methods_for_call(
@@ -2208,6 +2263,12 @@ fn eval_builtin(name: &str, arguments: &[Value], span: Span) -> Result<Value, Di
             let record_schemas = USER_RECORDS.with(|records| records.borrow().clone());
             let instance_methods = snapshot_instance_methods_for_thread();
             let instance_dictionaries = snapshot_instance_dictionaries_for_thread();
+            // So any FunctionValue built inside the spawned thread body
+            // (e.g. a def/lambda declared in a block the callable
+            // executes) still gets tagged with the right source
+            // (issue #450) — Arc<SourceFile> is Send+Sync, safe to
+            // move across the thread boundary.
+            let thread_source = current_source();
             let handle = thread::spawn(move || {
                 USER_MODULES.with(|modules| {
                     *modules.borrow_mut() = restore_module_exports_for_thread(module_exports);
@@ -2222,6 +2283,7 @@ fn eval_builtin(name: &str, arguments: &[Value], span: Span) -> Result<Value, Di
                     *dictionaries.borrow_mut() =
                         restore_instance_dictionaries_for_thread(instance_dictionaries);
                 });
+                CURRENT_SOURCE.with(|cell| *cell.borrow_mut() = thread_source);
                 clear_function_restore_cache();
                 let callable = restore_thread_value(callable);
                 clear_function_restore_cache();

--- a/crates/klassic-eval/src/value.rs
+++ b/crates/klassic-eval/src/value.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 use std::rc::Rc;
+use std::sync::Arc;
 
+use klassic_span::SourceFile;
 use klassic_syntax::{Expr, TypeAnnotation, TypeClassConstraint};
 
 use super::Environment;
@@ -211,4 +213,11 @@ pub struct FunctionValue {
     pub(crate) constraints: Vec<TypeClassConstraint>,
     pub(crate) body: Expr,
     pub(crate) env: Environment,
+    /// The module this def/lambda was declared in, if known — lets a
+    /// runtime error raised inside `body` render against the file it
+    /// actually came from rather than whatever file happens to be
+    /// evaluating when the call fails (issue #450). `None` only for
+    /// values built in isolated test/internal paths that never go
+    /// through the evaluator's normal source-tracked evaluation.
+    pub(crate) source: Option<Arc<SourceFile>>,
 }

--- a/crates/klassic-span/src/lib.rs
+++ b/crates/klassic-span/src/lib.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::sync::Arc;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Span {
@@ -83,6 +84,13 @@ pub struct Diagnostic {
     pub span: Option<Span>,
     pub message: String,
     pub incomplete_input: bool,
+    /// The source file `span` actually indexes into, when known. A
+    /// runtime error raised inside a stdlib/imported module's
+    /// function body carries a span in that module's own byte space;
+    /// tagging it here lets rendering pick the right `SourceFile`
+    /// instead of misrendering against whichever file happens to be
+    /// evaluating when the error surfaces (issue #450).
+    pub source: Option<Arc<SourceFile>>,
 }
 
 impl Diagnostic {
@@ -93,6 +101,7 @@ impl Diagnostic {
             span: Some(span),
             message: message.into(),
             incomplete_input: false,
+            source: None,
         }
     }
 
@@ -103,6 +112,7 @@ impl Diagnostic {
             span: Some(span),
             message: message.into(),
             incomplete_input: false,
+            source: None,
         }
     }
 
@@ -113,6 +123,7 @@ impl Diagnostic {
             span: Some(span),
             message: message.into(),
             incomplete_input: false,
+            source: None,
         }
     }
 
@@ -123,6 +134,7 @@ impl Diagnostic {
             span: None,
             message: message.into(),
             incomplete_input: false,
+            source: None,
         }
     }
 
@@ -142,6 +154,16 @@ impl Diagnostic {
                 format!("{}:{}:{}: {}", source.name(), line, column, self.message)
             }
             None => format!("{}: {}", source.name(), self.message),
+        }
+    }
+
+    /// Render against `self.source` when tagged (a runtime error that
+    /// crossed into a different module's function body), falling back
+    /// to `fallback` (the file actually being evaluated) otherwise.
+    pub fn render_with_fallback(&self, fallback: &SourceFile) -> String {
+        match &self.source {
+            Some(source) => self.render(source),
+            None => self.render(fallback),
         }
     }
 }

--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -6844,6 +6844,7 @@ fn type_error(span: Span, message: impl Into<String>) -> Diagnostic {
         span: Some(span),
         message: message.into(),
         incomplete_input: false,
+        source: None,
     }
 }
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1233,6 +1233,15 @@ cargo run -- -e "1 + 2"
 - The ELF writer computes the data segment offset from the actual text length and
   page-aligns it, so larger generated programs do not overwrite or truncate text.
 - Diagnostics are source-span aware across parse, type, and runtime errors.
+- Every `.kl` module the evaluator loads (the prelude, each imported `std.*`
+  module, each locally imported user file) is evaluated as its own
+  `SourceFile`, and every `FunctionValue`/`ThreadFunctionSnapshot` built while
+  one is active is tagged with an `Arc` clone (`CURRENT_SOURCE` in
+  `klassic-eval`). A runtime error that crosses a function-call boundary is
+  stamped with the innermost def's own source the first time it does, so
+  `Diagnostic::render_with_fallback` renders it against the module it
+  actually came from rather than whatever file the top-level caller happens
+  to be evaluating (issue #450).
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -133,6 +133,81 @@ fn arity_diagnostic_pluralizes() {
     );
 }
 
+/// A runtime error raised inside a stdlib function's body must render
+/// against that stdlib module's own source, not the user file that
+/// happened to be evaluating when the error surfaced (issue #450).
+/// Before the fix this reported a bogus `file:line` (the user file's
+/// line count plus one, from `SourceFile::line_col`'s out-of-range
+/// clamp) with the innermost builtin's own diagnostic text.
+#[test]
+fn runtime_error_inside_stdlib_function_reports_stdlib_source() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_issue450_{stamp}.kl"));
+    // A short user file: the bogus line the old code produced would be
+    // "6:1" (5 lines + 1), never a real location inside std.list.
+    fs::write(
+        &source_path,
+        "val a = 1\nval b = 2\nval c = 3\nimport std.list.{last}\nprintln(last([]))\n",
+    )
+    .expect("temp source file should write");
+    let output = Command::new(klassic_bin())
+        .arg(source_path.to_str().expect("path should be utf-8"))
+        .output()
+        .expect("binary should run");
+    let _ = fs::remove_file(&source_path);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.starts_with("<stdlib std.list>:"),
+        "expected the stdlib module's own diagnostic name, got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("6:1"),
+        "expected a real stdlib location, not the old bogus (user_lines + 1) line, got:\n{stderr}"
+    );
+}
+
+/// A runtime error raised inside a def declared in a different local
+/// module file (multi-file `import`, not stdlib) must likewise render
+/// against that module's own source (issue #450's fix is not
+/// stdlib-specific: any separately-evaluated SourceFile qualifies).
+#[test]
+fn runtime_error_inside_local_module_reports_module_source() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("klassic_issue450_multi_{stamp}"));
+    fs::create_dir_all(&dir).expect("temp dir should create");
+    let helper_path = dir.join("helper.kl");
+    let main_path = dir.join("main.kl");
+    fs::write(
+        &helper_path,
+        "module helper\n\ndef dangerous(xs) = head(xs)\n",
+    )
+    .expect("helper.kl should write");
+    fs::write(
+        &main_path,
+        "import helper.{dangerous}\nval a = 1\nval b = 2\nprintln(dangerous([]))\n",
+    )
+    .expect("main.kl should write");
+    let output = Command::new(klassic_bin())
+        .arg(main_path.to_str().expect("path should be utf-8"))
+        .output()
+        .expect("binary should run");
+    let _ = fs::remove_dir_all(&dir);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.starts_with("helper:3:"),
+        "expected the module's own diagnostic name and its real line (3), got:\n{stderr}"
+    );
+}
+
 /// Consistency helpers added across the ADT/collection stdlib:
 /// `Result.getOrElse` (the Option name, aliasing unwrapOr), `contains` /
 /// `exists` predicates on both Option and Result (dispatching by


### PR DESCRIPTION
## Summary

A runtime error raised inside a stdlib function's body was rendered against the user's own `SourceFile`, because every `.kl` module the evaluator loads (prelude, each imported `std.*` module, each locally imported user file) is evaluated as its own throwaway `SourceFile`, and the final `EvaluationError` always wrapped the diagnostic with whichever `SourceFile` the top-level `evaluate_text_typed` call happened to be holding. A stdlib-space byte offset rendered against the user file's (much shorter) text silently clamped to one past its last line, producing a bogus `file:N+1:1` location instead of erroring loudly.

```
$ klassic -e 'import std.list.{last}
last([])'
<stdlib std.list>:31:38: head expects a non-empty list
```
(Before this fix: `<e>:2:1: head expects a non-empty list` — a bogus line that doesn't exist in the 2-line input.)

## Fix

Every `FunctionValue`/`ThreadFunctionSnapshot` built while a source is being evaluated is tagged with an `Arc<SourceFile>` clone (`CURRENT_SOURCE` thread-local, cleared/restored around each `evaluate_text_typed` call). `invoke_user_function` stamps a still-untagged `Diagnostic` with the called function's own source the first time an error crosses a function-call boundary — innermost def wins, so a chain of stdlib calls attributes to where the failure actually originated. `Diagnostic::render_with_fallback` renders against that tag when present, falling back to the file actually being evaluated otherwise.

Same fix applies to a user's own multi-file local modules (evaluated as separate `SourceFile`s too, not just the stdlib bundle) — verified with a 2-file repro.

## Scope

This is the "bogus line" half of #450. The other half — the message naming the innermost builtin (`head`) rather than the function the user actually called (`last`) — needs real call-stack tracking, which doesn't exist anywhere in the evaluator today. That's a larger, separate piece of work; not attempted here to keep this change reviewable and low-risk.

## Verification

- Repro from the issue fixed: correct `<stdlib std.list>` name and line
- Ordinary same-file errors unaffected (verified unchanged line/column reporting)
- Multi-file user-module errors also correctly attributed
- `thread { ... }` closures propagate the source tag across the OS thread boundary (verified the mechanism compiles and the existing thread test suite stays green)
- 667 tests green, fmt/clippy clean

## Test plan

- [x] stdlib-function-body error reports the stdlib module's name/line, not a bogus one
- [x] multi-file local-module error reports that module's name/line
- [x] 667 tests green, fmt/clippy clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)