### PR TITLE
fix: attribute runtime errors to the function the user called (#450)

### DIFF
--- a/crates/klassic-eval/src/lib.rs
+++ b/crates/klassic-eval/src/lib.rs
@@ -126,6 +126,17 @@ thread_local! {
     /// instead of whatever file happens to be evaluating when the
     /// error surfaces (issue #450).
     static CURRENT_SOURCE: RefCell<Option<Arc<SourceFile>>> = const { RefCell::new(None) };
+
+    /// The literal name the user wrote to reach the call currently in
+    /// flight (e.g. `"last"` for `last([])`), set around each call
+    /// site that knows one and restored on the way out. A single slot
+    /// is enough (not a stack) because each push remembers the prior
+    /// value and a drop guard restores it when that call's dynamic
+    /// extent ends -- correct nesting for free. `invoke_user_function`
+    /// reads this to attribute a runtime error to the name the user
+    /// actually called instead of only the innermost builtin (issue
+    /// #450, second half).
+    static CURRENT_CALL_NAME: RefCell<Option<String>> = const { RefCell::new(None) };
 }
 
 fn clear_function_snapshot_cache() {
@@ -136,6 +147,31 @@ fn clear_function_snapshot_cache() {
 /// `CURRENT_SOURCE`.
 fn current_source() -> Option<Arc<SourceFile>> {
     CURRENT_SOURCE.with(|cell| cell.borrow().clone())
+}
+
+/// The literal name of the call currently in flight, if any — see
+/// `CURRENT_CALL_NAME`.
+fn current_call_name() -> Option<String> {
+    CURRENT_CALL_NAME.with(|cell| cell.borrow().clone())
+}
+
+/// Sets `CURRENT_CALL_NAME` to `name` for the caller's scope,
+/// restoring the previous value when this guard drops (including on
+/// early return through `?`).
+struct CallNameGuard(Option<String>);
+
+impl CallNameGuard {
+    fn push(name: impl Into<String>) -> Self {
+        let previous = CURRENT_CALL_NAME.with(|cell| cell.borrow().clone());
+        CURRENT_CALL_NAME.with(|cell| *cell.borrow_mut() = Some(name.into()));
+        Self(previous)
+    }
+}
+
+impl Drop for CallNameGuard {
+    fn drop(&mut self) {
+        CURRENT_CALL_NAME.with(|cell| *cell.borrow_mut() = self.0.take());
+    }
 }
 
 fn clear_function_restore_cache() {
@@ -1020,6 +1056,7 @@ fn type_diagnostic(span: Span, message: String) -> Diagnostic {
         message,
         incomplete_input: false,
         source: None,
+        call_name: None,
     }
 }
 
@@ -1909,6 +1946,7 @@ fn eval_call(
                 .iter()
                 .map(|argument| eval_expr(argument, environment, state))
                 .collect::<Result<Vec<_>, _>>()?;
+            let _call_name = CallNameGuard::push(field.as_str());
             return apply_callable(member, argument_values, span);
         }
         let target_value = eval_expr(target, environment, state)?;
@@ -1926,6 +1964,7 @@ fn eval_call(
             // applies when the method call supplies fewer args than
             // its arity: `xs.foldLeft(init)(f)` binds [xs, init] here,
             // then the trailing `(f)` completes it.
+            let _call_name = CallNameGuard::push(field.as_str());
             return apply_callable(
                 Value::BuiltinFunction(Rc::new(BuiltinFunctionValue {
                     name: builtin,
@@ -1944,6 +1983,7 @@ fn eval_call(
                     .map(|argument| eval_expr(argument, environment, state))
                     .collect::<Result<Vec<_>, _>>()?,
             );
+            let _call_name = CallNameGuard::push(field.as_str());
             return apply_callable(method, all_arguments, span);
         }
     }
@@ -1966,6 +2006,11 @@ fn eval_call(
     }
 
     let callee_value = eval_expr(callee, environment, state)?;
+    let _call_name = if let Expr::Identifier { name, .. } = callee {
+        Some(CallNameGuard::push(name.as_str()))
+    } else {
+        None
+    };
     apply_callable(callee_value, argument_values, span)
 }
 
@@ -2122,16 +2167,20 @@ fn invoke_user_function(
     let result = eval_expr(&function.body, &mut call_env, &mut state);
     call_env.pop_scope();
     // The innermost failure (e.g. a builtin call deep inside this
-    // def's body) doesn't know which module it came from. Tag it with
-    // this function's own source the first time it crosses a function
-    // boundary, so it renders against the module the def actually
-    // lives in rather than whichever file is evaluating at the top
-    // level (issue #450). A diagnostic that already has a source came
-    // from a still-deeper call — leave it alone so the tag reflects
-    // the innermost def, not every frame it unwound through.
+    // def's body) doesn't know which module it came from, or what
+    // name the user called to reach it. Tag both the first time the
+    // error crosses a function boundary, so it renders against the
+    // module the def actually lives in and names the call the user
+    // actually made rather than only the innermost builtin (issue
+    // #450). A diagnostic that already carries either tag came from a
+    // still-deeper call — leave it alone so the tags reflect the
+    // innermost def/call, not every frame they unwound through.
     result.map_err(|mut diagnostic| {
         if diagnostic.source.is_none() {
             diagnostic.source = function.source.clone();
+        }
+        if diagnostic.call_name.is_none() {
+            diagnostic.call_name = current_call_name();
         }
         diagnostic
     })

--- a/crates/klassic-span/src/lib.rs
+++ b/crates/klassic-span/src/lib.rs
@@ -91,6 +91,13 @@ pub struct Diagnostic {
     /// instead of misrendering against whichever file happens to be
     /// evaluating when the error surfaces (issue #450).
     pub source: Option<Arc<SourceFile>>,
+    /// The name the user actually called to reach the def whose body
+    /// raised this error, when known — e.g. `last` for a `head`
+    /// failure raised deep inside `def last(xs) = ... head(xs) ...`.
+    /// Rendered as a `{name}: ` prefix on the message so the error
+    /// names what the user called instead of only the innermost
+    /// builtin (issue #450, second half).
+    pub call_name: Option<String>,
 }
 
 impl Diagnostic {
@@ -102,6 +109,7 @@ impl Diagnostic {
             message: message.into(),
             incomplete_input: false,
             source: None,
+            call_name: None,
         }
     }
 
@@ -113,6 +121,7 @@ impl Diagnostic {
             message: message.into(),
             incomplete_input: false,
             source: None,
+            call_name: None,
         }
     }
 
@@ -124,6 +133,7 @@ impl Diagnostic {
             message: message.into(),
             incomplete_input: false,
             source: None,
+            call_name: None,
         }
     }
 
@@ -135,6 +145,7 @@ impl Diagnostic {
             message: message.into(),
             incomplete_input: false,
             source: None,
+            call_name: None,
         }
     }
 
@@ -147,13 +158,21 @@ impl Diagnostic {
         self.incomplete_input
     }
 
+    fn formatted_message(&self) -> String {
+        match &self.call_name {
+            Some(name) => format!("{name}: {}", self.message),
+            None => self.message.clone(),
+        }
+    }
+
     pub fn render(&self, source: &SourceFile) -> String {
+        let message = self.formatted_message();
         match self.span {
             Some(span) => {
                 let (line, column) = source.line_col(span.start);
-                format!("{}:{}:{}: {}", source.name(), line, column, self.message)
+                format!("{}:{}:{}: {}", source.name(), line, column, message)
             }
-            None => format!("{}: {}", source.name(), self.message),
+            None => format!("{}: {}", source.name(), message),
         }
     }
 

--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -6845,6 +6845,7 @@ fn type_error(span: Span, message: impl Into<String>) -> Diagnostic {
         message: message.into(),
         incomplete_input: false,
         source: None,
+        call_name: None,
     }
 }
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1265,6 +1265,24 @@ cargo run -- -e "1 + 2"
   `Diagnostic::render_with_fallback` renders it against the module it
   actually came from rather than whatever file the top-level caller happens
   to be evaluating (issue #450).
+- A `Diagnostic` also carries an optional `call_name`: the literal name the
+  user wrote to reach the call currently in flight (e.g. `last` for
+  `last([])`), tracked via a `CURRENT_CALL_NAME` thread-local pushed/restored
+  by a drop guard around each of `eval_call`'s four `apply_callable` call
+  sites in `klassic-eval`. `invoke_user_function` stamps a still-untagged
+  diagnostic with it the same way it stamps `source`, so a runtime error
+  raised deep inside a def's body (e.g. `head` failing inside `std.list`'s
+  `last`) renders as `last: head expects a non-empty list` instead of naming
+  only the innermost builtin — a bare builtin call with no wrapping user
+  `def` gets no prefix at all, and a chain of wrapper calls attributes to
+  the innermost def, not every frame it unwound through (issue #450, second
+  half). Known gap: the five `apply_callable` call sites reached from
+  *inside* a builtin's own implementation (a user callback passed to
+  `map`/`foldLeft`/`filter`/`thread`/`stopwatch`) have no textual name
+  available at that specific call point, so an error inside such a callback
+  inherits the enclosing builtin's own name (e.g. `map: ...`) rather than
+  naming the callback itself — an improvement over no name at all, but not
+  fully precise; left as a documented limitation rather than chased further.
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -208,6 +208,63 @@ fn runtime_error_inside_local_module_reports_module_source() {
     );
 }
 
+/// The second half of issue #450: a runtime error raised inside a
+/// stdlib function's body must also name the function the user
+/// actually called (`last`), not just the innermost builtin
+/// (`head`). `def last(xs) = if(isEmpty(tail(xs))) head(xs) else
+/// last(tail(xs))` calls `head` internally on an empty list.
+#[test]
+fn runtime_error_names_the_function_the_user_called() {
+    let output = Command::new(klassic_bin())
+        .args(["-e", "import std.list.{last}\nlast([])"])
+        .output()
+        .expect("binary should run");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stderr.trim_end(),
+        "<stdlib std.list>:31:38: last: head expects a non-empty list"
+    );
+}
+
+/// A bare builtin call with no wrapping user `def` must NOT gain a
+/// spurious call-name prefix — there is no user-level call to
+/// attribute the error to.
+#[test]
+fn runtime_error_bare_builtin_call_has_no_call_name_prefix() {
+    let output = Command::new(klassic_bin())
+        .args(["-e", "head([])"])
+        .output()
+        .expect("binary should run");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stderr.trim_end(),
+        "<expression>:1:1: head expects a non-empty list"
+    );
+}
+
+/// When a user def wraps a call into a stdlib function, the
+/// call-name attribution names the innermost def (`last`), not the
+/// user's own wrapper (`wrapper`) — matching the "innermost def wins"
+/// rule the source-attribution half of #450 already established.
+#[test]
+fn runtime_error_through_wrapper_names_innermost_def() {
+    let output = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "import std.list.{last}\ndef wrapper(xs) = last(xs)\nwrapper([])",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stderr.trim_end(),
+        "<stdlib std.list>:31:38: last: head expects a non-empty list"
+    );
+}
+
 /// Consistency helpers added across the ADT/collection stdlib:
 /// `Result.getOrElse` (the Option name, aliasing unwrapOr), `contains` /
 /// `exists` predicates on both Option and Result (dispatching by


### PR DESCRIPTION
## Summary

Second half of #450: a runtime error raised inside a stdlib function's body named only the innermost builtin (`"head expects a non-empty list"`) rather than the function the user actually called (`"last"`, where `std.list`'s `last(xs)` calls `head(xs)` internally on an empty list).

```
$ klassic -e 'import std.list.{last}
last([])'
<stdlib std.list>:31:38: last: head expects a non-empty list
```

## Mechanism

`Diagnostic` gains a `call_name: Option<String>` field alongside the `source` field the first half of #450 added, rendered as a `"{name}: "` prefix on the message. A `CURRENT_CALL_NAME` thread-local (mirroring `CURRENT_SOURCE`) tracks the literal name the user wrote to reach the call currently in flight, pushed via a drop-guard (`CallNameGuard`) around each of `eval_call`'s four `apply_callable` call sites — the name is a plain `&str` local there, before the callee resolves to a `Value`. `invoke_user_function` stamps a still-untagged diagnostic with it the same way it stamps `source`: innermost def wins, so a chain of wrapper calls attributes to where the failure actually originated, not every frame it unwound through.

A bare builtin call with no wrapping user `def` gets no prefix at all (`head([])` directly still reads `"head expects a non-empty list"`), since it never crosses `invoke_user_function`.

## Known limitation (documented, not chased)

The five `apply_callable` call sites reached from *inside* a builtin's own implementation (a user callback passed to `map`/`foldLeft`/`filter`/`thread`/`stopwatch`) have no textual name available at that specific call point, so an error inside such a callback inherits the enclosing builtin's own name (e.g. `"map: ..."`) rather than naming the callback itself. Still strictly better than no name at all, and doesn't miscompile or crash — just imprecise in that one case.

## Verification

- `last([])` → `<stdlib std.list>:31:38: last: head expects a non-empty list`
- Bare `head([])` → unchanged, no spurious prefix
- Wrapper chain (`wrapper(xs) = last(xs)`) → attributes to `last`, not `wrapper`
- 672 tests green, fmt/clippy clean

## Test plan

- [x] stdlib-function-body error names the function the user called
- [x] bare builtin call has no call-name prefix
- [x] wrapper-chain call attributes to the innermost def
- [x] 672 tests green, fmt/clippy clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)