### PR TITLE
feat: replaceAll for aarch64 (#538, remaining M13 slice)

### DIFF
--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -565,6 +565,41 @@ impl Assembler {
         self.bind(done);
     }
 
+    /// `dst = 1` if the `len` bytes at `a_ptr` equal the `len` bytes
+    /// at `b_ptr`, `0` otherwise. Consumes `len`/`a_ptr`/`b_ptr`
+    /// (post-increments through them) -- callers that need the
+    /// originals intact afterward should pass working copies.
+    /// `scratch1`/`scratch2` hold one byte from each side per
+    /// iteration.
+    fn bytes_equal(
+        &mut self,
+        len: Reg,
+        a_ptr: Reg,
+        b_ptr: Reg,
+        dst: Reg,
+        scratch1: Reg,
+        scratch2: Reg,
+    ) {
+        let differ = self.new_label();
+        let same = self.new_label();
+        let done = self.new_label();
+        let loop_start = self.new_label();
+        self.bind(loop_start);
+        self.branch(same, BranchKind::CompareZero(len));
+        self.ldrb_post_increment(scratch1, a_ptr);
+        self.ldrb_post_increment(scratch2, b_ptr);
+        self.cmp_reg(scratch1, scratch2);
+        self.branch(differ, BranchKind::Conditional(Cond::Ne));
+        self.sub_reg_imm(len, len, 1);
+        self.branch(loop_start, BranchKind::Unconditional);
+        self.bind(same);
+        self.mov_imm64(dst, 1);
+        self.branch(done, BranchKind::Unconditional);
+        self.bind(differ);
+        self.mov_imm64(dst, 0);
+        self.bind(done);
+    }
+
     /// `lsr xd, xn, #shift`
     fn lsr_imm(&mut self, dst: Reg, src: Reg, shift: u32) {
         debug_assert!(shift < 64);
@@ -1971,6 +2006,163 @@ impl Emitter {
         self.asm.mov_reg(Reg::X0, Reg::X5);
     }
 
+    /// `replaceAll`(input, pattern, replacement): literal-substring
+    /// replacement (not the evaluator's `"[0-9]"` pseudo-regex special
+    /// case, and an empty pattern aborts rather than replicating
+    /// Rust's between-every-character `str::replace("")` semantics --
+    /// both explicit, documented scope reductions from x86_64
+    /// parity). Non-overlapping matches, scanning left to right.
+    ///
+    /// This needs six fixed values alive across the whole two-pass
+    /// operation (each of input/pattern/replacement's byte-base
+    /// pointer and length) plus a running match count and total
+    /// result length -- more than fits resident in registers across
+    /// two `emit_alloc` calls without a deliberate spill scheme (this
+    /// is exactly the register-pressure wall an earlier attempt at
+    /// this routine hit and abandoned). Instead of spilling to
+    /// individual stack slots, the six fixed values are written once
+    /// into a single 48-byte scratch heap object right after they're
+    /// computed, and re-loaded from it by offset wherever needed --
+    /// so the only value that must stay resident in a register across
+    /// every subsequent `emit_alloc` call is the one pointer to that
+    /// object (`x6`), the same one-value-survives-the-call discipline
+    /// every other M13 routine already uses (M13 slice 1's `trim` bug
+    /// was exactly a missed instance of it).
+    fn emit_str_replace_all(&mut self) {
+        // x0=input, x1=pattern, x2=replacement
+        self.asm.ldr_imm(Reg::X3, Reg::X1, 0); // pattern_len
+        let pattern_ok = self.asm.new_label();
+        self.asm
+            .branch(pattern_ok, BranchKind::CompareNonZero(Reg::X3));
+        self.asm.emit_write_rodata(
+            STDERR_FD,
+            b"klassic: replaceAll pattern must not be empty\n",
+        );
+        self.asm.emit_exit(1);
+        self.asm.bind(pattern_ok);
+
+        self.asm.push(Reg::X0);
+        self.asm.push(Reg::X1);
+        self.asm.push(Reg::X2);
+        self.asm.mov_imm64(Reg::X4, 48);
+        self.emit_alloc(); // x5 = scratch struct
+        self.asm.mov_reg(Reg::X6, Reg::X5);
+        self.asm.pop(Reg::X2);
+        self.asm.pop(Reg::X1);
+        self.asm.pop(Reg::X0);
+
+        // Scratch layout: [0]=input_bytes_base [8]=input_len
+        // [16]=pattern_bytes_base [24]=pattern_len
+        // [32]=replacement_bytes_base [40]=replacement_len
+        self.asm.ldr_imm(Reg::X7, Reg::X0, 0);
+        self.asm.str_imm(Reg::X7, Reg::X6, 8);
+        self.asm.add_reg_imm(Reg::X7, Reg::X0, 8);
+        self.asm.str_imm(Reg::X7, Reg::X6, 0);
+        self.asm.ldr_imm(Reg::X7, Reg::X1, 0);
+        self.asm.str_imm(Reg::X7, Reg::X6, 24);
+        self.asm.add_reg_imm(Reg::X7, Reg::X1, 8);
+        self.asm.str_imm(Reg::X7, Reg::X6, 16);
+        self.asm.ldr_imm(Reg::X7, Reg::X2, 0);
+        self.asm.str_imm(Reg::X7, Reg::X6, 40);
+        self.asm.add_reg_imm(Reg::X7, Reg::X2, 8);
+        self.asm.str_imm(Reg::X7, Reg::X6, 32);
+
+        // Pass 1: count non-overlapping matches.
+        self.asm.ldr_imm(Reg::X8, Reg::X6, 0); // input_bytes_base
+        self.asm.ldr_imm(Reg::X9, Reg::X6, 8); // input_len
+        self.asm.mov_imm64(Reg::X10, 0); // pos
+        self.asm.mov_imm64(Reg::X11, 0); // match_count
+
+        let count_loop = self.asm.new_label();
+        let count_done = self.asm.new_label();
+        let count_is_match = self.asm.new_label();
+        self.asm.bind(count_loop);
+        self.asm.ldr_imm(Reg::X7, Reg::X6, 24); // pattern_len
+        self.asm.add_reg(Reg::X0, Reg::X10, Reg::X7);
+        self.asm.cmp_reg(Reg::X0, Reg::X9);
+        self.asm
+            .branch(count_done, BranchKind::Conditional(Cond::Gt));
+        self.asm.add_reg(Reg::X0, Reg::X8, Reg::X10); // a_ptr
+        self.asm.ldr_imm(Reg::X1, Reg::X6, 16); // b_ptr = pattern_bytes_base
+        self.asm.mov_reg(Reg::X2, Reg::X7); // len = pattern_len
+        self.asm
+            .bytes_equal(Reg::X2, Reg::X0, Reg::X1, Reg::X3, Reg::X4, Reg::X12);
+        self.asm
+            .branch(count_is_match, BranchKind::CompareNonZero(Reg::X3));
+        self.asm.add_reg_imm(Reg::X10, Reg::X10, 1);
+        self.asm.branch(count_loop, BranchKind::Unconditional);
+        self.asm.bind(count_is_match);
+        self.asm.add_reg_imm(Reg::X11, Reg::X11, 1);
+        self.asm.add_reg(Reg::X10, Reg::X10, Reg::X7);
+        self.asm.branch(count_loop, BranchKind::Unconditional);
+        self.asm.bind(count_done);
+
+        // total_content_len = input_len + match_count*(replacement_len - pattern_len)
+        self.asm.ldr_imm(Reg::X0, Reg::X6, 40); // replacement_len
+        self.asm.ldr_imm(Reg::X1, Reg::X6, 24); // pattern_len
+        self.asm.sub_reg(Reg::X0, Reg::X0, Reg::X1);
+        self.asm.mul_reg(Reg::X0, Reg::X0, Reg::X11);
+        self.asm.add_reg(Reg::X0, Reg::X9, Reg::X0);
+
+        self.asm.push(Reg::X6);
+        self.asm.push(Reg::X0); // total_content_len
+        self.asm.add_reg_imm(Reg::X4, Reg::X0, 15);
+        self.asm.lsr_imm(Reg::X4, Reg::X4, 3);
+        self.asm.lsl_imm(Reg::X4, Reg::X4, 3);
+        self.emit_alloc(); // x5 = result object
+        self.asm.pop(Reg::X12); // total_content_len
+        self.asm.pop(Reg::X6); // scratch struct ptr
+
+        self.asm.str_imm(Reg::X12, Reg::X5, 0);
+
+        // Pass 2: copy, substituting at each match.
+        self.asm.mov_imm64(Reg::X10, 0); // pos
+        self.asm.add_reg_imm(Reg::X11, Reg::X5, 8); // dst cursor
+
+        let copy_loop = self.asm.new_label();
+        let copy_no_match = self.asm.new_label();
+        let copy_is_match = self.asm.new_label();
+        let copy_done = self.asm.new_label();
+        self.asm.bind(copy_loop);
+        self.asm.ldr_imm(Reg::X0, Reg::X6, 8); // input_len
+        self.asm.cmp_reg(Reg::X10, Reg::X0);
+        self.asm
+            .branch(copy_done, BranchKind::Conditional(Cond::Ge));
+        self.asm.ldr_imm(Reg::X7, Reg::X6, 24); // pattern_len
+        self.asm.add_reg(Reg::X0, Reg::X10, Reg::X7);
+        self.asm.ldr_imm(Reg::X1, Reg::X6, 8); // input_len
+        self.asm.cmp_reg(Reg::X0, Reg::X1);
+        self.asm
+            .branch(copy_no_match, BranchKind::Conditional(Cond::Gt));
+        self.asm.ldr_imm(Reg::X0, Reg::X6, 0); // input_bytes_base
+        self.asm.add_reg(Reg::X0, Reg::X0, Reg::X10);
+        self.asm.ldr_imm(Reg::X1, Reg::X6, 16); // pattern_bytes_base
+        self.asm.mov_reg(Reg::X2, Reg::X7);
+        self.asm
+            .bytes_equal(Reg::X2, Reg::X0, Reg::X1, Reg::X3, Reg::X4, Reg::X12);
+        self.asm
+            .branch(copy_is_match, BranchKind::CompareNonZero(Reg::X3));
+
+        self.asm.bind(copy_no_match);
+        self.asm.ldr_imm(Reg::X0, Reg::X6, 0); // input_bytes_base
+        self.asm.add_reg(Reg::X0, Reg::X0, Reg::X10);
+        self.asm.ldrb_post_increment(Reg::X1, Reg::X0);
+        self.asm.strb_post_increment(Reg::X1, Reg::X11);
+        self.asm.add_reg_imm(Reg::X10, Reg::X10, 1);
+        self.asm.branch(copy_loop, BranchKind::Unconditional);
+
+        self.asm.bind(copy_is_match);
+        self.asm.ldr_imm(Reg::X0, Reg::X6, 32); // replacement_bytes_base
+        self.asm.ldr_imm(Reg::X1, Reg::X6, 40); // replacement_len
+        self.emit_copy_bytes(Reg::X1, Reg::X0, Reg::X11, Reg::X2);
+        self.asm.ldr_imm(Reg::X7, Reg::X6, 24); // pattern_len
+        self.asm.add_reg(Reg::X10, Reg::X10, Reg::X7);
+        self.asm.branch(copy_loop, BranchKind::Unconditional);
+        self.asm.bind(copy_done);
+
+        self.asm.mov_reg(Reg::X0, Reg::X5);
+    }
+
     fn emit_str_char_count(&mut self) {
         self.asm.ldr_imm(Reg::X2, Reg::X0, 0);
         self.asm.add_reg_imm(Reg::X3, Reg::X0, 8);
@@ -2593,6 +2785,27 @@ impl Emitter {
                 self.asm.mov_reg(Reg::X1, Reg::X0);
                 self.asm.pop(Reg::X0);
                 self.emit_str_join();
+                Ok(Some(ValueType::Str))
+            }
+            ("replaceAll", 3) => {
+                if self.expression(&arguments[0])? != ValueType::Str {
+                    return Err(unsupported(span, "replaceAll of a non-string"));
+                }
+                self.asm.push(Reg::X0);
+                if self.expression(&arguments[1])? != ValueType::Str {
+                    return Err(unsupported(span, "replaceAll with a non-string pattern"));
+                }
+                self.asm.push(Reg::X0);
+                if self.expression(&arguments[2])? != ValueType::Str {
+                    return Err(unsupported(
+                        span,
+                        "replaceAll with a non-string replacement",
+                    ));
+                }
+                self.asm.mov_reg(Reg::X2, Reg::X0);
+                self.asm.pop(Reg::X1);
+                self.asm.pop(Reg::X0);
+                self.emit_str_replace_all();
                 Ok(Some(ValueType::Str))
             }
             ("head", 1) => {

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -923,15 +923,28 @@ cargo run -- -e "1 + 2"
   copying each element into a single exact-size allocation with the
   separator interspersed between elements). This is the first M13
   routine to walk a cons-list rather than operate on a single string.
-  Remaining M13 slice: `replaceAll`/`split`, which need pattern
-  matching plus a result whose length isn't known until the match
-  count is, and are left for a follow-up PR once a value-spilling
-  scheme is designed -- both routines need roughly 7 fixed values
-  (byte-base pointers and lengths for input/pattern/replacement, plus
-  a running match count and total result length) live simultaneously
-  across the copy loop, more than the register file holds without a
-  deliberate stack-spill discipline, and forcing it under time
-  pressure risks a repeat of (or worse than) the M13-slice-1 bug below.
+  `replaceAll` (M13's remaining slice, added later in issue #538 --
+  literal non-overlapping substring replacement; deliberately not the
+  evaluator's `"[0-9]"` pseudo-regex special case, and an empty
+  pattern aborts rather than replicating Rust's `str::replace("")`
+  between-every-character semantics, both explicit scope reductions
+  from x86_64 parity) needed the same six fixed values live
+  simultaneously across a two-pass count-then-copy algorithm that
+  stalled an earlier attempt at this routine (byte-base pointers and
+  lengths for input/pattern/replacement) -- more than the register
+  file holds without a deliberate spill scheme. Rather than spill to
+  individual stack slots, this writes all six values once into a
+  single 48-byte scratch heap object right after computing them, then
+  re-loads whichever value is needed from it by a fixed byte offset
+  wherever it's needed later, so only one pointer (to that object)
+  has to stay resident in a register across each subsequent
+  `emit_alloc` call, the same one-value-survives-the-call discipline
+  every other M13 routine already uses. Introduces the general
+  `bytes_equal` helper (walks two pointers byte-by-byte, sets a
+  0/1 result) for the pattern-match test. `split` is left for a
+  follow-up once someone wants it (the same scratch-struct approach
+  should generalize, since it was the register pressure that blocked
+  progress, not anything split-specific).
 
   M14 (issue #538) adds file I/O: `FileOutput#write`/`#append`
   (opens with `O_WRONLY|O_CREAT|` `O_TRUNC` or `O_APPEND`, writes the

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -22926,6 +22926,170 @@ fn build_target_aarch64_apple_darwin_string_join_runs() {
     );
 }
 
+/// Regression guard on any host: `replaceAll` (literal non-overlapping
+/// substring replacement -- not the evaluator's `"[0-9]"` pseudo-regex
+/// special case, and an empty pattern is a deliberate `unsupported`
+/// scope reduction from x86_64 parity) must cross-build for
+/// aarch64-apple-darwin -- the remaining M13 slice (issue #538).
+#[test]
+fn build_target_aarch64_apple_darwin_string_replace_all_cross_build() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_macho_replaceall_xbuild_{stamp}.kl"));
+    let bin_path = dir.join(format!("klassic_macho_replaceall_xbuild_{stamp}.bin"));
+    fs::write(
+        &source_path,
+        "println(replaceAll(\"abc\", \"b\", \"\"))\n\
+         println(replaceAll(\"aaa\", \"a\", \"bb\"))\n\
+         println(replaceAll(\"hello world hello\", \"hello\", \"hi\"))\n\
+         println(replaceAll(\"abcabc\", \"bc\", \"X\"))\n\
+         println(replaceAll(\"nomatch\", \"xyz\", \"replaced\"))\n\
+         println(replaceAll(\"aaaa\", \"aa\", \"b\"))\n\
+         println(replaceAll(\"overlapoverlapoverlap\", \"overlap\", \"X\"))\n",
+    )
+    .expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "aarch64-apple-darwin",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&bin_path);
+    assert!(
+        build_output.status.success(),
+        "darwin replaceAll cross build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+}
+
+/// M13 acceptance test: `replaceAll` actually runs on an Apple Silicon
+/// mac, matching the evaluator's output exactly.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn build_target_aarch64_apple_darwin_string_replace_all_runs() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_macho_replaceall_run_{stamp}.kl"));
+    let bin_path = dir.join(format!("klassic_macho_replaceall_run_{stamp}.bin"));
+    fs::write(
+        &source_path,
+        "println(replaceAll(\"abc\", \"b\", \"\"))\n\
+         println(replaceAll(\"aaa\", \"a\", \"bb\"))\n\
+         println(replaceAll(\"hello world hello\", \"hello\", \"hi\"))\n\
+         println(replaceAll(\"abcabc\", \"bc\", \"X\"))\n\
+         println(replaceAll(\"nomatch\", \"xyz\", \"replaced\"))\n\
+         println(replaceAll(\"aaaa\", \"aa\", \"b\"))\n\
+         println(replaceAll(\"overlapoverlapoverlap\", \"overlap\", \"X\"))\n",
+    )
+    .expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "aarch64-apple-darwin",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build_output.status.success(),
+        "darwin replaceAll build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+    let run_output = Command::new(&bin_path)
+        .output()
+        .expect("generated Mach-O should execute");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&bin_path);
+    assert!(
+        run_output.status.success(),
+        "Mach-O exited with {:?}\nstderr:\n{}",
+        run_output.status,
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run_output.stdout),
+        "ac\nbbbbbb\nhi world hi\naXaX\nnomatch\nbb\nXXX\n"
+    );
+}
+
+/// GC stress regression guard, macOS-gated only: `replaceAll` calls
+/// two `emit_alloc`s (the 48-byte scratch struct, then the exact-size
+/// result) per call. Force enough allocation churn to guarantee at
+/// least one heap-grow mmap fires mid-routine, the same failure class
+/// M13 slice 1's `trim` bug (#563) was invisible to until a
+/// large-enough working set crossed a segment boundary.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn build_target_aarch64_apple_darwin_string_replace_all_survives_heap_growth() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_macho_replaceall_churn_{stamp}.kl"));
+    let bin_path = dir.join(format!("klassic_macho_replaceall_churn_{stamp}.bin"));
+    let padded = "a".repeat(1000);
+    fs::write(
+        &source_path,
+        format!(
+            "mutable i = 0\n\
+             mutable lastLen = 0\n\
+             while (i < 50000) {{\n\
+             \x20 val r = replaceAll(\"{padded}\", \"a\", \"bb\")\n\
+             \x20 lastLen = length(r)\n\
+             \x20 i = i + 1\n\
+             }}\n\
+             println(lastLen)\n\
+             println(i)\n"
+        ),
+    )
+    .expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "aarch64-apple-darwin",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build_output.status.success(),
+        "darwin replaceAll churn build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+    let run_output = Command::new(&bin_path)
+        .output()
+        .expect("generated Mach-O should execute");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&bin_path);
+    assert!(
+        run_output.status.success(),
+        "Mach-O exited with {:?} (a SIGSEGV here means emit_str_replace_all \
+         clobbered a pointer across a heap-grow mmap)\nstderr:\n{}",
+        run_output.status,
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&run_output.stdout), "2000\n50000\n");
+}
+
 /// Regression guard on any host: `FileOutput#write`/`#append`,
 /// `FileInput#all`, and `FileOutput#delete` (tolerating a missing
 /// file) must cross-build for aarch64-apple-darwin -- M14 (issue


### PR DESCRIPTION
## Summary

The remaining M13 slice of issue #538's aarch64-apple-darwin parity plan: `replaceAll`.

Literal, non-overlapping substring replacement — deliberately **not** the evaluator's `"[0-9]"` pseudo-regex special case, and an empty pattern aborts at runtime rather than replicating Rust's `str::replace("")` between-every-character semantics. Both are explicit scope reductions from x86_64 parity, documented at the call site.

## The register-pressure problem, and how it's solved this time

An earlier attempt at this exact routine stalled (see the earlier #538 comment): it needs six fixed values alive simultaneously across a two-pass (count-then-copy) algorithm — each of input/pattern/replacement's byte-base pointer and length — more than the register file holds without a deliberate spill scheme, and forcing it risked a repeat of the M13 slice 1 `trim` bug (#563).

This lands with a different design: instead of spilling to individual stack slots, the six fixed values are written once into a single 48-byte scratch heap object right after they're computed, then re-loaded from it by a fixed byte offset wherever needed later. Only one register (the pointer to that object) has to stay resident across each subsequent `emit_alloc` call — the same one-value-survives-the-call discipline every other M13 routine already uses, just applied to a struct of values instead of a single one.

Introduces the general `bytes_equal` helper (walks two pointers byte-by-byte, produces a 0/1 result) for the pattern-match test.

## Verification

- The algorithm itself was verified against the evaluator by testing it on the x86_64 native backend (runs locally on Linux, unlike aarch64/Mach-O output) across a dozen cases including edge cases (empty-pattern-adjacent inputs, shrinking/growing replacements, would-be-overlapping matches) — all matched exactly.
- Got an independent register-allocation review of the aarch64 codegen specifically for the #563 bug class (a value outside x0-x5 held live and unprotected across an `emit_alloc` call). Traced clean across both `emit_alloc` calls, both passes, and the dispatch arm.
- Cross-built for `aarch64-apple-darwin` from this (Linux) host.
- Execution — including a GC-stress test sized to force a heap-grow mid-routine — asserted by macOS-CI-gated tests.
- 678 tests green, fmt/clippy clean.

## Test plan

- [x] Algorithm verified against the evaluator via x86_64 native (12+ cases including edge cases)
- [x] aarch64 cross-build structural check (any host)
- [x] Independent register-allocation review targeting the exact #563 bug class (clean)
- [x] 678 tests green, fmt/clippy clean
- [ ] CI green (including macOS execution test and the GC-stress heap-growth test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)