### PR TITLE
feat: split for aarch64 (#538, M13 fully complete)

### DIFF
--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -2163,6 +2163,213 @@ impl Emitter {
         self.asm.mov_reg(Reg::X0, Reg::X5);
     }
 
+    /// Build a fresh string object holding `input_bytes_base[start..end]`
+    /// (byte offsets, in x0/x1) and push it onto the machine stack.
+    /// Expects the split scratch struct in x6, `input_bytes_base` in
+    /// x8, `input_len` in x9, scan position in x10, segment-start
+    /// offset in x11, and running segment count in x12 -- all six
+    /// survive the `emit_alloc` call this needs, via an explicit
+    /// push/pop bracket (the one-value-survives-the-call discipline
+    /// `emit_str_replace_all` uses, just for six values at once
+    /// instead of one).
+    fn emit_split_build_segment_and_push(&mut self, start: Reg, end: Reg) {
+        self.asm.sub_reg(Reg::X2, end, start); // len = end - start
+        self.asm.push(Reg::X6);
+        self.asm.push(Reg::X8);
+        self.asm.push(Reg::X9);
+        self.asm.push(Reg::X10);
+        self.asm.push(Reg::X11);
+        self.asm.push(Reg::X12);
+        self.asm.push(Reg::X2); // len
+        self.asm.push(start);
+        self.asm.add_reg_imm(Reg::X4, Reg::X2, 15);
+        self.asm.lsr_imm(Reg::X4, Reg::X4, 3);
+        self.asm.lsl_imm(Reg::X4, Reg::X4, 3);
+        self.emit_alloc(); // x5 = new segment string object
+        self.asm.pop(Reg::X0); // start offset
+        self.asm.pop(Reg::X2); // len
+        self.asm.pop(Reg::X12);
+        self.asm.pop(Reg::X11);
+        self.asm.pop(Reg::X10);
+        self.asm.pop(Reg::X9);
+        self.asm.pop(Reg::X8);
+        self.asm.pop(Reg::X6);
+
+        self.asm.str_imm(Reg::X2, Reg::X5, 0);
+        self.asm.add_reg(Reg::X3, Reg::X8, Reg::X0); // src = input_bytes_base + start
+        self.asm.add_reg_imm(Reg::X7, Reg::X5, 8); // dst = new object's payload
+        self.emit_copy_bytes(Reg::X2, Reg::X3, Reg::X7, Reg::X1);
+        self.asm.mov_reg(Reg::X0, Reg::X5);
+        self.asm.push(Reg::X0);
+        self.asm.add_reg_imm(Reg::X12, Reg::X12, 1);
+    }
+
+    /// `split`(input, delimiter): non-empty-delimiter path, `Rust
+    /// str::split`-equivalent semantics (non-overlapping matches
+    /// scanned left to right, an empty segment between adjacent
+    /// delimiters or at a leading/trailing delimiter). Two-pass-plus-
+    /// build design: scan once, building each segment string and
+    /// pushing it onto the machine stack in left-to-right order, then
+    /// pop them back off (right-to-left, i.e. last segment first) and
+    /// `cons` each onto a growing list -- since `cons` prepends, this
+    /// naturally reassembles the original left-to-right order.
+    ///
+    /// Uses the same scratch-heap-struct approach as `replaceAll` for
+    /// the two fixed values needed throughout (input/delimiter's
+    /// byte-base pointer and length), since that's what actually
+    /// solved the register-pressure wall that stalled the earlier
+    /// `replaceAll` attempt, generalized here to a 32-byte struct.
+    fn emit_str_split_nonempty_delimiter(&mut self) {
+        // x0 = input, x1 = delimiter
+        self.asm.push(Reg::X0);
+        self.asm.push(Reg::X1);
+        self.asm.mov_imm64(Reg::X4, 32);
+        self.emit_alloc(); // x5 = scratch struct
+        self.asm.mov_reg(Reg::X6, Reg::X5);
+        self.asm.pop(Reg::X1);
+        self.asm.pop(Reg::X0);
+
+        // Scratch layout: [0]=input_bytes_base [8]=input_len
+        // [16]=delimiter_bytes_base [24]=delimiter_len
+        self.asm.ldr_imm(Reg::X7, Reg::X0, 0);
+        self.asm.str_imm(Reg::X7, Reg::X6, 8);
+        self.asm.add_reg_imm(Reg::X7, Reg::X0, 8);
+        self.asm.str_imm(Reg::X7, Reg::X6, 0);
+        self.asm.ldr_imm(Reg::X7, Reg::X1, 0);
+        self.asm.str_imm(Reg::X7, Reg::X6, 24);
+        self.asm.add_reg_imm(Reg::X7, Reg::X1, 8);
+        self.asm.str_imm(Reg::X7, Reg::X6, 16);
+
+        self.asm.ldr_imm(Reg::X8, Reg::X6, 0); // input_bytes_base
+        self.asm.ldr_imm(Reg::X9, Reg::X6, 8); // input_len
+        self.asm.mov_imm64(Reg::X10, 0); // pos
+        self.asm.mov_imm64(Reg::X11, 0); // segment_start
+        self.asm.mov_imm64(Reg::X12, 0); // segment_count
+
+        let scan_loop = self.asm.new_label();
+        let scan_is_match = self.asm.new_label();
+        let scan_done = self.asm.new_label();
+        self.asm.bind(scan_loop);
+        self.asm.ldr_imm(Reg::X0, Reg::X6, 24); // delimiter_len
+        self.asm.add_reg(Reg::X1, Reg::X10, Reg::X0);
+        self.asm.cmp_reg(Reg::X1, Reg::X9);
+        self.asm
+            .branch(scan_done, BranchKind::Conditional(Cond::Gt));
+        self.asm.add_reg(Reg::X0, Reg::X8, Reg::X10); // a_ptr
+        self.asm.ldr_imm(Reg::X1, Reg::X6, 16); // b_ptr = delimiter_bytes_base
+        self.asm.ldr_imm(Reg::X2, Reg::X6, 24); // len = delimiter_len
+        self.asm
+            .bytes_equal(Reg::X2, Reg::X0, Reg::X1, Reg::X3, Reg::X4, Reg::X7);
+        self.asm
+            .branch(scan_is_match, BranchKind::CompareNonZero(Reg::X3));
+        self.asm.add_reg_imm(Reg::X10, Reg::X10, 1);
+        self.asm.branch(scan_loop, BranchKind::Unconditional);
+
+        self.asm.bind(scan_is_match);
+        self.emit_split_build_segment_and_push(Reg::X11, Reg::X10);
+        self.asm.ldr_imm(Reg::X7, Reg::X6, 24); // delimiter_len
+        self.asm.add_reg(Reg::X10, Reg::X10, Reg::X7);
+        self.asm.mov_reg(Reg::X11, Reg::X10);
+        self.asm.branch(scan_loop, BranchKind::Unconditional);
+
+        self.asm.bind(scan_done);
+        self.emit_split_build_segment_and_push(Reg::X11, Reg::X9);
+
+        // Pop segments back off (last-pushed first) and cons each
+        // onto a growing list -- this reassembles left-to-right order.
+        self.asm.mov_imm64(Reg::X0, 0); // list = nil
+        let cons_loop = self.asm.new_label();
+        let cons_done = self.asm.new_label();
+        self.asm.bind(cons_loop);
+        self.asm
+            .branch(cons_done, BranchKind::CompareZero(Reg::X12));
+        self.emit_cons_cell();
+        self.asm.sub_reg_imm(Reg::X12, Reg::X12, 1);
+        self.asm.branch(cons_loop, BranchKind::Unconditional);
+        self.asm.bind(cons_done);
+    }
+
+    /// `split`(input, ""): each UTF-8 character becomes its own
+    /// one-character list element. Scans left to right, treating any
+    /// byte whose top two bits aren't `10` (a UTF-8 continuation
+    /// byte) as the start of a new character -- the same detection
+    /// `emit_str_char_count`/`emit_str_reverse` already use. Shares
+    /// `emit_split_build_segment_and_push`'s scratch-object
+    /// registers (x6/x8/x9/x10/x11/x12) even though there's no
+    /// delimiter scratch struct here; x6 is simply an unused
+    /// push/pop round-trip in this path (harmless, since nothing
+    /// reads it back).
+    fn emit_str_split_chars(&mut self) {
+        // x0 = input
+        self.asm.ldr_imm(Reg::X9, Reg::X0, 0); // input_len
+        self.asm.add_reg_imm(Reg::X8, Reg::X0, 8); // input_bytes_base
+        self.asm.mov_imm64(Reg::X10, 0); // pos
+        self.asm.mov_imm64(Reg::X12, 0); // char_count
+
+        let scan_loop = self.asm.new_label();
+        let scan_done = self.asm.new_label();
+        let continuation_loop = self.asm.new_label();
+        let char_end_found = self.asm.new_label();
+        self.asm.bind(scan_loop);
+        self.asm.cmp_reg(Reg::X10, Reg::X9);
+        self.asm
+            .branch(scan_done, BranchKind::Conditional(Cond::Ge));
+        self.asm.mov_reg(Reg::X11, Reg::X10); // char_start = pos
+        self.asm.add_reg_imm(Reg::X10, Reg::X10, 1); // consume the lead byte
+
+        self.asm.bind(continuation_loop);
+        self.asm.cmp_reg(Reg::X10, Reg::X9);
+        self.asm
+            .branch(char_end_found, BranchKind::Conditional(Cond::Ge));
+        self.asm.add_reg(Reg::X0, Reg::X8, Reg::X10);
+        self.asm.ldrb(Reg::X1, Reg::X0);
+        self.asm.lsr_imm(Reg::X1, Reg::X1, 6);
+        self.asm.cmp_imm(Reg::X1, 2);
+        self.asm
+            .branch(char_end_found, BranchKind::Conditional(Cond::Ne));
+        self.asm.add_reg_imm(Reg::X10, Reg::X10, 1); // consume continuation byte
+        self.asm
+            .branch(continuation_loop, BranchKind::Unconditional);
+
+        self.asm.bind(char_end_found);
+        self.emit_split_build_segment_and_push(Reg::X11, Reg::X10);
+        self.asm.branch(scan_loop, BranchKind::Unconditional);
+        self.asm.bind(scan_done);
+
+        self.asm.mov_imm64(Reg::X0, 0); // list = nil
+        let cons_loop = self.asm.new_label();
+        let cons_done = self.asm.new_label();
+        self.asm.bind(cons_loop);
+        self.asm
+            .branch(cons_done, BranchKind::CompareZero(Reg::X12));
+        self.emit_cons_cell();
+        self.asm.sub_reg_imm(Reg::X12, Reg::X12, 1);
+        self.asm.branch(cons_loop, BranchKind::Unconditional);
+        self.asm.bind(cons_done);
+    }
+
+    /// `split`(input, delimiter): dispatches to the empty-delimiter
+    /// (per-character) or non-empty-delimiter path.
+    fn emit_str_split(&mut self) {
+        // x0 = input, x1 = delimiter
+        self.asm.push(Reg::X0);
+        self.asm.push(Reg::X1);
+        self.asm.ldr_imm(Reg::X2, Reg::X1, 0); // delimiter_len
+        let non_empty = self.asm.new_label();
+        let done = self.asm.new_label();
+        self.asm
+            .branch(non_empty, BranchKind::CompareNonZero(Reg::X2));
+        self.asm.pop(Reg::X1);
+        self.asm.pop(Reg::X0);
+        self.emit_str_split_chars();
+        self.asm.branch(done, BranchKind::Unconditional);
+        self.asm.bind(non_empty);
+        self.asm.pop(Reg::X1);
+        self.asm.pop(Reg::X0);
+        self.emit_str_split_nonempty_delimiter();
+        self.asm.bind(done);
+    }
+
     fn emit_str_char_count(&mut self) {
         self.asm.ldr_imm(Reg::X2, Reg::X0, 0);
         self.asm.add_reg_imm(Reg::X3, Reg::X0, 8);
@@ -2807,6 +3014,19 @@ impl Emitter {
                 self.asm.pop(Reg::X0);
                 self.emit_str_replace_all();
                 Ok(Some(ValueType::Str))
+            }
+            ("split", 2) => {
+                if self.expression(&arguments[0])? != ValueType::Str {
+                    return Err(unsupported(span, "split of a non-string"));
+                }
+                self.asm.push(Reg::X0);
+                if self.expression(&arguments[1])? != ValueType::Str {
+                    return Err(unsupported(span, "split with a non-string delimiter"));
+                }
+                self.asm.mov_reg(Reg::X1, Reg::X0);
+                self.asm.pop(Reg::X0);
+                self.emit_str_split();
+                Ok(Some(ValueType::List(ListElem::Str)))
             }
             ("head", 1) => {
                 let ty = self.expression(&arguments[0])?;

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -941,10 +941,28 @@ cargo run -- -e "1 + 2"
   `emit_alloc` call, the same one-value-survives-the-call discipline
   every other M13 routine already uses. Introduces the general
   `bytes_equal` helper (walks two pointers byte-by-byte, sets a
-  0/1 result) for the pattern-match test. `split` is left for a
-  follow-up once someone wants it (the same scratch-struct approach
-  should generalize, since it was the register pressure that blocked
-  progress, not anything split-specific).
+  0/1 result) for the pattern-match test.
+
+  `split` (issue #538) generalized the same scratch-struct approach,
+  confirming it was the register pressure that blocked progress and
+  not anything `replaceAll`-specific. Two paths: an empty delimiter
+  splits per UTF-8 character (the same lead-byte/continuation-byte
+  boundary test `emit_str_char_count` already uses); a non-empty
+  delimiter scans for non-overlapping matches, Rust
+  `str::split`-equivalent (so `split("", ",")` is a one-element list
+  `[""]`, while `split("", "")` is genuinely empty -- the two paths
+  deliberately diverge on empty input, matching the evaluator).  Both
+  paths share a `emit_split_build_segment_and_push` helper: build one
+  segment's exact-size string object and push its pointer onto the
+  *machine* stack, incrementing a running count, so the eight values
+  that must survive its `emit_alloc` call (six fixed registers plus
+  the computed length and start offset) get one push/pop bracket
+  instead of being threaded through by hand at each of the two call
+  sites. Once every segment is found, the routine pops them back off
+  the stack in reverse (last found first) and `cons`es each onto a
+  growing list via the existing `emit_cons_cell` -- since `cons`
+  prepends, popping last-to-first reassembles the original
+  left-to-right order.
 
   M14 (issue #538) adds file I/O: `FileOutput#write`/`#append`
   (opens with `O_WRONLY|O_CREAT|` `O_TRUNC` or `O_APPEND`, writes the

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -23090,6 +23090,175 @@ fn build_target_aarch64_apple_darwin_string_replace_all_survives_heap_growth() {
     assert_eq!(String::from_utf8_lossy(&run_output.stdout), "2000\n50000\n");
 }
 
+/// Regression guard on any host: `split` (empty-delimiter per-
+/// character split and non-empty-delimiter Rust `str::split`-
+/// equivalent semantics, including the empty-input edge cases where
+/// the two paths deliberately diverge -- `split("", ",")` yields a
+/// one-element list `[""]`, `split("", "")` yields zero elements)
+/// must cross-build for aarch64-apple-darwin -- the last remaining
+/// M13 slice (issue #538). Results are checked via `join` (M13 slice
+/// 2, landed earlier) rather than relying on a specific `println`
+/// list-rendering format.
+#[test]
+fn build_target_aarch64_apple_darwin_string_split_cross_build() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_macho_split_xbuild_{stamp}.kl"));
+    let bin_path = dir.join(format!("klassic_macho_split_xbuild_{stamp}.bin"));
+    fs::write(
+        &source_path,
+        "println(join(split(\"a,b,c\", \",\"), \"|\"))\n\
+         println(join(split(\"hello\", \"\"), \"-\"))\n\
+         println(join(split(\"no-delim-here\", \"|\"), \"|\"))\n\
+         println(join(split(\"\", \",\"), \"|\"))\n\
+         println(join(split(\",a,\", \",\"), \"|\"))\n\
+         println(join(split(\"aaa\", \"a\"), \"|\"))\n\
+         println(join(split(\"\", \"\"), \"|\"))\n",
+    )
+    .expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "aarch64-apple-darwin",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&bin_path);
+    assert!(
+        build_output.status.success(),
+        "darwin split cross build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+}
+
+/// M13 acceptance test: `split` actually runs on an Apple Silicon
+/// mac, matching the evaluator's output exactly.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn build_target_aarch64_apple_darwin_string_split_runs() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_macho_split_run_{stamp}.kl"));
+    let bin_path = dir.join(format!("klassic_macho_split_run_{stamp}.bin"));
+    fs::write(
+        &source_path,
+        "println(join(split(\"a,b,c\", \",\"), \"|\"))\n\
+         println(join(split(\"hello\", \"\"), \"-\"))\n\
+         println(join(split(\"no-delim-here\", \"|\"), \"|\"))\n\
+         println(join(split(\"\", \",\"), \"|\"))\n\
+         println(join(split(\",a,\", \",\"), \"|\"))\n\
+         println(join(split(\"aaa\", \"a\"), \"|\"))\n\
+         println(join(split(\"\", \"\"), \"|\"))\n",
+    )
+    .expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "aarch64-apple-darwin",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build_output.status.success(),
+        "darwin split build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+    let run_output = Command::new(&bin_path)
+        .output()
+        .expect("generated Mach-O should execute");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&bin_path);
+    assert!(
+        run_output.status.success(),
+        "Mach-O exited with {:?}\nstderr:\n{}",
+        run_output.status,
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run_output.stdout),
+        "a|b|c\nh-e-l-l-o\nno-delim-here\n\n|a|\n|||\n\n"
+    );
+}
+
+/// GC stress regression guard, macOS-gated only: each `split` call
+/// builds several segment strings plus cons cells, so force enough
+/// allocation churn to guarantee a heap-grow mmap fires mid-routine
+/// -- the same failure class M13 slice 1's `trim` bug (#563) was
+/// invisible to until a large-enough working set crossed a segment
+/// boundary.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn build_target_aarch64_apple_darwin_string_split_survives_heap_growth() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_macho_split_churn_{stamp}.kl"));
+    let bin_path = dir.join(format!("klassic_macho_split_churn_{stamp}.bin"));
+    let padded = (0..200).map(|_| "abcde,").collect::<Vec<_>>().join("");
+    fs::write(
+        &source_path,
+        format!(
+            "mutable i = 0\n\
+             mutable lastLen = 0\n\
+             while (i < 20000) {{\n\
+             \x20 val parts = split(\"{padded}\", \",\")\n\
+             \x20 lastLen = parts.size()\n\
+             \x20 i = i + 1\n\
+             }}\n\
+             println(lastLen)\n\
+             println(i)\n"
+        ),
+    )
+    .expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "aarch64-apple-darwin",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build_output.status.success(),
+        "darwin split churn build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+    let run_output = Command::new(&bin_path)
+        .output()
+        .expect("generated Mach-O should execute");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&bin_path);
+    assert!(
+        run_output.status.success(),
+        "Mach-O exited with {:?} (a SIGSEGV here means split's segment-\
+         building or cons-reassembly clobbered a pointer across a \
+         heap-grow mmap)\nstderr:\n{}",
+        run_output.status,
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&run_output.stdout), "201\n20000\n");
+}
+
 /// Regression guard on any host: `FileOutput#write`/`#append`,
 /// `FileInput#all`, and `FileOutput#delete` (tolerating a missing
 /// file) must cross-build for aarch64-apple-darwin -- M14 (issue


### PR DESCRIPTION
## Summary

`split(input, delimiter)` for the aarch64-apple-darwin direct backend, generalizing the scratch-heap-object approach `replaceAll` used — confirming it was the register pressure that blocked earlier progress, not anything `replaceAll`-specific.

Two paths:
- **Empty delimiter**: splits per UTF-8 character (the same lead-byte/continuation-byte boundary test `emit_str_char_count` already uses).
- **Non-empty delimiter**: scans for non-overlapping matches, Rust `str::split`-equivalent semantics (so `split("", ",")` is a one-element list `[""]`, while `split("", "")` is genuinely empty — the two paths deliberately diverge on empty input, matching the evaluator exactly).

Both paths share a new `emit_split_build_segment_and_push` helper: build one segment's exact-size string object and push its pointer onto the machine stack, incrementing a running count. This means the eight values that must survive its `emit_alloc` call (six fixed registers plus the computed length and start offset) get one push/pop bracket instead of being threaded through by hand at each call site. Once every segment is found, the routine pops them back off the stack in reverse (last found first) and `cons`es each onto a growing list via the existing `emit_cons_cell` — since `cons` prepends, popping last-to-first reassembles the original left-to-right order.

## Verification

- Verified the algorithm against the evaluator via the x86_64 native backend (runs locally on Linux, unlike aarch64/Mach-O output) across seven cases including edge cases (empty input against both delimiter kinds, leading/trailing/adjacent delimiters, a delimiter matching the entire input) — all matched exactly, confirmed via `join` since list-rendering format isn't itself under test here.
- Got an independent register-allocation review of the aarch64 codegen — traced clean across the shared segment-building helper's 8-value push/pop bracket, both scan loops, the pop-and-cons reassembly (confirmed not reversed), and `emit_cons_cell`'s interaction with the loop counter.
- Cross-built for `aarch64-apple-darwin` from this (Linux) host.
- Execution — including a GC-stress test sized to force a heap-grow mid-routine — asserted by macOS-CI-gated tests.
- 679 tests green, fmt/clippy clean.

This completes **M13 in full** (issue #538) — every string builtin planned for aarch64 parity is now landed.

## Test plan

- [x] Algorithm verified against the evaluator via x86_64 native (7 cases including edge cases)
- [x] aarch64 cross-build structural check (any host)
- [x] Independent register-allocation review (clean)
- [x] 679 tests green, fmt/clippy clean
- [ ] CI green (including macOS execution test and the GC-stress heap-growth test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)