### PR TITLE
fix: retry Time#nowMillis with the real 3-argument gettimeofday ABI

### DIFF
--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -41,6 +41,18 @@ const SYS_MKDIR: u16 = 136;
 const SYS_FSTATAT64: u16 = 470;
 /// Darwin `rename`.
 const SYS_RENAME: u16 = 128;
+/// Darwin `gettimeofday`. `syscalls.master` (apple-oss-distributions/xnu)
+/// defines this as a **3-argument** syscall marked `NO_SYSCALL_STUB`:
+/// `int gettimeofday(struct timeval *tp, struct timezone *tzp,
+/// uint64_t *mach_absolute_time)`. An earlier attempt at this builtin
+/// called it with only 2 arguments (leaving x2 whatever it happened
+/// to hold), which produced inconsistent real-hardware behavior
+/// across two CI runs of the same binary depending on call order --
+/// a clean syscall-failure abort in one ordering, a SIGSEGV in
+/// another, a hallmark of the kernel misinterpreting a garbage x2 as
+/// a pointer to write `mach_absolute_time` through. This time x2 is
+/// explicitly zeroed (NULL) before the trap, matching the real ABI.
+const SYS_GETTIMEOFDAY: u16 = 116;
 /// Darwin's `AT_FDCWD` is `-2`, not Linux's `-100` (bsd/sys/fcntl.h).
 const AT_FDCWD: i64 = -2;
 /// Darwin's `O_*` open flags (bsd/sys/fcntl.h) -- numerically
@@ -618,6 +630,17 @@ impl Assembler {
     fn ldr_imm(&mut self, dst: Reg, base: Reg, imm: u32) {
         debug_assert!(imm.is_multiple_of(8) && imm / 8 < 4096);
         self.word(0xf940_0000 | ((imm / 8) << 10) | ((base as u32) << 5) | dst as u32);
+    }
+
+    /// `ldr wt, [xn, #imm]` (unsigned, 4-byte scaled, 32-bit --
+    /// zero-extends into the full 64-bit register per AAPCS64
+    /// W-register write semantics). Used where a field is genuinely
+    /// 4 bytes and a 64-bit load would pull in unrelated trailing
+    /// bytes (e.g. Darwin's `struct timeval.tv_usec`, a
+    /// `__int32_t` immediately followed by 4 bytes of padding).
+    fn ldr_imm32(&mut self, dst: Reg, base: Reg, imm: u32) {
+        debug_assert!(imm.is_multiple_of(4) && imm / 4 < 4096);
+        self.word(0xb940_0000 | ((imm / 4) << 10) | ((base as u32) << 5) | dst as u32);
     }
 
     /// `str xt, [xn, #imm]` (unsigned, 8-byte scaled)
@@ -1481,6 +1504,37 @@ impl Emitter {
         self.asm.bind(not_found);
         self.asm.mov_imm64(Reg::X0, 0);
         self.asm.bind(done);
+    }
+
+    /// `Time#nowMillis`(): `gettimeofday(&buf, NULL, NULL)` (all
+    /// three arguments -- see the `SYS_GETTIMEOFDAY` doc comment for
+    /// why the third one, previously omitted, is believed to be the
+    /// actual cause of this builtin's prior real-hardware crash) into
+    /// a fresh 16-byte bump-heap buffer laid out as Darwin's actual
+    /// `struct timeval` (`tv_sec: i64` at offset 0, `tv_usec: i32` at
+    /// offset 8 followed by 4 bytes of padding -- read with a 32-bit
+    /// load so the result never depends on those padding bytes being
+    /// zero), then computes `tv_sec*1000 + tv_usec/1000` (M16, issue
+    /// #538 / #570).
+    fn emit_time_now_millis(&mut self) {
+        self.asm.mov_imm64(Reg::X4, 16);
+        self.emit_alloc(); // x5 = timeval buffer
+        self.asm.mov_reg(Reg::X6, Reg::X5);
+
+        self.asm.mov_reg(Reg::X0, Reg::X6);
+        self.asm.mov_imm64(Reg::X1, 0); // tzp = NULL
+        self.asm.mov_imm64(Reg::X2, 0); // mach_absolute_time = NULL
+        self.asm.mov_imm64(Reg::X16, u64::from(SYS_GETTIMEOFDAY));
+        self.asm.svc_0x80();
+        self.asm
+            .emit_abort_if_syscall_failed(b"klassic: Time#nowMillis failed\n");
+
+        self.asm.ldr_imm(Reg::X0, Reg::X6, 0); // tv_sec
+        self.asm.ldr_imm32(Reg::X1, Reg::X6, 8); // tv_usec (32-bit field)
+        self.asm.mov_imm64(Reg::X2, 1000);
+        self.asm.mul_reg(Reg::X0, Reg::X0, Reg::X2); // tv_sec * 1000
+        self.asm.sdiv_reg(Reg::X1, Reg::X1, Reg::X2); // tv_usec / 1000
+        self.asm.add_reg(Reg::X0, Reg::X0, Reg::X1);
     }
 
     fn binary(
@@ -3373,6 +3427,10 @@ impl Emitter {
                 }
                 self.emit_environment_exists(key);
                 Ok(Some(ValueType::Bool))
+            }
+            ("Time#nowMillis", 0) => {
+                self.emit_time_now_millis();
+                Ok(Some(ValueType::Int))
             }
             _ => Ok(None),
         }

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1020,22 +1020,24 @@ cargo run -- -e "1 + 2"
   requiring the byte right after the match to be `'='` so `"FOO"`
   can't false-match an entry for `"FOOBAR"`.
 
-  `Time#nowMillis` was attempted in the same milestone (calling
-  `gettimeofday`, syscall 116, into a scratch buffer) and withdrawn
-  before merge: `syscalls.master` marks `gettimeofday`
-  `NO_SYSCALL_STUB` (normally served from the commpage on real
-  hardware, not trapped), and the real-hardware CI execution test --
-  the only way to actually find out -- showed the raw two-argument
-  `svc #0x80` form is genuinely unreliable rather than just slower.
-  The same binary produced two different symptoms across CI runs
-  depending on call order: a clean, intentional syscall-failure abort
-  in one ordering (`Environment#exists` called first) and a SIGSEGV in
-  another (`Time#nowMillis` called first, so its `gettimeofday` was
-  the very first heap allocation in the program). `Time#nowMillis`
-  remains an explicit `unsupported` diagnostic on this backend until a
-  safe alternative (reading the commpage directly, or
-  `mach_absolute_time`) is designed and verified on real hardware
-  first.
+  `Time#nowMillis` was attempted once and withdrawn after a
+  real-hardware crash (see issue #570), then re-landed with the actual
+  bug fixed. `gettimeofday` is syscall 116; `syscalls.master`
+  (apple-oss-distributions/xnu) defines it as a **3-argument**
+  syscall marked `NO_SYSCALL_STUB`: `int gettimeofday(struct timeval
+  *tp, struct timezone *tzp, uint64_t *mach_absolute_time)`. The first
+  attempt called it with only 2 arguments, leaving `x2` (the third
+  argument) holding whatever a prior computation left there -- the
+  kernel likely misinterpreted that garbage as a pointer to write
+  `mach_absolute_time` through, which explains the exact symptom
+  observed: the same binary produced a clean syscall-failure abort in
+  one CI run's call ordering and a SIGSEGV in another. The fix is one
+  instruction: explicitly zero `x2` before the trap. Reads the
+  resulting 16-byte `struct timeval` (`tv_sec: i64` at offset 0,
+  `tv_usec: i32` at offset 8 followed by 4 bytes of padding -- read
+  with the 32-bit `ldr_imm32` load introduced for this so the result
+  never depends on those padding bytes) and computes
+  `tv_sec*1000 + tv_usec/1000`.
 
   `x86_64-pc-windows-msvc` (`--target x86_64-pc-windows-msvc` /
   `windows-x86_64`) is the one target that does *not* get its own

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -23517,20 +23517,20 @@ fn build_target_aarch64_apple_darwin_dir_ops_runs() {
     );
 }
 
-/// Regression guard on any host: `Environment#exists` must
-/// cross-build for aarch64-apple-darwin -- M16 (issue #538), which
-/// also captures argc/argv/envp from dyld's LC_MAIN entry in the
-/// program prologue. `Time#nowMillis` was attempted in the same
-/// milestone but withdrawn before merge: the real-hardware execution
-/// test caught `gettimeofday`'s raw `svc #0x80` form crashing with
-/// SIGSEGV on one run and returning a clean syscall failure on
-/// another (same binary, same CI run, different symptoms depending
-/// on call order) -- `syscalls.master` marking it `NO_SYSCALL_STUB`
-/// turned out to mean genuinely unreliable behavior off the commpage
-/// path, not just slower. `Time#nowMillis` remains an explicit
-/// `unsupported` diagnostic on this backend until a safe alternative
-/// (e.g. reading the commpage directly, or `mach_absolute_time`) is
-/// designed and verified.
+/// Regression guard on any host: `Environment#exists` and
+/// `Time#nowMillis` must cross-build for aarch64-apple-darwin -- M16
+/// (issue #538), which also captures argc/argv/envp from dyld's
+/// LC_MAIN entry in the program prologue. `Time#nowMillis` was
+/// attempted once before and withdrawn after a real-hardware crash
+/// (see issue #570): the actual root cause turned out to be calling
+/// `gettimeofday` (syscall 116) with only 2 arguments when
+/// `syscalls.master` (apple-oss-distributions/xnu) defines it as a
+/// 3-argument, `NO_SYSCALL_STUB` syscall -- `int gettimeofday(struct
+/// timeval *tp, struct timezone *tzp, uint64_t *mach_absolute_time)`
+/// -- leaving x2 (the third argument) holding whatever garbage a
+/// prior computation left there, which the kernel likely
+/// misinterpreted as a pointer to write `mach_absolute_time`
+/// through. This attempt explicitly zeroes x2 before the trap.
 #[test]
 fn build_target_aarch64_apple_darwin_env_time_cross_build() {
     let stamp = SystemTime::now()
@@ -23542,7 +23542,10 @@ fn build_target_aarch64_apple_darwin_env_time_cross_build() {
     let bin_path = dir.join(format!("klassic_macho_envtime_xbuild_{stamp}.bin"));
     fs::write(
         &source_path,
-        "println(Environment#exists(\"KLASSIC_ENV_TIME_TEST_NONEXISTENT_XYZ\"))\n\
+        "val t = Time#nowMillis()\n\
+         println(t > 1700000000000)\n\
+         println(t < 3000000000000)\n\
+         println(Environment#exists(\"KLASSIC_ENV_TIME_TEST_NONEXISTENT_XYZ\"))\n\
          println(Environment#exists(\"PATH\"))\n",
     )
     .expect("temp source file should write");
@@ -23561,13 +23564,20 @@ fn build_target_aarch64_apple_darwin_env_time_cross_build() {
     let _ = fs::remove_file(&bin_path);
     assert!(
         build_output.status.success(),
-        "darwin env cross build should succeed\nstderr:\n{}",
+        "darwin env/time cross build should succeed\nstderr:\n{}",
         String::from_utf8_lossy(&build_output.stderr)
     );
 }
 
-/// M16 acceptance test: `Environment#exists` actually runs on an
-/// Apple Silicon mac.
+/// M16 acceptance test: `Environment#exists` and `Time#nowMillis`
+/// actually run on an Apple Silicon mac. `Time#nowMillis` can't be
+/// compared byte-for-byte against the evaluator (real time elapses
+/// between the two runs), so this checks the value falls in a sane
+/// range instead -- this is also the real-hardware re-verification of
+/// the 3-argument `gettimeofday` fix, on the exact class of test
+/// (`Time#nowMillis` called first, forcing its `gettimeofday` to be
+/// the very first heap allocation in the program) that caught the
+/// SIGSEGV the first time.
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 #[test]
 fn build_target_aarch64_apple_darwin_env_time_runs() {
@@ -23580,7 +23590,10 @@ fn build_target_aarch64_apple_darwin_env_time_runs() {
     let bin_path = dir.join(format!("klassic_macho_envtime_run_{stamp}.bin"));
     fs::write(
         &source_path,
-        "println(Environment#exists(\"KLASSIC_ENV_TIME_TEST_NONEXISTENT_XYZ\"))\n\
+        "val t = Time#nowMillis()\n\
+         println(t > 1700000000000)\n\
+         println(t < 3000000000000)\n\
+         println(Environment#exists(\"KLASSIC_ENV_TIME_TEST_NONEXISTENT_XYZ\"))\n\
          println(Environment#exists(\"PATH\"))\n",
     )
     .expect("temp source file should write");
@@ -23597,7 +23610,7 @@ fn build_target_aarch64_apple_darwin_env_time_runs() {
         .expect("binary should run");
     assert!(
         build_output.status.success(),
-        "darwin env build should succeed\nstderr:\n{}",
+        "darwin env/time build should succeed\nstderr:\n{}",
         String::from_utf8_lossy(&build_output.stderr)
     );
     let run_output = Command::new(&bin_path)
@@ -23607,11 +23620,15 @@ fn build_target_aarch64_apple_darwin_env_time_runs() {
     let _ = fs::remove_file(&bin_path);
     assert!(
         run_output.status.success(),
-        "Mach-O exited with {:?}\nstderr:\n{}",
+        "Mach-O exited with {:?} (a SIGSEGV here means the 3-argument \
+         gettimeofday fix didn't hold)\nstderr:\n{}",
         run_output.status,
         String::from_utf8_lossy(&run_output.stderr)
     );
-    assert_eq!(String::from_utf8_lossy(&run_output.stdout), "false\ntrue\n");
+    assert_eq!(
+        String::from_utf8_lossy(&run_output.stdout),
+        "true\ntrue\nfalse\ntrue\n"
+    );
 }
 
 /// On Apple Silicon a target-less `build` detects the host: programs


### PR DESCRIPTION
## Summary

Issue #570 (split off from #538/M16): `Time#nowMillis` was withdrawn after real-hardware CI caught the same binary producing two different symptoms depending on call order — a clean syscall-failure abort in one ordering, a SIGSEGV in another.

## Root cause found

`syscalls.master` (apple-oss-distributions/xnu) defines Darwin's `gettimeofday` (syscall 116, `NO_SYSCALL_STUB`) as a **3-argument** syscall:

```
int gettimeofday(struct timeval *tp, struct timezone *tzp, uint64_t *mach_absolute_time)
```

The withdrawn version called it with only `x0`/`x1` set (2 arguments), leaving `x2` holding whatever a prior computation left there. Disassembling the withdrawn binary confirms `x2` held `envp` (copied there by the program prologue) at the point of the trap when `Time#nowMillis` ran first — a live, non-NULL pointer into the process's argument/environment region. A kernel writing `mach_absolute_time` through that garbage plausibly explains both symptoms observed: SIGSEGV when the garbage happens to be unmapped/protected, some other visible failure otherwise.

## The fix

One instruction: explicitly zero `x2` (NULL — "skip this optional output") before the trap. This matches Apple's own `libsyscall/custom/__gettimeofday.s` wrapper, which does the identical `movz x2, #0x0` before its own trap.

## Important caveat — this is a hypothesis, not a proof

Got an independent review that disassembled the actual cross-built Mach-O binary (not just hand-traced the emitter source) to confirm the exact register state at the trap point, confirmed `x2=0` is the correct NULL sentinel (same convention `x1=0` already uses for `tzp`), and confirmed no register hazard was introduced by the fix. **The review is explicit that this only establishes the fix is internally consistent and the hypothesis is plausible — real confirmation requires the macOS-CI-gated execution test to actually run on hardware, which is the exact same test that caught the original bug.** If it crashes again on this PR's CI run, the 3-argument framing itself needs revisiting, not further register tweaks — I will not paper over a second failure.

## Other details unchanged from the withdrawn version

- `ldr_imm32` (32-bit load) for `tv_usec`: Darwin's real `struct timeval` has a 4-byte `tv_usec` followed by 4 bytes of padding; a 64-bit read would pull in padding bytes not guaranteed to be zero. This was already fixed in the withdrawn attempt and is unchanged here.
- Arithmetic (`tv_sec*1000 + tv_usec/1000`) and register discipline around `emit_alloc` are unchanged and were re-verified.

## Verification

- Verified against the evaluator for sane epoch-range bounds (can't compare byte-for-byte since real time elapses between runs).
- Cross-built for `aarch64-apple-darwin` from this (Linux) host.
- Independent review with actual Mach-O disassembly (not just source tracing) confirming the fix's internal correctness.
- 679 tests green, fmt/clippy clean.
- **Execution on real Apple Silicon hardware (the macOS CI job) is the actual test of whether this fixes the crash** — the test deliberately puts `Time#nowMillis()` first, the exact ordering that produced the SIGSEGV before.

## Test plan

- [x] Arithmetic/register review, confirmed via disassembly
- [x] aarch64 cross-build structural check (any host)
- [x] 679 tests green, fmt/clippy clean
- [ ] **CI green on macOS execution test — this is the real verification, not a formality**

🤖 Generated with [Claude Code](https://claude.com/claude-code)