### PR TITLE
fix: use-after-free in ==/assertResult staging across rhs collection

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -7161,7 +7161,16 @@ impl NativeCodeGenerator {
         if matches!(op, BinaryOp::Equal | BinaryOp::NotEqual)
             && matches!(lhs_value, NativeValue::HeapPointer)
         {
-            self.push_temp_reg(Reg::Rax);
+            // Root the lhs in a shadow-tracked slot across the rhs
+            // compile. A raw machine-stack push here was a real
+            // use-after-free: the lhs temporary's constructor root has
+            // already been popped, so when the rhs construction
+            // triggered a collection the lhs was swept and its memory
+            // reused -- `P(i,i) == P(i,i)` returned false 14 times in
+            // 100k iterations.
+            self.push_scope();
+            let lhs_slot = self.allocate_anonymous_slot(NativeValue::HeapPointer);
+            self.asm.store_rbp_slot(lhs_slot.offset, Reg::Rax);
             let rhs_value = self.compile_expr(rhs)?;
             if !matches!(rhs_value, NativeValue::HeapPointer) {
                 return Err(unsupported(
@@ -7169,9 +7178,13 @@ impl NativeCodeGenerator {
                     "native equality for a heap value and this value type",
                 ));
             }
-            // rax = rhs pointer; restore lhs pointer into rdi.
-            self.pop_temp_reg(Reg::Rdi);
+            // rax = rhs pointer; reload the (possibly still live only
+            // through the slot) lhs pointer into rdi. gc_deep_equal
+            // never allocates, so the operands are safe unrooted once
+            // the scope pops.
             self.asm.mov_reg_reg(Reg::Rsi, Reg::Rax);
+            self.asm.load_rbp_slot(Reg::Rdi, lhs_slot.offset);
+            self.pop_scope();
             self.asm.call_label(self.gc_deep_equal);
             if op == BinaryOp::NotEqual {
                 self.asm.cmp_reg_imm8(Reg::Rax, 0);
@@ -8942,8 +8955,15 @@ impl NativeCodeGenerator {
                 // same routine the `==` operator uses. The failure path
                 // reports a plain message rather than the raw pointers a
                 // value formatter would print for a heap value without a
-                // tracked shape.
-                self.push_temp_reg(Reg::Rax);
+                // tracked shape. The expected value is rooted in a
+                // shadow-tracked slot across the actual's compile -- a
+                // raw machine-stack push here was the same
+                // use-after-free the `==` operator had (the expected
+                // temporary was swept when the actual's construction
+                // collected).
+                self.push_scope();
+                let expected_slot = self.allocate_anonymous_slot(NativeValue::HeapPointer);
+                self.asm.store_rbp_slot(expected_slot.offset, Reg::Rax);
                 let actual = self.compile_expr(&actual_arguments[0])?;
                 if !matches!(actual, NativeValue::HeapPointer) {
                     return Err(unsupported(
@@ -8951,8 +8971,9 @@ impl NativeCodeGenerator {
                         "native assertResult for values with different types",
                     ));
                 }
-                self.pop_temp_reg(Reg::Rdi);
                 self.asm.mov_reg_reg(Reg::Rsi, Reg::Rax);
+                self.asm.load_rbp_slot(Reg::Rdi, expected_slot.offset);
+                self.pop_scope();
                 self.asm.call_label(self.gc_deep_equal);
                 let ok = self.asm.create_text_label();
                 self.asm.cmp_reg_imm8(Reg::Rax, 0);

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -20865,6 +20865,170 @@ fn native_build_survives_enum_allocation_churn_across_collections() {
     assert_eq!(String::from_utf8_lossy(&run_output.stdout), "50000\n");
 }
 
+/// Regression guard for a real use-after-free: `==` on two freshly
+/// constructed enums staged the lhs pointer with a raw machine-stack
+/// push (not a GC root) across the rhs compile. The lhs temporary's
+/// constructor-scope root is already popped at that point, so when the
+/// rhs construction triggered a collection the lhs was swept and its
+/// memory reused -- `P(i,i) == P(i,i)` silently returned false 14
+/// times in 100k iterations before the fix (the lhs is now rooted in a
+/// shadow-tracked slot across the rhs compile). The loop count is
+/// sized so collections inevitably strike during rhs construction.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_enum_equality_lhs_survives_collection_during_rhs() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic_native_eq_uaf_{stamp}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic_native_eq_uaf_{stamp}.bin"));
+    fs::write(
+        &source_path,
+        "enum Pair { case P(a: Int, b: Int) }\n\
+         mutable i = 0\n\
+         mutable ok = 0\n\
+         while (i < 100000) {\n\
+           if (P(i, i) == P(i, i)) {\n\
+             ok = ok + 1\n\
+           }\n\
+           i = i + 1\n\
+         }\n\
+         println(ok)\n",
+    )
+    .expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_str().expect("source path should be utf-8"),
+            "-o",
+            output_path.to_str().expect("output path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build_output.status.success(),
+        "native build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+    let run_output = Command::new(&output_path)
+        .output()
+        .expect("compiled binary should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+    assert!(
+        run_output.status.success(),
+        "compiled binary should exit cleanly\nstderr:\n{}",
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&run_output.stdout), "100000\n");
+}
+
+/// Same use-after-free class through `assertResult`: the expected
+/// value was staged with a raw push across the actual's compile.
+/// Before the fix this program aborted with "assertResult failed"
+/// (the evaluator passes).
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_assert_result_expected_survives_collection_during_actual() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic_native_assert_uaf_{stamp}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic_native_assert_uaf_{stamp}.bin"));
+    fs::write(
+        &source_path,
+        "enum Pair { case P(a: Int, b: Int) }\n\
+         mutable i = 0\n\
+         while (i < 100000) {\n\
+           assertResult(P(i, i))(P(i, i))\n\
+           i = i + 1\n\
+         }\n\
+         println(\"all-passed\")\n",
+    )
+    .expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_str().expect("source path should be utf-8"),
+            "-o",
+            output_path.to_str().expect("output path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build_output.status.success(),
+        "native build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+    let run_output = Command::new(&output_path)
+        .output()
+        .expect("compiled binary should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+    assert!(
+        run_output.status.success(),
+        "assertResult must not fail across collections\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run_output.stdout),
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&run_output.stdout), "all-passed\n");
+}
+
+/// Nested-payload variant of the equality use-after-free: a freed lhs
+/// tree makes `gc_deep_equal` walk reused memory, maximizing the
+/// chance of a wrong verdict (12/50k before the fix).
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_deep_equal_walks_lhs_after_forced_collection() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic_native_deep_uaf_{stamp}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic_native_deep_uaf_{stamp}.bin"));
+    fs::write(
+        &source_path,
+        "enum Tree { case Leaf(v: Int); case Branch(l: Tree, r: Tree) }\n\
+         mutable i = 0\n\
+         mutable ok = 0\n\
+         while (i < 50000) {\n\
+           if (Branch(Leaf(i), Leaf(i + 1)) == Branch(Leaf(i), Leaf(i + 1))) {\n\
+             ok = ok + 1\n\
+           }\n\
+           i = i + 1\n\
+         }\n\
+         println(ok)\n",
+    )
+    .expect("temp source file should write");
+    let build_output = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_str().expect("source path should be utf-8"),
+            "-o",
+            output_path.to_str().expect("output path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build_output.status.success(),
+        "native build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+    let run_output = Command::new(&output_path)
+        .output()
+        .expect("compiled binary should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+    assert!(
+        run_output.status.success(),
+        "compiled binary should exit cleanly\nstderr:\n{}",
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&run_output.stdout), "50000\n");
+}
+
 /// Functions whose annotations name a lowered monomorphic enum now use a
 /// per-frame by-pointer calling convention: the enum's `__gc_record`
 /// pointer travels in a qword argument register (or caller stack push)


### PR DESCRIPTION
## Summary

**A real, silent, shipping use-after-free in today's collector**, found by the ZGC plan's M1 survey milestone (docs/zgc-plan.md).

`==` on heap values (enums) and `assertResult` staged the lhs/expected heap pointer with a raw machine-stack push — **not a GC root** — across the rhs compile. The lhs temporary's constructor-scope root is already popped at that point, so when the rhs construction triggered a collection, the lhs was swept and its memory reused by the free-list (which zeroes the payload). `gc_deep_equal` then compared reused memory:

- `P(i,i) == P(i,i)` → **false, 14 times out of 100k iterations** (silent wrong answer)
- `assertResult(P(i,i))(P(i,i))` → **"assertResult failed" abort** (evaluator passes)
- `Branch(Leaf..) == Branch(Leaf..)` → false, 12/50k

## Fix

Root the lhs/expected in a shadow-tracked anonymous slot across the rhs/actual compile (the established `allocate_anonymous_slot` pattern), reload into `rdi` afterward, and pop the scope before calling `gc_deep_equal` (which never allocates, so the operands are safe unrooted during the call). The scope pop restores rsp and the shadow count — no rsp displacement escapes the expression, honoring the invariant a previous staging attempt violated.

## Independent review

Full register/rsp trace at both sites verified clean (slot stores are rbp-relative and immune to rsp movement; `emit_gc_shadow_pop_n` preserves rdi/rsi; `gc_deep_equal` contains no allocation). The review also classified **all 7** `push_temp_reg`-across-compile sites in the backend: the only other heap-capable one (the generic binary-op fallthrough) is **unreachable for heap values from well-typed programs** (the type checker forbids arithmetic/comparison/bitwise on enums — verified empirically) and is deferred to the ZGC plan's M3b staging sweep, which rewrites all staging anyway.

## Verification

- All 3 repros flipped from deterministic failure to matching the evaluator exactly
- 682 tests green (679 + 3 new regression tests sized to force collections during rhs construction), fmt/clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)