### PR TITLE
feat: --gc-log and --gc-stress GC observability flags (ZGC plan M2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ cargo run -- --backend c build program.kl -o program.c  # portable C backend (su
 cargo run -- --target x86_64-unknown-linux-gnu build path/to/program.kl -o program
 cargo run -- --warn-trust path/to/program.kl         # report trusted proofs
 cargo run -- --deny-trust path/to/program.kl         # reject trusted proofs
+cargo run -- --gc-log build program.kl -o program    # GC stats to stderr at exit
+cargo run -- --gc-stress build program.kl -o program # collect before every alloc (bug-shaker)
 ```
 
 ## Architecture

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -17,6 +17,16 @@ pub struct NativeCompilerConfig {
     pub target: NativeTarget,
     pub deny_trust: bool,
     pub warn_trust: bool,
+    /// `--gc-log`: the emitted program prints one line of GC statistics
+    /// to stderr at exit (collections, allocations, bytes, max/total
+    /// pause nanoseconds). Off by default; zero cost when off.
+    pub gc_log: bool,
+    /// `--gc-stress`: the emitted `gc_alloc` runs a full collection
+    /// before every allocation attempt. Turns any pointer left
+    /// unrooted across an allocation into a deterministic crash rather
+    /// than a size-dependent heisenbug — the standing bug-shaker for
+    /// the collector's staging invariants.
+    pub gc_stress: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -631,6 +641,8 @@ fn compile_internal(
             generator.mono_enum_variants = mono_enum_variants;
             generator.ext_method_enum_types = ext_registry;
             generator.variant_owner_enum = variant_owner_enum;
+            generator.gc_log = config.gc_log;
+            generator.gc_stress = config.gc_stress;
             let object = generator.compile(&expr).map_err(|diagnostic| {
                 NativeCompileError::with_view(source, user_view, diagnostic)
             })?;
@@ -4298,6 +4310,26 @@ struct NativeCodeGenerator {
     gc_segments: DataLabel,
     gc_segment_count: DataLabel,
     gc_collect_counter: DataLabel,
+    /// `--gc-log` statistics cells (all `.data` i64, initialised 0):
+    /// total allocations, total payload+header bytes handed out, and
+    /// the max / cumulative collection-pause nanoseconds measured via
+    /// the `clock_gettime` shim around each `gc_collect`.
+    gc_alloc_count: DataLabel,
+    gc_bytes_allocated: DataLabel,
+    gc_pause_max_ns: DataLabel,
+    gc_pause_total_ns: DataLabel,
+    /// Scratch `timespec` (two i64) for the pause-timing clock_gettime
+    /// calls; only touched when `gc_log` is set.
+    gc_pause_timespec: DataLabel,
+    /// Monotonic nanoseconds captured at a collection's entry, read
+    /// back at its exit to compute the pause. Single-threaded and
+    /// `gc_collect` never re-enters, so a global cell is safe.
+    gc_pause_start_ns: DataLabel,
+    /// `--gc-log` (report GC stats to stderr at exit) and `--gc-stress`
+    /// (collect before every allocation). Both compile-time; zero cost
+    /// when off.
+    gc_log: bool,
+    gc_stress: bool,
     gc_alloc: TextLabel,
     gc_collect: TextLabel,
     gc_pin: TextLabel,
@@ -4484,6 +4516,12 @@ impl NativeCodeGenerator {
         let gc_segments = asm.data_label_with_i64s(&vec![0; 3 * Self::GC_MAX_SEGMENTS]);
         let gc_segment_count = asm.data_label_with_i64s(&[0]);
         let gc_collect_counter = asm.data_label_with_i64s(&[0]);
+        let gc_alloc_count = asm.data_label_with_i64s(&[0]);
+        let gc_bytes_allocated = asm.data_label_with_i64s(&[0]);
+        let gc_pause_max_ns = asm.data_label_with_i64s(&[0]);
+        let gc_pause_total_ns = asm.data_label_with_i64s(&[0]);
+        let gc_pause_timespec = asm.data_label_with_i64s(&[0, 0]);
+        let gc_pause_start_ns = asm.data_label_with_i64s(&[0]);
         let random_state = asm.data_label_with_i64s(&[0]);
         let gc_alloc = asm.create_text_label();
         let gc_collect = asm.create_text_label();
@@ -4607,6 +4645,14 @@ impl NativeCodeGenerator {
             gc_segments,
             gc_segment_count,
             gc_collect_counter,
+            gc_alloc_count,
+            gc_bytes_allocated,
+            gc_pause_max_ns,
+            gc_pause_total_ns,
+            gc_pause_timespec,
+            gc_pause_start_ns,
+            gc_log: false,
+            gc_stress: false,
             gc_alloc,
             gc_collect,
             gc_pin,
@@ -5202,6 +5248,9 @@ impl NativeCodeGenerator {
         self.emit_initialize_gc_heap();
         self.compile_top_level(expr)?;
         self.emit_queued_threads()?;
+        if self.gc_log {
+            self.emit_gc_log_report();
+        }
         self.emit_exit_success();
         self.emit_functions()?;
         self.emit_stack_overflow_abort_runtime();
@@ -37667,6 +37716,46 @@ impl NativeCodeGenerator {
     ///   [rbp -  8]: saved rbx
     ///   [rbp - 16]: total block size (header + payload, 16-byte aligned)
     ///   [rbp - 24]: type tag
+    /// Read `CLOCK_MONOTONIC` into `gc_pause_timespec` and fold it to
+    /// nanoseconds in `rax` (`tv_sec * 1e9 + tv_nsec`). Clobbers
+    /// rax/rcx/rdi/rsi/r8/r11 (the clock_gettime syscall's registers
+    /// plus the fold). Linux-only — the syscall path panics on Windows,
+    /// so pause timing is gated `!is_windows` at every call site.
+    fn emit_read_monotonic_ns_to_rax(&mut self) {
+        self.emit_clock_gettime(self.gc_pause_timespec);
+        self.asm.mov_data_addr(Reg::Rcx, self.gc_pause_timespec);
+        self.asm.load_ptr_disp32(Reg::Rax, Reg::Rcx, 0); // tv_sec
+        self.asm.mov_imm64(Reg::R8, 1_000_000_000);
+        self.asm.imul_reg_reg(Reg::Rax, Reg::R8);
+        self.asm.load_ptr_disp32(Reg::R8, Reg::Rcx, 8); // tv_nsec
+        self.asm.add_reg_reg(Reg::Rax, Reg::R8);
+    }
+
+    /// One `<label><number>` field of the `--gc-log` exit report,
+    /// written to stderr. `print_i64` reloads all its inputs, so no
+    /// register is live across this helper.
+    fn emit_gc_log_field(&mut self, label: &[u8], cell: DataLabel) {
+        let text = self.asm.data_label_with_bytes(label);
+        self.emit_write_data(self.platform.stderr_fd(), text, label.len());
+        self.asm.mov_data_addr(Reg::Rdi, cell);
+        self.asm.load_ptr_disp32(Reg::Rdi, Reg::Rdi, 0);
+        self.asm.mov_imm64(Reg::Rsi, self.platform.stderr_fd());
+        self.asm.mov_imm64(Reg::Rdx, 0); // no leading newline
+        self.asm.call_label(self.print_i64);
+    }
+
+    /// Emit the `--gc-log` statistics line to stderr. Called from the
+    /// normal exit path just before `exit(0)` when `gc_log` is set.
+    fn emit_gc_log_report(&mut self) {
+        self.emit_gc_log_field(b"gc: collections=", self.gc_collect_counter);
+        self.emit_gc_log_field(b" allocs=", self.gc_alloc_count);
+        self.emit_gc_log_field(b" bytes=", self.gc_bytes_allocated);
+        self.emit_gc_log_field(b" max_pause_ns=", self.gc_pause_max_ns);
+        self.emit_gc_log_field(b" total_pause_ns=", self.gc_pause_total_ns);
+        let newline = self.asm.data_label_with_bytes(b"\n");
+        self.emit_write_data(self.platform.stderr_fd(), newline, 1);
+    }
+
     fn emit_gc_alloc_runtime(&mut self) {
         self.asm.bind_text_label(self.gc_alloc);
         self.asm.push_reg(Reg::Rbp);
@@ -37685,6 +37774,16 @@ impl NativeCodeGenerator {
         let do_grow = self.asm.create_text_label();
         let oom = self.asm.create_text_label();
         let after_collect = self.asm.create_text_label();
+
+        // --gc-stress: collect before every allocation attempt. The
+        // request's own object is allocated by the attempt that
+        // follows, so collecting here only reclaims prior garbage --
+        // and turns any pointer left unrooted across an allocation into
+        // a deterministic crash. gc_collect makes its own frame and
+        // preserves this frame's rbp-relative slots.
+        if self.gc_stress {
+            self.asm.call_label(self.gc_collect);
+        }
 
         self.emit_gc_alloc_attempt(do_collect, success);
         // First attempt failed; run collector then retry.
@@ -37712,6 +37811,20 @@ impl NativeCodeGenerator {
         self.emit_exit_code(1);
 
         self.asm.bind_text_label(success);
+        // --gc-log: count this allocation and its byte size (total,
+        // header included, in slot 16). rax holds the user pointer and
+        // must survive, so the counter bumps use r10/r11 only.
+        if self.gc_log {
+            self.asm.mov_data_addr(Reg::R10, self.gc_alloc_count);
+            self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
+            self.asm.add_reg_imm32(Reg::R11, 1);
+            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R11);
+            self.asm.load_rbp_slot(Reg::R11, 16); // total block bytes
+            self.asm.mov_data_addr(Reg::R10, self.gc_bytes_allocated);
+            self.asm.load_ptr_disp32(Reg::Rbx, Reg::R10, 0);
+            self.asm.add_reg_reg(Reg::Rbx, Reg::R11);
+            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rbx);
+        }
         // Tear down locals and return.
         self.asm.add_reg_imm32(Reg::Rsp, 16);
         self.asm.pop_reg(Reg::Rbx);
@@ -37814,6 +37927,14 @@ impl NativeCodeGenerator {
         self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
         self.asm.add_reg_imm32(Reg::Rax, 1);
         self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
+        // --gc-log pause timing (Linux only; the clock syscall path
+        // panics on Windows). Capture the monotonic start before the
+        // mark/sweep work; the delta is folded in at the epilogue.
+        if self.gc_log && !self.is_windows {
+            self.emit_read_monotonic_ns_to_rax();
+            self.asm.mov_data_addr(Reg::R10, self.gc_pause_start_ns);
+            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
+        }
         // Reserve six qword locals (rbp-relative addressing). The first
         // four are reused across phases; the last pair holds the segment
         // iteration state used by the sweep loop.
@@ -38051,6 +38172,28 @@ impl NativeCodeGenerator {
         // free_list_head = r9
         self.asm.mov_data_addr(Reg::R10, self.gc_free_list_head);
         self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R9);
+
+        // --gc-log pause timing epilogue: delta = now - start; total +=
+        // delta; max = max(max, delta). All registers are dead here.
+        if self.gc_log && !self.is_windows {
+            self.emit_read_monotonic_ns_to_rax();
+            self.asm.mov_data_addr(Reg::R10, self.gc_pause_start_ns);
+            self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
+            self.asm.sub_reg_reg(Reg::Rax, Reg::R11); // rax = delta ns
+            // total += delta
+            self.asm.mov_data_addr(Reg::R10, self.gc_pause_total_ns);
+            self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
+            self.asm.add_reg_reg(Reg::R11, Reg::Rax);
+            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R11);
+            // max = max(max, delta)
+            self.asm.mov_data_addr(Reg::R10, self.gc_pause_max_ns);
+            self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
+            self.asm.cmp_reg_reg(Reg::Rax, Reg::R11);
+            let keep_max = self.asm.create_text_label();
+            self.asm.jcc_label(Condition::LessEqual, keep_max);
+            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
+            self.asm.bind_text_label(keep_max);
+        }
 
         self.asm.leave();
         self.asm.ret();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,13 @@ pub struct ExecutionConfig {
     /// `build` through the portable C backend instead of silently
     /// cross-building for the default Linux target.
     pub explicit_target: bool,
+    /// `--gc-log`: emitted programs print GC statistics to stderr at
+    /// exit.
+    pub gc_log: bool,
+    /// `--gc-stress`: emitted `gc_alloc` collects before every
+    /// allocation (deterministic detector for pointers left unrooted
+    /// across an allocation).
+    pub gc_stress: bool,
 }
 
 impl ExecutionConfig {
@@ -25,6 +32,8 @@ impl ExecutionConfig {
             native_target,
             c_backend: false,
             explicit_target: false,
+            gc_log: false,
+            gc_stress: false,
         }
     }
 }
@@ -76,6 +85,8 @@ pub fn parse_command_line(args: &[String]) -> Result<ParsedCommand, CommandLineE
     let mut warn_trust = false;
     let mut native_target = NativeTarget::default();
     let mut explicit_target = false;
+    let mut gc_log = false;
+    let mut gc_stress = false;
     let mut others = Vec::new();
     let mut script_args = Vec::new();
     let mut seen_separator = false;
@@ -98,6 +109,14 @@ pub fn parse_command_line(args: &[String]) -> Result<ParsedCommand, CommandLineE
             }
             "--warn-trust" => {
                 warn_trust = true;
+                index += 1;
+            }
+            "--gc-log" => {
+                gc_log = true;
+                index += 1;
+            }
+            "--gc-stress" => {
+                gc_stress = true;
                 index += 1;
             }
             "--backend" => {
@@ -139,6 +158,8 @@ pub fn parse_command_line(args: &[String]) -> Result<ParsedCommand, CommandLineE
     let mut config = ExecutionConfig::new(deny_trust, warn_trust, native_target);
     config.c_backend = c_backend;
     config.explicit_target = explicit_target;
+    config.gc_log = gc_log;
+    config.gc_stress = gc_stress;
     let action = match others.as_slice() {
         [command] if command == "targets" => RunAction::ListTargets,
         [flag] if flag == "--version" || flag == "-V" => RunAction::ShowVersion,
@@ -284,6 +305,35 @@ mod tests {
             }
             other => panic!("unexpected action: {other:?}"),
         }
+    }
+
+    #[test]
+    fn parses_gc_log_and_gc_stress_flags() {
+        let args = vec![
+            "--gc-log".to_string(),
+            "--gc-stress".to_string(),
+            "build".to_string(),
+            "sample.kl".to_string(),
+            "-o".to_string(),
+            "sample".to_string(),
+        ];
+        let parsed = parse_command_line(&args).expect("build command should parse");
+        assert!(parsed.config.gc_log);
+        assert!(parsed.config.gc_stress);
+        assert!(matches!(parsed.action, RunAction::BuildFile { .. }));
+    }
+
+    #[test]
+    fn gc_flags_default_off() {
+        let args = vec![
+            "build".to_string(),
+            "sample.kl".to_string(),
+            "-o".to_string(),
+            "sample".to_string(),
+        ];
+        let parsed = parse_command_line(&args).expect("build command should parse");
+        assert!(!parsed.config.gc_log);
+        assert!(!parsed.config.gc_stress);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,8 @@ fn run(command: ParsedCommand) -> Result<(), u8> {
                 target,
                 deny_trust: command.config.deny_trust,
                 warn_trust: command.config.warn_trust,
+                gc_log: command.config.gc_log,
+                gc_stress: command.config.gc_stress,
             };
             let user_modules = user_modules_for(&input, &text)?;
             let bytes = match compile_source_with_prelude_and_modules_for_target(

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -20865,6 +20865,153 @@ fn native_build_survives_enum_allocation_churn_across_collections() {
     assert_eq!(String::from_utf8_lossy(&run_output.stdout), "50000\n");
 }
 
+/// A churn program that outlives the 1 MiB initial heap, used by the
+/// `--gc-log` / `--gc-stress` tests below.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+const GC_CHURN_PROGRAM: &str = "enum Tree { case Leaf(v: Int); case Branch(l: Tree, r: Tree) }\n\
+     mutable i = 0\n\
+     mutable acc = 0\n\
+     while (i < 50000) {\n\
+       val t = Branch(Leaf(7), Leaf(2))\n\
+       acc = acc + (t match { case Branch(l, r) => 1; case Leaf(v) => 0 })\n\
+       i = i + 1\n\
+     }\n\
+     println(acc)\n";
+
+/// Build the churn program with the given extra flags and return
+/// (stdout, stderr) of the compiled binary.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn build_and_run_gc_program(source: &str, flags: &[&str]) -> (String, String) {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let source_path = std::env::temp_dir().join(format!("klassic_gc_flag_{stamp}.kl"));
+    let output_path = std::env::temp_dir().join(format!("klassic_gc_flag_{stamp}.bin"));
+    fs::write(&source_path, source).expect("temp source file should write");
+    let mut args: Vec<&str> = flags.to_vec();
+    args.push("build");
+    let source_str = source_path
+        .to_str()
+        .expect("path should be utf-8")
+        .to_string();
+    let output_str = output_path
+        .to_str()
+        .expect("path should be utf-8")
+        .to_string();
+    args.push(&source_str);
+    args.push("-o");
+    args.push(&output_str);
+    let build_output = Command::new(klassic_bin())
+        .args(&args)
+        .output()
+        .expect("binary should run");
+    assert!(
+        build_output.status.success(),
+        "native build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+    let run_output = Command::new(&output_path)
+        .output()
+        .expect("compiled binary should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&output_path);
+    assert!(
+        run_output.status.success(),
+        "compiled binary should exit cleanly\nstderr:\n{}",
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+    (
+        String::from_utf8_lossy(&run_output.stdout).into_owned(),
+        String::from_utf8_lossy(&run_output.stderr).into_owned(),
+    )
+}
+
+/// `--gc-log` reports collection statistics to stderr at exit while
+/// leaving stdout byte-identical to a build without the flag.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_gc_log_reports_collections_on_churn() {
+    let (plain_stdout, plain_stderr) = build_and_run_gc_program(GC_CHURN_PROGRAM, &[]);
+    assert_eq!(plain_stdout, "50000\n");
+    assert_eq!(plain_stderr, "", "no --gc-log flag: stderr must be clean");
+
+    let (log_stdout, log_stderr) = build_and_run_gc_program(GC_CHURN_PROGRAM, &["--gc-log"]);
+    assert_eq!(log_stdout, "50000\n", "--gc-log must not disturb stdout");
+    assert!(
+        log_stderr.starts_with("gc: collections="),
+        "--gc-log stderr should start with the stats line, got:\n{log_stderr}"
+    );
+    // The churn exhausts the 1 MiB heap several times, so at least one
+    // collection must have run and the reported counters must be
+    // internally consistent (allocs > 0, bytes > 0).
+    let collections = log_stderr
+        .split("collections=")
+        .nth(1)
+        .and_then(|s| s.split_whitespace().next())
+        .and_then(|s| s.parse::<u64>().ok())
+        .expect("stats line should contain a collections count");
+    assert!(
+        collections >= 1,
+        "churn should force at least one collection"
+    );
+    assert!(log_stderr.contains(" allocs="));
+    assert!(log_stderr.contains(" bytes="));
+    assert!(log_stderr.contains(" max_pause_ns="));
+    assert!(log_stderr.contains(" total_pause_ns="));
+}
+
+/// `--gc-stress` collects before every allocation, so the same churn
+/// reports one collection per allocation and still produces the exact
+/// same output -- the deterministic proof that no pointer is left
+/// unrooted across an allocation (the M1 fix holds under maximal
+/// pressure).
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_gc_stress_forces_a_collection_per_alloc_and_stays_correct() {
+    let (stdout, stderr) = build_and_run_gc_program(GC_CHURN_PROGRAM, &["--gc-log", "--gc-stress"]);
+    assert_eq!(stdout, "50000\n", "stress mode must not change the result");
+    let collections = stderr
+        .split("collections=")
+        .nth(1)
+        .and_then(|s| s.split_whitespace().next())
+        .and_then(|s| s.parse::<u64>().ok())
+        .expect("stats line should contain a collections count");
+    let allocs = stderr
+        .split(" allocs=")
+        .nth(1)
+        .and_then(|s| s.split_whitespace().next())
+        .and_then(|s| s.parse::<u64>().ok())
+        .expect("stats line should contain an allocs count");
+    // Every allocation collects, so collections == allocs.
+    assert_eq!(
+        collections, allocs,
+        "--gc-stress must collect once per allocation"
+    );
+    assert!(allocs > 100_000, "churn should allocate many objects");
+}
+
+/// `--gc-stress` re-runs the M1 use-after-free repro under maximal
+/// collection pressure (a full collection before every allocation),
+/// removing any sizing luck: the equality must still match the
+/// evaluator's 100000.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_gc_stress_equality_repro_stays_correct() {
+    let program = "enum Pair { case P(a: Int, b: Int) }\n\
+         mutable i = 0\n\
+         mutable ok = 0\n\
+         while (i < 100000) {\n\
+           if (P(i, i) == P(i, i)) {\n\
+             ok = ok + 1\n\
+           }\n\
+           i = i + 1\n\
+         }\n\
+         println(ok)\n";
+    let (stdout, _stderr) = build_and_run_gc_program(program, &["--gc-stress"]);
+    assert_eq!(stdout, "100000\n");
+}
+
 /// Regression guard for a real use-after-free: `==` on two freshly
 /// constructed enums staged the lhs pointer with a raw machine-stack
 /// push (not a GC root) across the rhs compile. The lhs temporary's


### PR DESCRIPTION
## Summary

Milestone M2 of the ZGC implementation plan (docs/zgc-plan.md): two compile-time GC flags for the x86_64 native backend, both off by default with zero cost when off.

- **`--gc-log`**: the emitted program prints one GC statistics line to stderr at normal exit — `gc: collections=<n> allocs=<n> bytes=<n> max_pause_ns=<n> total_pause_ns=<n>`. Pause timing brackets the `gc_collect` body via `clock_gettime(CLOCK_MONOTONIC)` through the existing shim (Linux only — the syscall path panics on Windows, so pause fields stay 0 there while counters still work). Stdout is untouched; a build without the flag is byte-identical.
- **`--gc-stress`**: `gc_alloc` runs a full collection before every allocation attempt. Turns any pointer left unrooted across an allocation from a size-dependent heisenbug into a deterministic crash — the standing bug-shaker for the collector's staging invariants, and the acceptance tool for the upcoming M3 staging rewrites.

Observed on a churn program: `--gc-log` reports `collections=12 allocs=400000 bytes=13600000`; `--gc-stress` reports `collections=400000 allocs=400000` (one collection per allocation) with **identical stdout** — confirming the M1 use-after-free fix holds under maximal collection pressure.

## Why this comes first

Per the plan's sequencing: `--gc-stress` must exist before the M3 staging rewrites and the M4+ region/colored-pointer work, because a moving collector turns every "unrooted across alloc" hazard from latent into a guaranteed crash. Building the deterministic detector now isolates the variable.

## Wiring

Follows the existing `--deny-trust`/`--warn-trust` path: `parse_command_line` → `ExecutionConfig` → `NativeCompilerConfig` → generator field injection. New `.data` cells sit beside `gc_collect_counter`; the report reuses `print_i64` to stderr.

## Verification

- `--gc-log` stats present and correct, stdout clean, non-log build byte-identical
- `--gc-stress` forces collections==allocs and keeps output exact, including on the M1 equality repro
- 687 tests green (682 + 5 new: 3 cli_smoke, 2 cli parse), fmt/clippy clean
- Independent register-level review in progress (returned pointer survival, gc_collect frame safety across the stress call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)