### PR TITLE
fix: root gc_write/gc_read staging across allocation (ZGC plan M3a)

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -13276,6 +13276,17 @@ impl NativeCodeGenerator {
             "native heap string equality first argument",
             false,
         )?;
+        // Root the first operand in a shadow-tracked slot across the
+        // second's compile, and FREE it (via the scope) once the
+        // comparison is done. The old code allocated this slot without
+        // ever releasing it -- a permanent rsp/next_stack_offset
+        // imbalance that was harmless on its own but corrupts the stack
+        // when this equality is the short-circuited RHS of a `&&`: the
+        // runtime skips the leaked `sub rsp` but the enclosing scope's
+        // `pop_scope` still adds it back. (Exposed by rooting the
+        // gc_read staging in the enum field-read path.) The comparison
+        // result is a Bool in rax, which `pop_scope` preserves.
+        self.push_scope();
         let a_slot = self.allocate_anonymous_slot(NativeValue::HeapPointer);
         self.asm.store_rbp_slot(a_slot.offset, Reg::Rax);
         let b = self.compile_expr(rhs)?;
@@ -13293,6 +13304,7 @@ impl NativeCodeGenerator {
             self.asm.setcc_al(Condition::Equal);
             self.asm.movzx_rax_al();
         }
+        self.pop_scope();
         Ok(NativeValue::Bool)
     }
 
@@ -13757,20 +13769,34 @@ impl NativeCodeGenerator {
                 &format!("native {name} for non-address argument"),
             ));
         }
-        self.asm.push_reg(Reg::Rax);
-        self.next_stack_offset += 8;
+        // Root the base in a shadow-tracked slot across the offset
+        // compile rather than holding it on the raw machine stack: an
+        // offset subexpression that allocates could otherwise let a
+        // collection sweep (or a moving collector relocate) the base
+        // out from under the load. The interior pointer is formed after
+        // the offset compile, from the rooted (relocation-updated)
+        // base. In practice the enum lowering always passes a literal
+        // offset, but this keeps the read sound for any offset
+        // expression and under a future moving collector. This is also
+        // the load site a ZGC load barrier will attach to (M5).
+        self.push_scope();
+        let base_slot = self.allocate_anonymous_slot(NativeValue::HeapPointer);
+        self.asm.store_rbp_slot(base_slot.offset, Reg::Rax);
         let offset = self.compile_expr(&arguments[1])?;
         if offset != NativeValue::Int {
+            self.pop_scope();
             return Err(unsupported(
                 span,
                 &format!("native {name} for non-Int byte_offset argument"),
             ));
         }
-        self.asm.pop_reg(Reg::Rcx);
-        self.next_stack_offset -= 8;
-        self.asm.add_reg_reg(Reg::Rax, Reg::Rcx);
-        // rax = address + offset; load *(rax)
+        // rax = offset; add the rooted base to form the interior
+        // pointer, then load. No allocation occurs between here and the
+        // load, so holding the result raw in rax afterward is safe.
+        self.asm.load_rbp_slot(Reg::Rcx, base_slot.offset);
+        self.asm.add_reg_reg(Reg::Rax, Reg::Rcx); // rax = offset + base
         self.asm.load_ptr_disp32(Reg::Rax, Reg::Rax, 0);
+        self.pop_scope();
         Ok(result)
     }
 
@@ -13941,20 +13967,32 @@ impl NativeCodeGenerator {
                 "native __gc_write for non-address argument",
             ));
         }
-        self.asm.push_reg(Reg::Rax);
-        self.next_stack_offset += 8;
+        // Root the base pointer in a shadow-tracked slot and stash the
+        // byte offset, then compile the value LAST and only afterward
+        // recompute `base + offset`. The old code held the interior
+        // pointer `base + offset` on the raw machine stack across the
+        // value compile, which for a boxed field allocates -- a
+        // moving collector could relocate the record at that
+        // allocation and leave the interior pointer stale (writing into
+        // freed memory). With the base rooted and the interior pointer
+        // formed only after the last allocation, the write always
+        // lands in the live object. (This also removes the old code's
+        // reliance on the record being kept alive by a separate
+        // construction-scope root while an unrooted interior pointer
+        // sat on the stack.)
+        self.push_scope();
+        let base_slot = self.allocate_anonymous_slot(NativeValue::HeapPointer);
+        self.asm.store_rbp_slot(base_slot.offset, Reg::Rax);
         let offset = self.compile_expr(&arguments[1])?;
         if offset != NativeValue::Int {
+            self.pop_scope();
             return Err(unsupported(
                 span,
                 "native __gc_write for non-Int byte_offset argument",
             ));
         }
-        self.asm.pop_reg(Reg::Rcx);
-        self.next_stack_offset -= 8;
-        self.asm.add_reg_reg(Reg::Rcx, Reg::Rax); // rcx = addr + offset
-        self.asm.push_reg(Reg::Rcx);
-        self.next_stack_offset += 8;
+        let offset_slot = self.allocate_anonymous_slot(NativeValue::Int);
+        self.asm.store_rbp_slot(offset_slot.offset, Reg::Rax);
         let value = self.compile_expr(&arguments[2])?;
         if !matches!(
             value,
@@ -13963,14 +14001,20 @@ impl NativeCodeGenerator {
                 | NativeValue::HeapString
                 | NativeValue::RuntimeDouble
         ) {
+            self.pop_scope();
             return Err(unsupported(
                 span,
                 "native __gc_write for non-qword value argument",
             ));
         }
-        self.asm.pop_reg(Reg::Rcx);
-        self.next_stack_offset -= 8;
+        // value is in rax. Recompute the interior pointer from the
+        // rooted base (updated in place if the value's allocation
+        // relocated it) plus the stashed offset, then store.
+        self.asm.load_rbp_slot(Reg::Rcx, base_slot.offset);
+        self.asm.load_rbp_slot(Reg::Rdx, offset_slot.offset);
+        self.asm.add_reg_reg(Reg::Rcx, Reg::Rdx); // rcx = base + offset
         self.asm.store_ptr_disp32(Reg::Rcx, 0, Reg::Rax);
+        self.pop_scope();
         Ok(NativeValue::Unit)
     }
 

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -21012,6 +21012,53 @@ fn native_gc_stress_equality_repro_stays_correct() {
     assert_eq!(stdout, "100000\n");
 }
 
+/// M3a: `__gc_write` no longer holds the interior pointer `base+offset`
+/// on the raw machine stack across the value compile. Here the field's
+/// value is a freshly built nested enum, whose construction allocates
+/// (and under `--gc-stress` collects) between the base and the store.
+/// The base is rooted and the interior pointer re-formed after the
+/// allocation, so the write lands in the live record.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_gc_write_field_value_allocates_matches_evaluator() {
+    let program = "enum Tree { case Leaf(v: Int); case Branch(l: Tree, r: Tree) }\n\
+         enum Box { case B(t: Tree) }\n\
+         mutable i = 0\n\
+         mutable acc = 0\n\
+         while (i < 50000) {\n\
+           val b = B(Branch(Leaf(i), Leaf(i + 1)))\n\
+           acc = acc + (b match { case B(t) => (t match { case Branch(l, r) => 1; case Leaf(v) => 0 }) })\n\
+           i = i + 1\n\
+         }\n\
+         println(acc)\n";
+    let (plain, _e1) = build_and_run_gc_program(program, &[]);
+    assert_eq!(plain, "50000\n");
+    let (stress, _e2) = build_and_run_gc_program(program, &["--gc-stress"]);
+    assert_eq!(stress, "50000\n", "gc_write must be sound under stress");
+}
+
+/// M3a regression: a string-literal pattern arm (`case Named("x")`)
+/// followed by another arm used to crash on the non-matching input.
+/// The literal pattern compiles to a short-circuited `field == "x"`;
+/// `compile_heap_string_equality` leaked a stack slot, so on the
+/// short-circuit path the enclosing scope's `pop_scope` over-added rsp
+/// and corrupted the stack. Rooting the gc_read staging exposed it;
+/// balancing the equality's slot fixes it. `kind(Anon)` must return 0,
+/// not segfault.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_string_literal_pattern_then_other_arm_no_crash() {
+    let program = "enum Tag { case Named(s: String); case Anon }\n\
+         def kind(t) = t match { case Named(\"x\") => 1; case Named(other) => 2; case Anon => 0 }\n\
+         println(kind(Named(\"x\")))\n\
+         println(kind(Named(\"y\")))\n\
+         println(kind(Anon))\n";
+    let (plain, _e1) = build_and_run_gc_program(program, &[]);
+    assert_eq!(plain, "1\n2\n0\n");
+    let (stress, _e2) = build_and_run_gc_program(program, &["--gc-stress"]);
+    assert_eq!(stress, "1\n2\n0\n");
+}
+
 /// Regression guard for a real use-after-free: `==` on two freshly
 /// constructed enums staged the lhs pointer with a raw machine-stack
 /// push (not a GC root) across the rhs compile. The lhs temporary's


### PR DESCRIPTION
## Summary

Milestone M3a of the ZGC plan (docs/zgc-plan.md): remove the interior-pointer-on-raw-stack hazard from the two heap-access primitives, so a moving collector (M7) can relocate objects at allocation points without leaving stale interior pointers.

- **`compile_gc_write`**: held `base + offset` on the raw machine stack across the value compile (which allocates for boxed fields). Now roots the base in a shadow-tracked slot, stashes the offset, and recomputes the interior pointer from the (relocation-updated) base only *after* the value's last allocation.
- **`compile_gc_read_qword`**: held the base on the raw stack across the offset compile. Now roots it; forms the interior pointer afterward. This is also the load site a ZGC load barrier attaches to (M5).

## Latent bug fixed along the way

Rooting the field-read staging exposed a real pre-existing bug in `compile_heap_string_equality`: it allocated a slot for the first operand and **never freed it**. Harmless alone, but when the equality is the short-circuited RHS of a `&&` (which is exactly what a `case Named("x")` string-literal pattern compiles to), the runtime skips the leaked `sub rsp` on the short-circuit path while the enclosing scope's `pop_scope` still adds it back — corrupting rsp and segfaulting the next arm. `native_build_compiles_string_enum_payloads`'s `kind(Anon)` was null-dereffing. Fixed by scoping the slot so it's freed after the comparison.

## Verification

- 689 tests green (687 + 2 new), fmt/clippy clean
- **All correct under `--gc-stress`** (collect on every allocation) — the deterministic detector from M2:
  - `native_gc_write_field_value_allocates_matches_evaluator` (field set to a freshly built nested enum, allocation between base and store)
  - `native_string_literal_pattern_then_other_arm_no_crash` (the short-circuit crash repro)
- Independent register-level review in progress (also auditing for sibling leaky-slot sites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)