### PR TITLE
refactor: root function-argument staging in slots (ZGC plan M3b)

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -8446,7 +8446,21 @@ impl NativeCodeGenerator {
     ) -> Result<NativeValue, Diagnostic> {
         let mut staged_runtime_arguments = Vec::new();
         let mut staged_record_arguments = Vec::new();
-        let mut qword_arg_values = Vec::new();
+        // Each qword argument is spilled into a shadow-tracked stack slot
+        // (rbp offset + value type) rather than pinned by value and pushed
+        // raw. A heap-pointer slot is a real GC root the collector updates
+        // through its slot address, so a collection triggered while a
+        // later argument is being evaluated keeps every earlier heap
+        // argument live (and relocatable). The old gc_pin rooted by value
+        // -- relocation-hostile -- and the raw machine-stack push was
+        // invisible to the collector entirely.
+        let mut qword_arg_slots: Vec<(i32, NativeValue)> = Vec::new();
+        // Scope brackets the whole staging region so the argument slots
+        // (and their shadow roots) are freed after the call in one shot.
+        // Error paths below abort compilation, so they do not need to
+        // unwind the scope; the success path pops it after the return
+        // value is materialized.
+        self.push_scope();
         for (index, (argument, expected_value)) in arguments
             .iter()
             .zip(function.param_values.iter())
@@ -8552,6 +8566,7 @@ impl NativeCodeGenerator {
                             NativeValue::HeapString
                         }
                         _ => {
+                            self.pop_scope();
                             return Err(unsupported(
                                 span,
                                 "native function string argument for this value type",
@@ -8562,6 +8577,7 @@ impl NativeCodeGenerator {
                     value
                 };
                 if value != *expected_value {
+                    self.pop_scope();
                     return Err(unsupported(
                         span,
                         "native function argument for this value type",
@@ -8583,6 +8599,7 @@ impl NativeCodeGenerator {
                         argument_shape.as_ref(),
                     ) && !enum_shapes_compatible(actual_shape, expected_shape)
                     {
+                        self.pop_scope();
                         return Err(Diagnostic::compile(
                             argument.span(),
                             "native function argument is a generic enum whose payload shape \
@@ -8590,14 +8607,16 @@ impl NativeCodeGenerator {
                                 .to_string(),
                         ));
                     }
-                    self.asm.mov_reg_reg(Reg::Rdi, Reg::Rax);
-                    self.asm.call_label(self.gc_pin);
                 }
-                self.push_temp_reg(Reg::Rax);
-                qword_arg_values.push(*expected_value);
+                // Root the argument (heap slots become GC roots; Int/Bool
+                // slots are plain storage) and remember where it lives.
+                let slot = self.allocate_anonymous_slot(*expected_value);
+                self.asm.store_rbp_slot(slot.offset, Reg::Rax);
+                qword_arg_slots.push((slot.offset, *expected_value));
                 continue;
             }
             if value != *expected_value {
+                self.pop_scope();
                 return Err(unsupported(
                     span,
                     "native function argument for this value type",
@@ -8621,31 +8640,41 @@ impl NativeCodeGenerator {
                 "function record argument exceeds 65536 bytes",
             )?;
         }
-        // Every argument is evaluated; nothing below allocates, so the
-        // staging pins can drop before the call. Peek each pinned
-        // pointer from its push slot (gc_unpin only clobbers rax / r10
-        // / r11, never the argument registers).
-        let qword_count = qword_arg_values.len();
-        for (index, value) in qword_arg_values.iter().enumerate() {
-            if matches!(value, NativeValue::HeapPointer | NativeValue::HeapString) {
-                let disp = ((qword_count - 1 - index) * 8) as i32;
-                self.asm.mov_reg_reg(Reg::R10, Reg::Rsp);
-                self.asm.load_ptr_disp32(Reg::Rdi, Reg::R10, disp);
-                self.asm.call_label(self.gc_unpin);
-            }
-        }
+        // Materialize the argument registers / stack from the rooted
+        // slots. Every argument is already evaluated and rooted, so no
+        // allocation occurs between here and the call -- the raw
+        // register / stack copies below cannot be swept or relocated.
+        let qword_count = qword_arg_slots.len();
         let arg_regs = argument_registers(qword_count);
         let pass_on_stack = qword_count > arg_regs.len();
-        if !pass_on_stack {
-            for reg in arg_regs.into_iter().rev() {
-                self.pop_temp_reg(reg);
+        if pass_on_stack {
+            // Klassic passes every argument on the stack when there are
+            // more than six. Push arg0 deepest .. argN on top, matching
+            // the callee's frame layout. These are raw pushes:
+            // next_stack_offset is not bumped, so the scope's pop only
+            // reclaims the argument slots, and the explicit `add rsp`
+            // after the call removes these pushed copies.
+            for (offset, _) in &qword_arg_slots {
+                self.asm.load_rbp_slot(Reg::Rax, *offset);
+                self.asm.push_reg(Reg::Rax);
+            }
+        } else {
+            // rdi=arg0, rsi=arg1, ...: load each slot into its register.
+            // The slots are rbp-relative, so the load order is
+            // independent and nothing between the loads and the call
+            // clobbers an argument register.
+            for (reg, (offset, _)) in arg_regs.iter().zip(qword_arg_slots.iter()) {
+                self.asm.load_rbp_slot(*reg, *offset);
             }
         }
         self.asm.call_label(function.label);
         if pass_on_stack {
             self.asm.add_reg_imm32(Reg::Rsp, (qword_count * 8) as i32);
-            self.release_temp_stack(qword_count * 8);
         }
+        // Free the argument slots and their shadow roots before copying
+        // the return value (which uses fixed .data scratch, not the
+        // stack). pop_scope preserves rax, so a heap return survives.
+        self.pop_scope();
         let result = self.copy_function_return_to_call_site(function.return_value, span)?;
         if let Some(shape) = &function.return_enum_shape {
             self.pending_enum_shape = Some(shape.clone());

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -21059,6 +21059,79 @@ fn native_string_literal_pattern_then_other_arm_no_crash() {
     assert_eq!(stress, "1\n2\n0\n");
 }
 
+/// M3b: by-pointer function arguments are now rooted in shadow-tracked
+/// slots for the whole staging region rather than pinned by value and
+/// pushed raw. Here two heap (enum) arguments are each freshly built --
+/// constructing the second collects while the first is only reachable
+/// through its staging slot. Under --gc-stress (collect on every
+/// allocation) the equality must still match the evaluator's 50000.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_pointer_arg_staging_survives_collection() {
+    let program = "enum Tree { case Leaf(v: Int); case Branch(l: Tree, r: Tree) }\n\
+         def same(a: Tree, b: Tree): Boolean = a == b\n\
+         mutable i = 0\n\
+         mutable ok = 0\n\
+         while (i < 50000) {\n\
+           if (same(Branch(Leaf(i), Leaf(i)), Branch(Leaf(i), Leaf(i)))) {\n\
+             ok = ok + 1\n\
+           }\n\
+           i = i + 1\n\
+         }\n\
+         println(ok)\n";
+    let (plain, _e1) = build_and_run_gc_program(program, &[]);
+    assert_eq!(plain, "50000\n");
+    let (stress, _e2) = build_and_run_gc_program(program, &["--gc-stress"]);
+    assert_eq!(stress, "50000\n");
+}
+
+/// M3b: the >6-argument path passes every argument on the stack. Seven
+/// heap arguments, each a freshly built enum that allocates (and under
+/// stress collects), exercise the stack-passing materialization from
+/// rooted slots. Result must match the evaluator under stress.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_pointer_arg_staging_over_six_stack_passed() {
+    let program = "enum Tree { case Leaf(v: Int); case Branch(l: Tree, r: Tree) }\n\
+         def sz(t: Tree): Int = t match { case Leaf(v) => 1; case Branch(l, r) => sz(l) + sz(r) }\n\
+         def sum7(a: Tree, b: Tree, c: Tree, d: Tree, e: Tree, f: Tree, g: Tree): Int =\n\
+           sz(a) + sz(b) + sz(c) + sz(d) + sz(e) + sz(f) + sz(g)\n\
+         mutable i = 0\n\
+         mutable acc = 0\n\
+         while (i < 20000) {\n\
+           acc = acc + sum7(Leaf(i), Branch(Leaf(i), Leaf(i)), Leaf(i), Leaf(i), Leaf(i), Leaf(i), Leaf(i))\n\
+           i = i + 1\n\
+         }\n\
+         println(acc)\n";
+    let (plain, _e1) = build_and_run_gc_program(program, &[]);
+    assert_eq!(plain, "160000\n");
+    let (stress, _e2) = build_and_run_gc_program(program, &["--gc-stress"]);
+    assert_eq!(stress, "160000\n");
+}
+
+/// M3b: mixed Int/heap arguments in a >6-arg call, interleaved so an
+/// Int slot sits between rooted heap slots. Guards the slot value-type
+/// tagging (Int slots must NOT be shadow-rooted, heap slots must be).
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_pointer_arg_staging_mixed_int_and_heap() {
+    let program = "enum Tree { case Leaf(v: Int); case Branch(l: Tree, r: Tree) }\n\
+         def sz(t: Tree): Int = t match { case Leaf(v) => 1; case Branch(l, r) => sz(l) + sz(r) }\n\
+         def mix(a: Int, t: Tree, b: Int, u: Tree, c: Int, v: Tree, d: Int, w: Tree): Int =\n\
+           a + sz(t) + b + sz(u) + c + sz(v) + d + sz(w)\n\
+         mutable i = 0\n\
+         mutable acc = 0\n\
+         while (i < 20000) {\n\
+           acc = acc + mix(1, Branch(Leaf(i), Leaf(i)), 2, Leaf(i), 3, Branch(Leaf(i), Leaf(i)), 4, Leaf(i))\n\
+           i = i + 1\n\
+         }\n\
+         println(acc)\n";
+    let (plain, _e1) = build_and_run_gc_program(program, &[]);
+    assert_eq!(plain, "320000\n");
+    let (stress, _e2) = build_and_run_gc_program(program, &["--gc-stress"]);
+    assert_eq!(stress, "320000\n");
+}
+
 /// Regression guard for a real use-after-free: `==` on two freshly
 /// constructed enums staged the lhs pointer with a raw machine-stack
 /// push (not a GC root) across the rhs compile. The lhs temporary's


### PR DESCRIPTION
## Summary

Milestone M3b of the ZGC plan (docs/zgc-plan.md) — the **highest-risk** milestone. Rewrites the by-pointer call ABI's argument staging in `compile_pointer_abi_function_call` so it survives a moving collector.

**Old**: each heap argument was pinned by value in the root table (`gc_pin`) and pushed raw onto the machine stack (`push_temp_reg`) as it was compiled, then unpinned and popped into argument registers. Both are hostile to a moving collector — `gc_pin` roots by value (relocation changes the value, breaking the value-matched unpin) and the raw stack copy is invisible to the collector entirely. A collection triggered while a later argument is evaluated could sweep or move an earlier heap argument.

**New**: each qword argument is spilled into a shadow-tracked anonymous slot. Heap slots become real GC roots the collector updates through the slot address; Int/Bool slots are plain storage (correctly not rooted). A `push_scope`/`pop_scope` brackets the staging region so the slots and shadow roots free in one shot after the call. Argument registers (≤6) or the all-on-stack convention (>6) are materialized from the slots only after every argument is evaluated — no allocation between materialization and the call.

`gc_pin`/`gc_unpin` now have no callers; the emitted runtime is dead code M3c will delete.

## Invariant preserved (the 3a-era rsp lesson)

No push crosses an expression compile: the raw >6 stack pushes happen after all arguments are already in slots, and `next_stack_offset` is not bumped for them, so `pop_scope` reclaims exactly the slots.

## Verification

- 692 tests green (689 + 3 new), fmt/clippy clean
- **All correct under `--gc-stress`** (collect on every allocation):
  - `native_pointer_arg_staging_survives_collection` (2 heap args, sibling construction collects → 50000)
  - `native_pointer_arg_staging_over_six_stack_passed` (7 heap args, the >6 stack-passing path → 160000)
  - `native_pointer_arg_staging_mixed_int_and_heap` (Int slots between rooted heap slots in a >6 call → 320000)
  - nested pointer-ABI calls and deep recursion checked manually
- Mandatory independent register/stack-exact review in progress (ABI equivalence, rsp balance, rooting windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)