### PR TITLE
feat: ZGC colored pointers + load barrier + --gc-poison (plan M5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ cargo run -- --warn-trust path/to/program.kl         # report trusted proofs
 cargo run -- --deny-trust path/to/program.kl         # reject trusted proofs
 cargo run -- --gc-log build program.kl -o program    # GC stats to stderr at exit
 cargo run -- --gc-stress build program.kl -o program # collect before every alloc (bug-shaker)
+cargo run -- --gc-poison build program.kl -o program # bad-color heap ptrs; unbarriered deref faults
 ```
 
 ## Architecture

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -13807,6 +13807,16 @@ impl NativeCodeGenerator {
         self.asm.load_rbp_slot(Reg::R10, m_slot.offset);
         self.asm.add_reg_imm32(Reg::R10, 8);
         self.asm.add_reg_reg(Reg::R10, Reg::R8);
+        // Verbatim copy of a COLORED key/value slot into the new list:
+        // no load barrier, no re-color -- the color bits pass through
+        // untouched, and the result list is read back through the
+        // barriered read funnel later. This is sound only because rdi
+        // holds the colored pointer across just these two instructions
+        // with NO allocation, shadow-push, or collection point between
+        // them. M7 WARNING: once the collector moves objects, a colored
+        // pointer briefly live in a register here would be invisible to
+        // the root walk / relocation -- do not introduce a GC-triggering
+        // step between this load and the store below.
         self.asm.load_ptr_disp32(Reg::Rdi, Reg::R10, 0);
         // dst at new[i].
         self.asm.mov_reg_reg(Reg::R8, Reg::Rcx);
@@ -38459,6 +38469,13 @@ impl NativeCodeGenerator {
         self.asm.and_reg_reg(Reg::Rax, Reg::R13); // strip -> raw
         self.asm.mov_reg_reg(Reg::R11, Reg::Rax);
         self.asm.or_reg_reg(Reg::R11, Reg::R14); // recolor to good
+        // Self-heal: write the good-colored pointer back to the slot the
+        // value was loaded from. r10 (the field address) is carried in
+        // from the barrier fast path. M7 WARNING: this is only valid
+        // because M5 is non-moving, so the healed pointer's address is
+        // unchanged. Once relocation lands, the slow path must evacuate
+        // first and store the FORWARDED address, re-deriving the target
+        // -- do not simply carry r10 across a relocating heal.
         self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R11); // self-heal
         self.asm.ret();
     }

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -27,6 +27,10 @@ pub struct NativeCompilerConfig {
     /// than a size-dependent heisenbug — the standing bug-shaker for
     /// the collector's staging invariants.
     pub gc_stress: bool,
+    /// `--gc-poison`: heap-stored pointers are colored with the BAD
+    /// color, so the load-barrier slow path runs on every load and any
+    /// unbarriered dereference faults on a non-canonical address.
+    pub gc_poison: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -643,6 +647,7 @@ fn compile_internal(
             generator.variant_owner_enum = variant_owner_enum;
             generator.gc_log = config.gc_log;
             generator.gc_stress = config.gc_stress;
+            generator.gc_poison = config.gc_poison;
             let object = generator.compile(&expr).map_err(|diagnostic| {
                 NativeCompileError::with_view(source, user_view, diagnostic)
             })?;
@@ -4342,10 +4347,18 @@ struct NativeCodeGenerator {
     /// when off.
     gc_log: bool,
     gc_stress: bool,
+    /// `--gc-poison`: color heap-stored pointers with a BAD color, so any
+    /// unbarriered dereference faults on a non-canonical address and the
+    /// load-barrier slow path is exercised on every load.
+    gc_poison: bool,
     gc_alloc: TextLabel,
     gc_collect: TextLabel,
     gc_mark_visit: TextLabel,
     gc_deep_equal: TextLabel,
+    /// ZGC load-barrier slow path: heals a bad-colored heap pointer
+    /// (strip, recolor to good, self-heal store) and returns the raw
+    /// address. Leaf routine; clobbers only rax (output) and r11.
+    gc_load_barrier_slow: TextLabel,
     /// Acquire a fresh empty region as the current bump target (from the
     /// free-region pool, else the uncommitted tail within budget).
     gc_acquire_region: TextLabel,
@@ -4545,6 +4558,7 @@ impl NativeCodeGenerator {
         let gc_collect = asm.create_text_label();
         let gc_mark_visit = asm.create_text_label();
         let gc_deep_equal = asm.create_text_label();
+        let gc_load_barrier_slow = asm.create_text_label();
         let gc_acquire_region = asm.create_text_label();
         let gc_alloc_large = asm.create_text_label();
         let gc_grow_budget = asm.create_text_label();
@@ -4669,10 +4683,12 @@ impl NativeCodeGenerator {
             gc_pause_start_ns,
             gc_log: false,
             gc_stress: false,
+            gc_poison: false,
             gc_alloc,
             gc_collect,
             gc_mark_visit,
             gc_deep_equal,
+            gc_load_barrier_slow,
             gc_acquire_region,
             gc_alloc_large,
             gc_grow_budget,
@@ -5260,6 +5276,7 @@ impl NativeCodeGenerator {
         self.emit_store_command_line_state();
         self.emit_initialize_stack_floor();
         self.emit_initialize_gc_heap();
+        self.emit_initialize_color_registers();
         self.compile_top_level(expr)?;
         self.emit_queued_threads()?;
         if self.gc_log {
@@ -5271,6 +5288,7 @@ impl NativeCodeGenerator {
         self.emit_print_i64_runtime();
         self.emit_gc_mark_visit_runtime();
         self.emit_gc_deep_equal_runtime();
+        self.emit_gc_load_barrier_slow_runtime();
         self.emit_gc_alloc_runtime();
         self.emit_gc_collect_runtime();
         self.emit_gc_acquire_region_runtime();
@@ -13852,7 +13870,24 @@ impl NativeCodeGenerator {
         // load, so holding the result raw in rax afterward is safe.
         self.asm.load_rbp_slot(Reg::Rcx, base_slot.offset);
         self.asm.add_reg_reg(Reg::Rax, Reg::Rcx); // rax = offset + base
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::Rax, 0);
+        if matches!(result, NativeValue::HeapPointer | NativeValue::HeapString) {
+            // ZGC load barrier: a heap slot holds a COLORED pointer. Save
+            // the field address (for self-heal), load the value, and if
+            // its color is bad take the slow path; then strip the color
+            // so the register holds a raw (canonical) pointer. Only the
+            // pointer-typed reads barrier -- an Int/Double read through
+            // this same funnel must NOT strip (its high bits are data).
+            let ok = self.asm.create_text_label();
+            self.asm.mov_reg_reg(Reg::R10, Reg::Rax); // field addr
+            self.asm.load_ptr_disp32(Reg::Rax, Reg::Rax, 0); // colored value
+            self.asm.test_reg_reg(Reg::Rax, Reg::R15); // bad color?
+            self.asm.jcc_label(Condition::Equal, ok);
+            self.asm.call_label(self.gc_load_barrier_slow);
+            self.asm.bind_text_label(ok);
+            self.asm.and_reg_reg(Reg::Rax, Reg::R13); // strip -> raw
+        } else {
+            self.asm.load_ptr_disp32(Reg::Rax, Reg::Rax, 0);
+        }
         self.pop_scope();
         Ok(result)
     }
@@ -14070,6 +14105,18 @@ impl NativeCodeGenerator {
         self.asm.load_rbp_slot(Reg::Rcx, base_slot.offset);
         self.asm.load_rbp_slot(Reg::Rdx, offset_slot.offset);
         self.asm.add_reg_reg(Reg::Rcx, Reg::Rdx); // rcx = base + offset
+        if matches!(value, NativeValue::HeapPointer | NativeValue::HeapString) {
+            // ZGC color-on-store: a heap slot holds a COLORED pointer.
+            // Never color a null, though -- `0 | good_color` would be a
+            // bogus non-null pointer; a genuine null stays a raw 0 (which
+            // the load barrier passes through untouched). An Int/Double
+            // value stored through this same funnel is left uncolored.
+            let store_raw = self.asm.create_text_label();
+            self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
+            self.asm.jcc_label(Condition::Equal, store_raw);
+            self.asm.or_reg_reg(Reg::Rax, Reg::R14); // raw | good_color
+            self.asm.bind_text_label(store_raw);
+        }
         self.asm.store_ptr_disp32(Reg::Rcx, 0, Reg::Rax);
         self.pop_scope();
         Ok(NativeValue::Unit)
@@ -37693,6 +37740,38 @@ impl NativeCodeGenerator {
         self.emit_exit_code(1);
     }
 
+    /// ZGC colored-pointer bits (in bits 60-62; mmap addresses are <= 47
+    /// bits, so these are free, and any pointer with one set is
+    /// non-canonical -- dereferencing a colored pointer without stripping
+    /// faults, which is the barrier-coverage guarantee).
+    const GC_COLOR_M0: u64 = 1 << 60;
+    const GC_COLOR_M1: u64 = 1 << 61;
+    const GC_COLOR_R: u64 = 1 << 62;
+    const GC_COLOR_MASK: u64 = 7 << 60;
+    /// Strip mask: clears the color bits, leaving the raw address.
+    const GC_COLOR_STRIP: u64 = !Self::GC_COLOR_MASK;
+    /// Bad-color test mask: a good (M0) pointer ANDs to zero; a poisoned
+    /// (M1) or relocation-flagged (R) pointer ANDs non-zero and takes the
+    /// load-barrier slow path.
+    const GC_COLOR_BAD_MASK: u64 = Self::GC_COLOR_M1 | Self::GC_COLOR_R;
+
+    /// Initialize the reserved color registers once, before any user
+    /// code or collector routine runs. r13 = strip mask, r14 = good
+    /// color (M1 under --gc-poison, so every stored pointer is bad and
+    /// exercises the slow path / faults if unbarriered), r15 = bad mask.
+    /// All three are callee-saved, so they survive every syscall and
+    /// Windows shim and never need reloading in M5 (no phase flips yet).
+    fn emit_initialize_color_registers(&mut self) {
+        self.asm.mov_imm64(Reg::R13, Self::GC_COLOR_STRIP);
+        let good_color = if self.gc_poison {
+            Self::GC_COLOR_M1
+        } else {
+            Self::GC_COLOR_M0
+        };
+        self.asm.mov_imm64(Reg::R14, good_color);
+        self.asm.mov_imm64(Reg::R15, Self::GC_COLOR_BAD_MASK);
+    }
+
     fn emit_initialize_gc_heap(&mut self) {
         // Reserve the whole region heap up front: one anonymous mapping
         // of GC_RESERVE_BYTES (64 MiB). Linux demand-pages it, so only
@@ -38128,6 +38207,11 @@ impl NativeCodeGenerator {
         self.asm.cmp_reg_reg(Reg::R10, Reg::R11);
         self.asm.jcc_label(Condition::AboveOrEqual, trace_loop);
         self.asm.load_ptr_disp32(Reg::Rdi, Reg::R10, 0);
+        // Heap slots hold colored pointers; strip the color before
+        // gc_mark_visit dereferences the block header at [rdi-16]. (A
+        // no-op until color-on-store is turned on, since raw pointers
+        // AND with the strip mask unchanged.)
+        self.asm.and_reg_reg(Reg::Rdi, Reg::R13);
         self.asm.test_reg_reg(Reg::Rdi, Reg::Rdi);
         self.asm.jcc_label(Condition::Equal, trace_skip_field);
         self.asm.call_label(self.gc_mark_visit);
@@ -38361,6 +38445,24 @@ impl NativeCodeGenerator {
         self.emit_exit_code(1);
     }
 
+    /// `gc_load_barrier_slow` (in: rax = bad-colored heap pointer,
+    /// r10 = the field address it was loaded from; out: rax = raw
+    /// stripped pointer). Heals the slot: strips the color, recolors to
+    /// the good color (r14), and stores the good-colored pointer back to
+    /// the slot (self-heal; a plain store, single mutator). Under M5's
+    /// STW non-moving collector this is the entire slow path -- no
+    /// marking, no relocation, no allocation, so it cannot recurse. Only
+    /// reached for a non-null pointer (a null slot ANDs to zero against
+    /// the bad mask and takes the fast path).
+    fn emit_gc_load_barrier_slow_runtime(&mut self) {
+        self.asm.bind_text_label(self.gc_load_barrier_slow);
+        self.asm.and_reg_reg(Reg::Rax, Reg::R13); // strip -> raw
+        self.asm.mov_reg_reg(Reg::R11, Reg::Rax);
+        self.asm.or_reg_reg(Reg::R11, Reg::R14); // recolor to good
+        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R11); // self-heal
+        self.asm.ret();
+    }
+
     /// `gc_deep_equal(a, b)` (rdi = a, rsi = b) compares two heap values
     /// structurally, returning rax = 1 when they are equal and rax = 0
     /// otherwise. It is the native counterpart of the evaluator's
@@ -38465,8 +38567,12 @@ impl NativeCodeGenerator {
         self.asm.jcc_label(Condition::AboveOrEqual, equal);
         self.asm.load_rbp_slot(Reg::R11, 24);
         // rdi = a_slot = [cursor_a], rsi = b_slot = [cursor_b], recurse.
+        // Both slots hold colored pointers; strip before the recursive
+        // deep-equal dereferences them. (No-op until color-on-store.)
         self.asm.load_ptr_disp32(Reg::Rdi, Reg::R10, 0);
+        self.asm.and_reg_reg(Reg::Rdi, Reg::R13);
         self.asm.load_ptr_disp32(Reg::Rsi, Reg::R11, 0);
+        self.asm.and_reg_reg(Reg::Rsi, Reg::R13);
         self.asm.call_label(self.gc_deep_equal);
         self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
         self.asm.jcc_label(Condition::Equal, not_equal);
@@ -41174,6 +41280,14 @@ enum Reg {
     R9 = 9,
     R10 = 10,
     R11 = 11,
+    // R12 is intentionally omitted (unused; naming an unconstructed
+    // variant would trip the dead-code lint). R13-R15 are the ZGC
+    // reserved registers: r13 = color strip mask, r14 = good color,
+    // r15 = bad-color test mask. They are set once in the prologue and,
+    // being callee-saved, survive every syscall and Windows shim.
+    R13 = 13,
+    R14 = 14,
+    R15 = 15,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/docs/zgc-plan.md
+++ b/docs/zgc-plan.md
@@ -124,8 +124,9 @@ bumps a dedicated to-space region), so it cannot recurse or run a
 quantum.
 
 Color-on-store: the single heap-pointer store site ORs the current
-good color into pointer-typed values before the store (unconditional
-OR; coloring null is harmless).
+good color into pointer-typed values before the store, EXCEPT for a
+null (a null slot must stay a raw 0 -- `0 | good_color` would be a
+bogus non-null pointer, so the store guards on null).
 
 Phase machine (state in a `.data` qword):
 `Idle -> MarkStart (pause) -> Mark (quanta) -> MarkEnd (pause,
@@ -269,12 +270,28 @@ the semantic oracle everywhere (eval == native differential).
   not dropped (a leak that otherwise OOMs under `--gc-stress` with
   heavy turnover).
 - **M5 — Colored pointers + load barriers (collections still atomic) +
-  poison canary.** Color bits, reserved registers, the two barriers,
-  color-on-store, walker updates, a grep-audited coverage checklist in
-  the PR, and `--gc-poison` (leave bad colors set while idle so any
-  unbarriered dereference faults deterministically on a non-canonical
-  address — a missed barrier cannot silently work). The poison suite
-  gates every later milestone.
+  poison canary.** DONE. Color bits live in pointer bits 60-62 (M0=1<<60,
+  M1=1<<61, R=1<<62); a colored pointer is non-canonical, so any
+  unbarriered dereference faults. Reserved registers r13 = strip mask,
+  r14 = good color, r15 = bad-color test mask, set once in the prologue
+  (callee-saved, never reloaded in M5 since there is no phase flip yet).
+  Color-on-store at the single write funnel (`compile_gc_write`) colors
+  a heap-stored pointer with the good color, guarding NULL (a null slot
+  stays a raw 0 -- coloring it would make a bogus non-null). The load
+  barrier at the single read funnel (`compile_gc_read_qword`, only for
+  HeapPointer/HeapString reads) tests the color, runs a slow-path stub
+  on a bad color (strip + recolor + self-heal store), then strips to a
+  raw pointer. The GC walkers (mark trace, deep-equal) strip colors off
+  the slots they read. The `Map#keys`/`values` copy is a verbatim
+  colored memcpy. Collections stay fully STW non-moving; the slow path
+  does no marking/relocation/allocation, so it cannot recurse.
+  `--gc-poison` sets r14 to the BAD color, so every heap slot holds a
+  poisoned pointer, the slow path runs on every load, and any missed
+  barrier faults deterministically. Coverage is doubly guaranteed:
+  normal mode already faults on an unbarriered dereference (the good
+  color M0 is equally non-canonical), catching a missing fast-path
+  strip; poison catches a completely-missing barrier and exercises the
+  slow path on every load. The poison suite gates every later milestone.
 - **M6 — Incremental marking.** Phase machine, quanta, the two mark
   pauses (O(roots)), color alternation, allocate-black, worklist
   overflow degrading to logged STW. Pause metrics become real numbers.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,10 @@ pub struct ExecutionConfig {
     /// allocation (deterministic detector for pointers left unrooted
     /// across an allocation).
     pub gc_stress: bool,
+    /// `--gc-poison`: heap-stored pointers are colored BAD, so any
+    /// unbarriered dereference faults on a non-canonical address and the
+    /// load-barrier slow path runs on every load.
+    pub gc_poison: bool,
 }
 
 impl ExecutionConfig {
@@ -34,6 +38,7 @@ impl ExecutionConfig {
             explicit_target: false,
             gc_log: false,
             gc_stress: false,
+            gc_poison: false,
         }
     }
 }
@@ -87,6 +92,7 @@ pub fn parse_command_line(args: &[String]) -> Result<ParsedCommand, CommandLineE
     let mut explicit_target = false;
     let mut gc_log = false;
     let mut gc_stress = false;
+    let mut gc_poison = false;
     let mut others = Vec::new();
     let mut script_args = Vec::new();
     let mut seen_separator = false;
@@ -117,6 +123,10 @@ pub fn parse_command_line(args: &[String]) -> Result<ParsedCommand, CommandLineE
             }
             "--gc-stress" => {
                 gc_stress = true;
+                index += 1;
+            }
+            "--gc-poison" => {
+                gc_poison = true;
                 index += 1;
             }
             "--backend" => {
@@ -160,6 +170,7 @@ pub fn parse_command_line(args: &[String]) -> Result<ParsedCommand, CommandLineE
     config.explicit_target = explicit_target;
     config.gc_log = gc_log;
     config.gc_stress = gc_stress;
+    config.gc_poison = gc_poison;
     let action = match others.as_slice() {
         [command] if command == "targets" => RunAction::ListTargets,
         [flag] if flag == "--version" || flag == "-V" => RunAction::ShowVersion,
@@ -324,6 +335,20 @@ mod tests {
     }
 
     #[test]
+    fn parses_gc_poison_flag() {
+        let args = vec![
+            "--gc-poison".to_string(),
+            "build".to_string(),
+            "sample.kl".to_string(),
+            "-o".to_string(),
+            "sample".to_string(),
+        ];
+        let parsed = parse_command_line(&args).expect("build command should parse");
+        assert!(parsed.config.gc_poison);
+        assert!(matches!(parsed.action, RunAction::BuildFile { .. }));
+    }
+
+    #[test]
     fn gc_flags_default_off() {
         let args = vec![
             "build".to_string(),
@@ -334,6 +359,7 @@ mod tests {
         let parsed = parse_command_line(&args).expect("build command should parse");
         assert!(!parsed.config.gc_log);
         assert!(!parsed.config.gc_stress);
+        assert!(!parsed.config.gc_poison);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,7 @@ fn run(command: ParsedCommand) -> Result<(), u8> {
                 warn_trust: command.config.warn_trust,
                 gc_log: command.config.gc_log,
                 gc_stress: command.config.gc_stress,
+                gc_poison: command.config.gc_poison,
             };
             let user_modules = user_modules_for(&input, &text)?;
             let bytes = match compile_source_with_prelude_and_modules_for_target(

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -21029,6 +21029,64 @@ fn native_gc_stress_churn_does_not_leak_regions() {
     assert_eq!(stress, "750000\n");
 }
 
+/// M5: --gc-poison colors every heap-stored pointer with the BAD color,
+/// so the load-barrier slow path runs on every heap-pointer load (and
+/// any unbarriered dereference would fault on a non-canonical address).
+/// The barrier must be transparent: every program's output under poison
+/// must match a normal build. This is the barrier-coverage guarantee --
+/// a missing barrier would SIGSEGV here, not silently diverge. Exercises
+/// enum construction/read, match, deep-equal (==), and heap strings.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_gc_poison_is_transparent() {
+    // Enum churn + equality (deep-equal walker strips colored slots).
+    let churn = "enum Tree { case Leaf(v: Int); case Branch(l: Tree, r: Tree) }\n\
+         def same(a: Tree, b: Tree): Boolean = a == b\n\
+         mutable i = 0\n\
+         mutable ok = 0\n\
+         while (i < 20000) {\n\
+           if (same(Branch(Leaf(i), Leaf(i)), Branch(Leaf(i), Leaf(i)))) { ok = ok + 1 }\n\
+           i = i + 1\n\
+         }\n\
+         println(ok)\n";
+    let (plain, _e1) = build_and_run_gc_program(churn, &[]);
+    let (poison, _e2) = build_and_run_gc_program(churn, &["--gc-poison"]);
+    assert_eq!(plain, "20000\n");
+    assert_eq!(poison, plain, "poison must be transparent to output");
+
+    // Heap-string enum payloads with string-literal pattern matching.
+    let strings = "enum Tag { case Named(s: String); case Anon }\n\
+         def kind(t) = t match { case Named(\"x\") => 1; case Named(other) => 2; case Anon => 0 }\n\
+         println(kind(Named(\"x\")))\n\
+         println(kind(Named(\"y\")))\n\
+         println(kind(Anon))\n";
+    let (splain, _e3) = build_and_run_gc_program(strings, &[]);
+    let (spoison, _e4) = build_and_run_gc_program(strings, &["--gc-poison"]);
+    assert_eq!(splain, "1\n2\n0\n");
+    assert_eq!(spoison, splain);
+}
+
+/// M5: the most hostile configuration -- collect before every
+/// allocation (--gc-stress) AND poison every heap slot (--gc-poison).
+/// The collector's mark trace and deep-equal walker must strip colors
+/// off the slots they read, on top of the load barrier healing every
+/// mutator load. Output must still match a normal build.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_gc_stress_poison_combined_stays_correct() {
+    let program = "enum Tree { case Leaf(v: Int); case Branch(l: Tree, r: Tree) }\n\
+         def sz(t: Tree): Int = t match { case Leaf(v) => 1; case Branch(l, r) => sz(l) + sz(r) }\n\
+         mutable i = 0\n\
+         mutable acc = 0\n\
+         while (i < 15000) {\n\
+           acc = acc + sz(Branch(Leaf(i), Branch(Leaf(i), Leaf(i))))\n\
+           i = i + 1\n\
+         }\n\
+         println(acc)\n";
+    let (combined, _e) = build_and_run_gc_program(program, &["--gc-stress", "--gc-poison"]);
+    assert_eq!(combined, "45000\n"); // 15000 * 3
+}
+
 /// M4: an all-live per-frame allocation graph deeper than the initial
 /// 8-region (1 MiB) budget forces the allocator's stall path -- the
 /// collector frees nothing, so gc_grow_budget doubles the soft budget


### PR DESCRIPTION
## Summary

Milestone M5 of the ZGC plan (docs/zgc-plan.md) — the ZGC core. Heap-stored pointers carry a color in bits 60-62; every heap-pointer load goes through a load barrier that validates/strips the color. A colored pointer is **non-canonical**, so any unbarriered dereference faults — that is the barrier-coverage guarantee. Collections stay fully STW non-moving (incremental marking is M6, relocation is M7); M5 gets the color + barrier machinery correct under atomic STW so a missed barrier is caught before the collector ever moves an object.

- **Reserved registers** r13 = strip mask, r14 = good color, r15 = bad-color test mask, set once in the prologue. R13–R15 added to the `Reg` enum (encoders already handle codes 12–15); callee-saved, so they survive every syscall/shim and never reload in M5.
- **Color-on-store** at the single write funnel (`compile_gc_write`), gated on pointer type, with a **null guard** (a null slot stays raw 0).
- **Load barrier** at the single read funnel (`compile_gc_read_qword`, HeapPointer/HeapString only): save field addr, load, test color, slow-path stub on bad color (strip + recolor + self-heal store), strip to raw. Int/Double reads keep the plain load.
- **Walkers strip** colors off the slots they read (mark trace before `gc_mark_visit`; both deep-equal recursion loads). Roots and raw-bytes compares untouched.
- **`--gc-poison`** sets r14 to the BAD color, so every heap slot is poisoned, the slow path runs on every load, and any missed barrier faults deterministically.

## Coverage guarantee (doubly ensured)

Normal mode already faults on an unbarriered dereference (M0 is equally non-canonical), catching a missing fast-path strip; poison catches a completely-missing barrier and exercises the slow path every load. A manual negative test (removing the fast-path strip) SIGSEGVs the normal suite, proving the strip is load-bearing.

## Verification

- 697 tests green (694 + 3 new: poison-transparent, stress+poison combined, cli parse)
- All GC programs match the evaluator under normal, `--gc-stress`, `--gc-poison`, and `--gc-stress --gc-poison`
- Independent adversarial review in progress (reserved-register integrity, barrier coverage completeness, null handling, poison semantics)

### Coverage checklist (grep-audited)
- Heap-pointer LOAD → barrier: `compile_gc_read_qword` (funnel, gated). Verbatim colored copy (no barrier): `compile_gc_smap_keys_or_values`.
- Heap-pointer STORE → color: `compile_gc_write` (funnel, gated + null guard).
- GC-internal colored-slot derefs → strip: mark trace, both deep-equal loads. Root deref = raw (no strip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)