### PR TITLE
feat: C garbage collector (LLVM plan M6)

### DIFF
--- a/runtime/gc/gc_test.c
+++ b/runtime/gc/gc_test.c
@@ -17,13 +17,17 @@ static int64_t *make_leaf(int64_t v) {
     return p;
 }
 
-/* A pair record: two pointer fields. */
+/* A pair record: two pointer fields, stored through the write barrier so
+ * the slots carry the good color (as the codegen will emit). */
 static void **make_pair(void *a, void *b) {
     void **p = (void **)klassic_gc_alloc(16, KLASSIC_GC_POINTER_RECORD);
-    p[0] = a;
-    p[1] = b;
+    klassic_gc_write(&p[0], a);
+    klassic_gc_write(&p[1], b);
     return p;
 }
+
+/* Read a pointer field through the load barrier (strips the color). */
+static void *pair_field(void **p, int i) { return klassic_gc_read(&p[i]); }
 
 /* A cons cell: [int value][pointer to next]. Modeled as a pointer record
  * whose first field is a leaf (so it is traced uniformly). */
@@ -41,8 +45,8 @@ static void test_survivor_kept_and_intact(void) {
         (void)garbage; /* unrooted -> collectible */
     }
     klassic_gc_collect();
-    int64_t *a = (int64_t *)keeper[0];
-    int64_t *b = (int64_t *)keeper[1];
+    int64_t *a = (int64_t *)pair_field(keeper, 0);
+    int64_t *b = (int64_t *)pair_field(keeper, 1);
     assert(a[0] == 100 && b[0] == 23);
     assert(klassic_gc_collection_count() > 0);
     klassic_gc_shadow_pop_n(1);
@@ -66,8 +70,8 @@ static void test_linked_structure_survives_churn(void) {
     /* Walk the chain: values 499,498,...,0. Sum = 499*500/2 = 124750. */
     int64_t sum = 0;
     int count = 0;
-    for (void **node = list; node; node = (void **)node[1]) {
-        int64_t *value = (int64_t *)node[0];
+    for (void **node = list; node; node = (void **)pair_field(node, 1)) {
+        int64_t *value = (int64_t *)pair_field(node, 0);
         sum += value[0];
         count++;
     }
@@ -94,8 +98,28 @@ static void test_garbage_is_reclaimed(void) {
     printf("test_garbage_is_reclaimed OK (live_regions=%llu)\n", (unsigned long long)live);
 }
 
+/* The load barrier strips a color and heals a bad-colored slot. */
+static void test_load_barrier_strips_and_heals(void) {
+    void **cell = (void **)klassic_gc_alloc(8, KLASSIC_GC_POINTER_RECORD);
+    int64_t *target = make_leaf(777);
+    /* Simulate a stale bad-colored slot (as if left by a previous cycle):
+     * store the raw target OR'd with a bad color directly. */
+    extern uint64_t gc_bad_mask;
+    cell[0] = (void *)((uint64_t)target | (gc_bad_mask & (7ull << 60)));
+    /* A barriered read must return the raw pointer and heal the slot. */
+    void *got = klassic_gc_read(&cell[0]);
+    assert(got == (void *)target);
+    /* After healing, the slot is good-colored -> a second read fast-paths
+     * to the same raw pointer. */
+    void *again = klassic_gc_read(&cell[0]);
+    assert(again == (void *)target);
+    assert(((int64_t *)got)[0] == 777);
+    printf("test_load_barrier_strips_and_heals OK\n");
+}
+
 int main(void) {
     klassic_gc_init();
+    test_load_barrier_strips_and_heals();
     test_survivor_kept_and_intact();
     test_linked_structure_survives_churn();
     test_garbage_is_reclaimed();

--- a/runtime/gc/gc_test.c
+++ b/runtime/gc/gc_test.c
@@ -3,6 +3,16 @@
  * are the payoff of moving the GC to C: the collector is exercised on
  * synthetic heaps + roots with a memory sanitizer catching any
  * use-after-free or out-of-bounds the asm version could never surface.
+ *
+ * A precise incremental/moving collector requires the mutator to root
+ * every live heap pointer across an allocation (a "safepoint"), because a
+ * proactive collection can fire inside any alloc. These helpers therefore
+ * stage each intermediate value in a rooted shadow-stack slot before the
+ * next allocation -- exactly the discipline the code generator must
+ * follow (the asm backend's argument staging, M3b). Skipping it is a
+ * mutator bug, not a collector bug: an unrooted temporary allocated
+ * before a MarkStart is unmarked, and storing it into a survivor leaves a
+ * dangling field.
  */
 #include "klassic_gc.h"
 
@@ -10,15 +20,17 @@
 #include <stdint.h>
 #include <stdio.h>
 
-/* A leaf: raw bytes holding one int64. */
+/* A leaf: raw bytes holding one int64. The caller must root the result
+ * before its next allocation. */
 static int64_t *make_leaf(int64_t v) {
     int64_t *p = (int64_t *)klassic_gc_alloc(8, KLASSIC_GC_RAW_BYTES);
     p[0] = v;
     return p;
 }
 
-/* A pair record: two pointer fields, stored through the write barrier so
- * the slots carry the good color (as the codegen will emit). */
+/* A pair record with two pointer fields. `a` and `b` must already be live
+ * in the caller's rooted slots (they must survive this allocation);
+ * stored through the write barrier so the slots carry the good color. */
 static void **make_pair(void *a, void *b) {
     void **p = (void **)klassic_gc_alloc(16, KLASSIC_GC_POINTER_RECORD);
     klassic_gc_write(&p[0], a);
@@ -29,19 +41,56 @@ static void **make_pair(void *a, void *b) {
 /* Read a pointer field through the load barrier (strips the color). */
 static void *pair_field(void **p, int i) { return klassic_gc_read(&p[i]); }
 
-/* A cons cell: [int value][pointer to next]. Modeled as a pointer record
- * whose first field is a leaf (so it is traced uniformly). */
-static void **cons(int64_t head, void **tail) {
-    return make_pair(make_leaf(head), tail);
+/* Build a pair of two fresh int leaves, staging each intermediate in a
+ * rooted slot so a collection mid-construction cannot strand it. */
+static void **pair_of_leaves(int64_t av, int64_t bv) {
+    void *a = 0, *b = 0;
+    klassic_gc_shadow_push(&a);
+    klassic_gc_shadow_push(&b);
+    a = make_leaf(av); /* a rooted; survives b's allocation */
+    b = make_leaf(bv); /* b rooted; a still rooted */
+    void **p = make_pair(a, b);
+    klassic_gc_shadow_pop_n(2);
+    return p;
 }
 
-/* A rooted survivor is kept, and its whole reachable graph, while
- * unrooted garbage churned around it is reclaimed. */
+/* A cons cell [leaf(head)][tail]. `tail` must be live in the caller's
+ * rooted slot; the fresh head leaf is staged in a rooted slot here. */
+static void **cons(int64_t head, void **tail) {
+    void *leaf = 0;
+    klassic_gc_shadow_push(&leaf);
+    leaf = make_leaf(head);
+    void **p = make_pair(leaf, tail);
+    klassic_gc_shadow_pop_n(1);
+    return p;
+}
+
+/* The load barrier strips a color and heals a bad-colored slot. */
+static void test_load_barrier_strips_and_heals(void) {
+    void *target = 0;
+    klassic_gc_shadow_push(&target);
+    target = make_leaf(777);
+    void **cell = (void **)klassic_gc_alloc(16, KLASSIC_GC_POINTER_RECORD);
+    /* Simulate a stale bad-colored slot (as a previous cycle would leave):
+     * store the raw target OR'd with a bad color directly. */
+    cell[0] = (void *)((uint64_t)target | (gc_bad_mask & (7ull << 60)));
+    cell[1] = 0;
+    void *got = klassic_gc_read(&cell[0]); /* must strip + heal */
+    assert(got == target);
+    void *again = klassic_gc_read(&cell[0]); /* now good-colored -> fast */
+    assert(again == target);
+    assert(((int64_t *)got)[0] == 777);
+    klassic_gc_shadow_pop_n(1);
+    printf("test_load_barrier_strips_and_heals OK\n");
+}
+
+/* A rooted survivor and its whole graph are kept while unrooted garbage
+ * churned around it is reclaimed. */
 static void test_survivor_kept_and_intact(void) {
-    void **keeper = make_pair(make_leaf(100), make_leaf(23));
+    void **keeper = pair_of_leaves(100, 23);
     klassic_gc_shadow_push((void **)&keeper);
     for (int i = 0; i < 200000; i++) {
-        void **garbage = make_pair(make_leaf(i), make_leaf(i));
+        void **garbage = pair_of_leaves(i, i);
         (void)garbage; /* unrooted -> collectible */
     }
     klassic_gc_collect();
@@ -60,14 +109,13 @@ static void test_linked_structure_survives_churn(void) {
     void **list = 0;
     klassic_gc_shadow_push((void **)&list);
     for (int i = 0; i < 500; i++) {
-        list = cons(i, list); /* prepend; the whole chain stays rooted via `list` */
+        list = cons(i, list); /* whole chain stays rooted via `list` */
     }
     for (int i = 0; i < 200000; i++) {
-        void **garbage = make_pair(make_leaf(i), make_leaf(i));
+        void **garbage = pair_of_leaves(i, i);
         (void)garbage;
     }
     klassic_gc_collect();
-    /* Walk the chain: values 499,498,...,0. Sum = 499*500/2 = 124750. */
     int64_t sum = 0;
     int count = 0;
     for (void **node = list; node; node = (void **)pair_field(node, 1)) {
@@ -76,56 +124,20 @@ static void test_linked_structure_survives_churn(void) {
         count++;
     }
     assert(count == 500);
-    assert(sum == 124750);
+    assert(sum == 124750); /* 0+1+...+499 */
     klassic_gc_shadow_pop_n(1);
     printf("test_linked_structure_survives_churn OK (nodes=%d sum=%lld)\n", count,
            (long long)sum);
 }
 
-/* Pure garbage is reclaimed: the live-region count stays bounded across a
- * churn far larger than the heap. */
-static void test_garbage_is_reclaimed(void) {
-    for (int i = 0; i < 400000; i++) {
-        void **garbage = make_pair(make_leaf(i), make_leaf(i));
-        (void)garbage;
-    }
-    klassic_gc_collect();
-    uint64_t live = klassic_gc_live_region_count();
-    /* Nothing is rooted here, so after a collection only the current bump
-     * region (and maybe a straggler) remains live -- certainly not the
-     * hundreds of regions the churn would need without reclamation. */
-    assert(live <= 4);
-    printf("test_garbage_is_reclaimed OK (live_regions=%llu)\n", (unsigned long long)live);
-}
-
-/* The load barrier strips a color and heals a bad-colored slot. */
-static void test_load_barrier_strips_and_heals(void) {
-    void **cell = (void **)klassic_gc_alloc(8, KLASSIC_GC_POINTER_RECORD);
-    int64_t *target = make_leaf(777);
-    /* Simulate a stale bad-colored slot (as if left by a previous cycle):
-     * store the raw target OR'd with a bad color directly. */
-    extern uint64_t gc_bad_mask;
-    cell[0] = (void *)((uint64_t)target | (gc_bad_mask & (7ull << 60)));
-    /* A barriered read must return the raw pointer and heal the slot. */
-    void *got = klassic_gc_read(&cell[0]);
-    assert(got == (void *)target);
-    /* After healing, the slot is good-colored -> a second read fast-paths
-     * to the same raw pointer. */
-    void *again = klassic_gc_read(&cell[0]);
-    assert(again == (void *)target);
-    assert(((int64_t *)got)[0] == 777);
-    printf("test_load_barrier_strips_and_heals OK\n");
-}
-
 /* The proactive incremental driver keeps a rooted survivor intact across
- * many cycles WITHOUT any explicit collection -- exercising allocate-
- * black, the Mark-phase barrier, and recolor-on-trace across color flips. */
+ * many cycles WITHOUT any explicit collection. */
 static void test_incremental_driver_keeps_survivor(void) {
-    void **keeper = make_pair(make_leaf(555), make_leaf(444));
+    void **keeper = pair_of_leaves(555, 444);
     klassic_gc_shadow_push((void **)&keeper);
     uint64_t before = klassic_gc_collection_count();
     for (int i = 0; i < 400000; i++) {
-        void **garbage = make_pair(make_leaf(i), make_leaf(i));
+        void **garbage = pair_of_leaves(i, i);
         (void)garbage;
     }
     assert(klassic_gc_collection_count() > before); /* cycles ran on their own */
@@ -134,6 +146,18 @@ static void test_incremental_driver_keeps_survivor(void) {
     klassic_gc_shadow_pop_n(1);
     printf("test_incremental_driver_keeps_survivor OK (cycles=%llu)\n",
            (unsigned long long)(klassic_gc_collection_count() - before));
+}
+
+/* Pure garbage is reclaimed: the live-region count stays bounded. */
+static void test_garbage_is_reclaimed(void) {
+    for (int i = 0; i < 400000; i++) {
+        void **garbage = pair_of_leaves(i, i);
+        (void)garbage;
+    }
+    klassic_gc_collect();
+    uint64_t live = klassic_gc_live_region_count();
+    assert(live <= 4);
+    printf("test_garbage_is_reclaimed OK (live_regions=%llu)\n", (unsigned long long)live);
 }
 
 int main(void) {

--- a/runtime/gc/gc_test.c
+++ b/runtime/gc/gc_test.c
@@ -1,0 +1,104 @@
+/* gc_test.c -- standalone unit tests for the C garbage collector,
+ * compiled with -fsanitize=address,undefined (see run_tests.sh). These
+ * are the payoff of moving the GC to C: the collector is exercised on
+ * synthetic heaps + roots with a memory sanitizer catching any
+ * use-after-free or out-of-bounds the asm version could never surface.
+ */
+#include "klassic_gc.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+/* A leaf: raw bytes holding one int64. */
+static int64_t *make_leaf(int64_t v) {
+    int64_t *p = (int64_t *)klassic_gc_alloc(8, KLASSIC_GC_RAW_BYTES);
+    p[0] = v;
+    return p;
+}
+
+/* A pair record: two pointer fields. */
+static void **make_pair(void *a, void *b) {
+    void **p = (void **)klassic_gc_alloc(16, KLASSIC_GC_POINTER_RECORD);
+    p[0] = a;
+    p[1] = b;
+    return p;
+}
+
+/* A cons cell: [int value][pointer to next]. Modeled as a pointer record
+ * whose first field is a leaf (so it is traced uniformly). */
+static void **cons(int64_t head, void **tail) {
+    return make_pair(make_leaf(head), tail);
+}
+
+/* A rooted survivor is kept, and its whole reachable graph, while
+ * unrooted garbage churned around it is reclaimed. */
+static void test_survivor_kept_and_intact(void) {
+    void **keeper = make_pair(make_leaf(100), make_leaf(23));
+    klassic_gc_shadow_push((void **)&keeper);
+    for (int i = 0; i < 200000; i++) {
+        void **garbage = make_pair(make_leaf(i), make_leaf(i));
+        (void)garbage; /* unrooted -> collectible */
+    }
+    klassic_gc_collect();
+    int64_t *a = (int64_t *)keeper[0];
+    int64_t *b = (int64_t *)keeper[1];
+    assert(a[0] == 100 && b[0] == 23);
+    assert(klassic_gc_collection_count() > 0);
+    klassic_gc_shadow_pop_n(1);
+    printf("test_survivor_kept_and_intact OK (collections=%llu)\n",
+           (unsigned long long)klassic_gc_collection_count());
+}
+
+/* A long-lived linked structure survives many collections with its whole
+ * chain intact. */
+static void test_linked_structure_survives_churn(void) {
+    void **list = 0;
+    klassic_gc_shadow_push((void **)&list);
+    for (int i = 0; i < 500; i++) {
+        list = cons(i, list); /* prepend; the whole chain stays rooted via `list` */
+    }
+    for (int i = 0; i < 200000; i++) {
+        void **garbage = make_pair(make_leaf(i), make_leaf(i));
+        (void)garbage;
+    }
+    klassic_gc_collect();
+    /* Walk the chain: values 499,498,...,0. Sum = 499*500/2 = 124750. */
+    int64_t sum = 0;
+    int count = 0;
+    for (void **node = list; node; node = (void **)node[1]) {
+        int64_t *value = (int64_t *)node[0];
+        sum += value[0];
+        count++;
+    }
+    assert(count == 500);
+    assert(sum == 124750);
+    klassic_gc_shadow_pop_n(1);
+    printf("test_linked_structure_survives_churn OK (nodes=%d sum=%lld)\n", count,
+           (long long)sum);
+}
+
+/* Pure garbage is reclaimed: the live-region count stays bounded across a
+ * churn far larger than the heap. */
+static void test_garbage_is_reclaimed(void) {
+    for (int i = 0; i < 400000; i++) {
+        void **garbage = make_pair(make_leaf(i), make_leaf(i));
+        (void)garbage;
+    }
+    klassic_gc_collect();
+    uint64_t live = klassic_gc_live_region_count();
+    /* Nothing is rooted here, so after a collection only the current bump
+     * region (and maybe a straggler) remains live -- certainly not the
+     * hundreds of regions the churn would need without reclamation. */
+    assert(live <= 4);
+    printf("test_garbage_is_reclaimed OK (live_regions=%llu)\n", (unsigned long long)live);
+}
+
+int main(void) {
+    klassic_gc_init();
+    test_survivor_kept_and_intact();
+    test_linked_structure_survives_churn();
+    test_garbage_is_reclaimed();
+    printf("ALL GC TESTS PASSED\n");
+    return 0;
+}

--- a/runtime/gc/gc_test.c
+++ b/runtime/gc/gc_test.c
@@ -160,6 +160,58 @@ static void test_garbage_is_reclaimed(void) {
     printf("test_garbage_is_reclaimed OK (live_regions=%llu)\n", (unsigned long long)live);
 }
 
+/* Compaction physically moves a rooted survivor: its address changes,
+ * yet its payload and the root that points at it stay consistent. */
+static void test_survivor_is_relocated_and_intact(void) {
+    void **keeper = pair_of_leaves(314, 271);
+    klassic_gc_shadow_push((void **)&keeper);
+    void *before = (void *)keeper;
+    uint64_t relocs_before = klassic_gc_relocation_count();
+    for (int i = 0; i < 300000; i++) {
+        void **garbage = pair_of_leaves(i, i);
+        (void)garbage;
+    }
+    klassic_gc_collect();
+    /* Objects were physically evacuated, and the rooted survivor is one of
+     * them (its sparse region is a relocation target). */
+    assert(klassic_gc_relocation_count() > relocs_before);
+    assert((void *)keeper != before); /* the root was updated to to-space */
+    /* Payload survived the copy; the leaves moved too but read back intact. */
+    assert(((int64_t *)pair_field(keeper, 0))[0] == 314);
+    assert(((int64_t *)pair_field(keeper, 1))[0] == 271);
+    klassic_gc_shadow_pop_n(1);
+    printf("test_survivor_is_relocated_and_intact OK (relocs=%llu)\n",
+           (unsigned long long)(klassic_gc_relocation_count() - relocs_before));
+}
+
+/* A linked structure stays fully connected across compaction: every node
+ * and edge is rewritten to the moved locations with no dangling pointer. */
+static void test_linked_structure_survives_compaction(void) {
+    void **list = 0;
+    klassic_gc_shadow_push((void **)&list);
+    for (int i = 0; i < 300; i++) {
+        list = cons(i, list);
+    }
+    uint64_t relocs_before = klassic_gc_relocation_count();
+    for (int i = 0; i < 300000; i++) {
+        void **garbage = pair_of_leaves(i, i);
+        (void)garbage;
+    }
+    klassic_gc_collect();
+    assert(klassic_gc_relocation_count() > relocs_before);
+    int64_t sum = 0;
+    int count = 0;
+    for (void **node = list; node; node = (void **)pair_field(node, 1)) {
+        sum += ((int64_t *)pair_field(node, 0))[0];
+        count++;
+    }
+    assert(count == 300);
+    assert(sum == 44850); /* 0+1+...+299 */
+    klassic_gc_shadow_pop_n(1);
+    printf("test_linked_structure_survives_compaction OK (nodes=%d sum=%lld)\n", count,
+           (long long)sum);
+}
+
 int main(void) {
     klassic_gc_init();
     test_load_barrier_strips_and_heals();
@@ -167,6 +219,8 @@ int main(void) {
     test_survivor_kept_and_intact();
     test_linked_structure_survives_churn();
     test_garbage_is_reclaimed();
+    test_survivor_is_relocated_and_intact();
+    test_linked_structure_survives_compaction();
     printf("ALL GC TESTS PASSED\n");
     return 0;
 }

--- a/runtime/gc/gc_test.c
+++ b/runtime/gc/gc_test.c
@@ -117,9 +117,29 @@ static void test_load_barrier_strips_and_heals(void) {
     printf("test_load_barrier_strips_and_heals OK\n");
 }
 
+/* The proactive incremental driver keeps a rooted survivor intact across
+ * many cycles WITHOUT any explicit collection -- exercising allocate-
+ * black, the Mark-phase barrier, and recolor-on-trace across color flips. */
+static void test_incremental_driver_keeps_survivor(void) {
+    void **keeper = make_pair(make_leaf(555), make_leaf(444));
+    klassic_gc_shadow_push((void **)&keeper);
+    uint64_t before = klassic_gc_collection_count();
+    for (int i = 0; i < 400000; i++) {
+        void **garbage = make_pair(make_leaf(i), make_leaf(i));
+        (void)garbage;
+    }
+    assert(klassic_gc_collection_count() > before); /* cycles ran on their own */
+    assert(((int64_t *)pair_field(keeper, 0))[0] == 555);
+    assert(((int64_t *)pair_field(keeper, 1))[0] == 444);
+    klassic_gc_shadow_pop_n(1);
+    printf("test_incremental_driver_keeps_survivor OK (cycles=%llu)\n",
+           (unsigned long long)(klassic_gc_collection_count() - before));
+}
+
 int main(void) {
     klassic_gc_init();
     test_load_barrier_strips_and_heals();
+    test_incremental_driver_keeps_survivor();
     test_survivor_kept_and_intact();
     test_linked_structure_survives_churn();
     test_garbage_is_reclaimed();

--- a/runtime/gc/klassic_gc.c
+++ b/runtime/gc/klassic_gc.c
@@ -440,23 +440,27 @@ static void gc_relocate(void) {
     if (free_regions <= 1) {
         return; /* no room for a to-space -> mark-only cycle */
     }
-    uint64_t budget_left = (free_regions - 1) * REGION_SIZE;
-
-    /* Select the relocation set: non-current, non-empty regions that are
-     * less than half full, capped by the headroom budget. */
+    /* Select the relocation set: non-current, non-empty regions less than
+     * half full. A region under half live packs (blocks are then each
+     * under half a region, so >=50% dense) into at most one to-space
+     * region, so capping the count at free_regions - 1 keeps a headroom
+     * region and makes to-space exhaustion impossible. */
+    uint64_t max_from = free_regions - 1;
     uint64_t selected = 0;
     for (uint64_t idx = 0; idx < g_committed; idx++) {
         g_from_set[idx] = 0;
+        if (selected >= max_from) {
+            continue; /* keep clearing the rest of the set */
+        }
         uint8_t *base = region_at(idx);
         if (base == g_heap_base) {
             continue;
         }
         uint64_t live = g_region_live[idx];
-        if (live == 0 || live * 2 >= REGION_SIZE || live > budget_left) {
+        if (live == 0 || live * 2 >= REGION_SIZE) {
             continue;
         }
         g_from_set[idx] = 1;
-        budget_left -= live;
         selected++;
     }
     if (selected == 0) {

--- a/runtime/gc/klassic_gc.c
+++ b/runtime/gc/klassic_gc.c
@@ -365,6 +365,10 @@ static int to_acquire(void) {
     g_to_top = base;
     g_to_end = base + REGION_SIZE;
     g_region_top[region_index(base)] = (uint64_t)(uintptr_t)base;
+    /* A to-space region is a survivor destination, never from-space: mark it
+     * so the fixup walk visits it and the free walk spares it, even for a
+     * tail region committed after the selection loop already ran. */
+    g_from_set[region_index(base)] = 0;
     return 1;
 }
 

--- a/runtime/gc/klassic_gc.c
+++ b/runtime/gc/klassic_gc.c
@@ -47,6 +47,19 @@ static uint64_t g_collections;
 
 static int g_initialized;
 
+/* --- Colored pointers -------------------------------------------- */
+#define GC_COLOR_M0 (1ull << 60)
+#define GC_COLOR_M1 (1ull << 61)
+#define GC_COLOR_R (1ull << 62)
+#define GC_COLOR_MASK (7ull << 60)
+
+/* Mask cells (dso_local: defined here, referenced by the emitted fast
+ * path). good = M0, bad catches the other colors; strip clears the color
+ * bits. The moving milestone flips these; here they are static. */
+uint64_t gc_good_color = GC_COLOR_M0;
+uint64_t gc_bad_mask = GC_COLOR_M1 | GC_COLOR_R;
+uint64_t gc_strip_mask = ~GC_COLOR_MASK;
+
 static uint64_t align16(uint64_t n) { return (n + 15u) & ~(uint64_t)15u; }
 static uint64_t block_size(uint64_t word0) { return word0 & ~(uint64_t)15u; }
 
@@ -161,8 +174,33 @@ void klassic_gc_shadow_pop_n(uint64_t count) {
     g_shadow_top -= count;
 }
 
+uint64_t klassic_gc_load_barrier_slow(uint64_t value, void **slot) {
+    uint64_t raw = value & gc_strip_mask;
+    /* Self-heal: store the good-colored pointer back so later barriered
+     * loads of this slot take the fast path. (The moving milestone will
+     * remap here first.) A plain store -- single mutator. */
+    if (raw) {
+        *slot = (void *)(raw | gc_good_color);
+    }
+    return raw;
+}
+
+void *klassic_gc_read(void **slot) {
+    uint64_t value = (uint64_t)*slot;
+    if (value & gc_bad_mask) {
+        return (void *)klassic_gc_load_barrier_slow(value, slot);
+    }
+    return (void *)(value & gc_strip_mask);
+}
+
+void klassic_gc_write(void **slot, void *value) {
+    uint64_t raw = (uint64_t)value;
+    *slot = raw ? (void *)(raw | gc_good_color) : NULL;
+}
+
 /* Mark `user` if unmarked this cycle, pushing it for tracing. */
 static void mark_visit(void *user) {
+    user = (void *)((uint64_t)user & gc_strip_mask); /* defensive: raw */
     if (!user) {
         return;
     }
@@ -192,7 +230,13 @@ static void trace(void) {
         uint64_t slots = payload / 8;
         uint64_t start = (tag == KLASSIC_GC_POINTER_LIST) ? 1 : 0; /* skip length */
         for (uint64_t i = start; i < slots; i++) {
-            mark_visit(fields[i]);
+            uint64_t raw = (uint64_t)fields[i] & gc_strip_mask;
+            if (raw) {
+                /* Recolor-on-trace: rewrite the field to the good color so
+                 * a later barriered load fast-paths. */
+                fields[i] = (void *)(raw | gc_good_color);
+                mark_visit((void *)raw);
+            }
         }
     }
 }

--- a/runtime/gc/klassic_gc.c
+++ b/runtime/gc/klassic_gc.c
@@ -1,8 +1,7 @@
-/* klassic_gc.c -- non-moving region mark-sweep foundation (ZGC plan M4
- * equivalent), in C. See klassic_gc.h for the object layout and the
- * migration context. Colored pointers + load barrier, incremental
- * marking, and moving evacuation land in later commits; this file is the
- * base they build on.
+/* klassic_gc.c -- ZGC-style region collector in C: colored pointers + load
+ * barrier, incremental marking, and stop-the-world compacting evacuation
+ * with in-object forwarding. See klassic_gc.h for the object layout and
+ * the migration context.
  */
 #define _DEFAULT_SOURCE /* for MAP_ANONYMOUS under -std=c11 */
 
@@ -29,11 +28,20 @@ static uint64_t g_region_top[RESERVE_REGIONS]; /* per-region bump watermark */
 static uint64_t g_committed;                   /* high-water committed regions */
 static uint64_t g_budget = 8;                  /* soft budget, doubles on stall */
 static uint8_t *g_free_head;                    /* free-region pool, linked via base qword */
+static uint64_t g_region_live[RESERVE_REGIONS]; /* live bytes per region (set by sweep) */
+static uint8_t g_from_set[RESERVE_REGIONS];     /* 1 if region is in the relocation set */
 
 /* The current bump region. */
 static uint8_t *g_heap_base;
 static uint8_t *g_heap_top;
 static uint8_t *g_heap_end;
+
+/* A dedicated to-space bump for evacuation, separate from the mutator's
+ * current region so compaction never disturbs in-progress allocation. */
+static uint8_t *g_to_base;
+static uint8_t *g_to_top;
+static uint8_t *g_to_end;
+static uint64_t g_relocations; /* objects evacuated (observability) */
 
 /* Precise roots and the mark worklist. */
 static void **g_shadow[SHADOW_MAX];
@@ -296,24 +304,223 @@ static void gc_sweep(void) {
     for (uint64_t idx = 0; idx < g_committed; idx++) {
         uint8_t *base = region_at(idx);
         uint8_t *top = (uint8_t *)(uintptr_t)g_region_top[idx];
+        g_region_live[idx] = 0;
         if (top == base) {
             continue;
         }
         int any_live = 0;
+        uint64_t live = 0;
         for (uint8_t *cur = base; cur < top;) {
             uint64_t *b = (uint64_t *)cur;
             uint64_t sz = block_size(b[0]);
             if (b[0] & g_header_mark) {
                 b[0] &= stale_clear;
                 any_live = 1;
+                live += sz;
             }
             cur += sz;
         }
+        g_region_live[idx] = live;
         if (!any_live && base != g_heap_base) {
             *(uint8_t **)base = g_free_head;
             g_free_head = base;
             g_region_top[idx] = (uint64_t)(uintptr_t)base;
+            g_region_live[idx] = 0;
         }
+    }
+}
+
+/* --- Stop-the-world compacting evacuation (moving GC) ------------ *
+ * Called at MarkEnd after sweep, so marking is complete (live == marked)
+ * and -- being a safepoint reached from gc_alloc/collect -- no mutator
+ * pointer is live in a register outside the shadow stack. Sparse regions
+ * are evacuated into a fresh to-space, each vacated object left with an
+ * in-object forwarding word (word0 = new_user | FWD), then every root and
+ * live heap field is rewritten to the new location and the from-space
+ * regions are freed. The mutator's colored-pointer model is unchanged;
+ * lazy/concurrent relocation via the R-color barrier is a later
+ * refinement (see docs/zgc-plan.md). */
+
+/* Acquire a fresh zeroed region for the to-space bump (free pool first,
+ * then a committed tail region), without disturbing the mutator's current
+ * region. Returns 0 if none available. */
+static int to_acquire(void) {
+    uint8_t *base;
+    if (g_free_head) {
+        base = g_free_head;
+        g_free_head = *(uint8_t **)base;
+        memset(base, 0, REGION_SIZE);
+    } else if (g_committed < g_budget) {
+        base = region_at(g_committed);
+        g_committed++;
+    } else {
+        return 0;
+    }
+    g_to_base = base;
+    g_to_top = base;
+    g_to_end = base + REGION_SIZE;
+    g_region_top[region_index(base)] = (uint64_t)(uintptr_t)base;
+    return 1;
+}
+
+/* Bump `total` bytes in to-space, switching to a fresh region when the
+ * current one cannot fit the block. Returns NULL if to-space is exhausted
+ * (the headroom invariant makes this unreachable in practice). */
+static uint8_t *to_bump(uint64_t total) {
+    if (!g_to_base || (uint64_t)(g_to_end - g_to_top) < total) {
+        if (g_to_base) {
+            g_region_top[region_index(g_to_base)] = (uint64_t)(uintptr_t)g_to_top;
+        }
+        if (!to_acquire()) {
+            return NULL;
+        }
+    }
+    uint8_t *dst = g_to_top;
+    g_to_top += total;
+    return dst;
+}
+
+/* Rewrite one colored heap-pointer slot to follow forwarding, if its
+ * target has been evacuated. */
+static void fixup_field(void **slot) {
+    uint64_t raw = (uint64_t)*slot & gc_strip_mask;
+    if (!raw) {
+        return;
+    }
+    uint64_t w0 = *(uint64_t *)(raw - 16);
+    if (w0 & KLASSIC_GC_FWD) {
+        uint64_t nw = w0 & ~(uint64_t)15u; /* new user pointer (16-aligned) */
+        *slot = (void *)(nw | gc_good_color);
+    }
+}
+
+/* Rewrite a raw root slot to follow forwarding (roots hold raw pointers). */
+static void fixup_root(void **slot) {
+    uint64_t raw = (uint64_t)*slot;
+    if (!raw) {
+        return;
+    }
+    uint64_t w0 = *(uint64_t *)(raw - 16);
+    if (w0 & KLASSIC_GC_FWD) {
+        *slot = (void *)(w0 & ~(uint64_t)15u);
+    }
+}
+
+/* Rewrite the pointer fields of every live block in a kept region. */
+static void fixup_region(uint8_t *base, uint8_t *top) {
+    for (uint8_t *cur = base; cur < top;) {
+        uint64_t *b = (uint64_t *)cur;
+        uint64_t sz = block_size(b[0]);
+        if (b[0] & g_header_mark) {
+            uint64_t tag = b[1];
+            if (tag >= KLASSIC_GC_POINTER_RECORD) {
+                void **fields = (void **)(cur + 16);
+                uint64_t slots = (sz - 16) / 8;
+                uint64_t start = (tag == KLASSIC_GC_POINTER_LIST) ? 1 : 0;
+                for (uint64_t k = start; k < slots; k++) {
+                    fixup_field(&fields[k]);
+                }
+            }
+        }
+        cur += sz;
+    }
+}
+
+static void gc_relocate(void) {
+    /* Free capacity, in regions: the free pool plus the still-uncommitted
+     * budget tail. Reserve one region of headroom so evacuation (which
+     * wastes at most a partial region to fragmentation) cannot deadlock. */
+    uint64_t free_regions = 0;
+    for (uint8_t *p = g_free_head; p; p = *(uint8_t **)p) {
+        free_regions++;
+    }
+    if (g_committed < g_budget) {
+        free_regions += g_budget - g_committed;
+    }
+    if (free_regions <= 1) {
+        return; /* no room for a to-space -> mark-only cycle */
+    }
+    uint64_t budget_left = (free_regions - 1) * REGION_SIZE;
+
+    /* Select the relocation set: non-current, non-empty regions that are
+     * less than half full, capped by the headroom budget. */
+    uint64_t selected = 0;
+    for (uint64_t idx = 0; idx < g_committed; idx++) {
+        g_from_set[idx] = 0;
+        uint8_t *base = region_at(idx);
+        if (base == g_heap_base) {
+            continue;
+        }
+        uint64_t live = g_region_live[idx];
+        if (live == 0 || live * 2 >= REGION_SIZE || live > budget_left) {
+            continue;
+        }
+        g_from_set[idx] = 1;
+        budget_left -= live;
+        selected++;
+    }
+    if (selected == 0) {
+        return;
+    }
+
+    /* Evacuate: copy each live block into to-space, then overwrite its old
+     * header word0 with the forwarding pointer. Size is read before the
+     * overwrite, so the linear walk stays valid. */
+    g_to_base = g_to_top = g_to_end = NULL;
+    for (uint64_t idx = 0; idx < g_committed; idx++) {
+        if (!g_from_set[idx]) {
+            continue;
+        }
+        uint8_t *base = region_at(idx);
+        uint8_t *top = (uint8_t *)(uintptr_t)g_region_top[idx];
+        for (uint8_t *cur = base; cur < top;) {
+            uint64_t *b = (uint64_t *)cur;
+            uint64_t sz = block_size(b[0]);
+            if (b[0] & g_header_mark) {
+                uint8_t *dst = to_bump(sz);
+                if (!dst) {
+                    fprintf(stderr, "klassic gc: evacuation overran to-space\n");
+                    exit(1);
+                }
+                memcpy(dst, cur, sz);
+                b[0] = (uint64_t)(uintptr_t)(dst + 16) | KLASSIC_GC_FWD;
+                g_relocations++;
+            }
+            cur += sz;
+        }
+    }
+    if (g_to_base) {
+        g_region_top[region_index(g_to_base)] = (uint64_t)(uintptr_t)g_to_top;
+    }
+
+    /* Fix every reference to a moved object: roots, then the live fields of
+     * every kept region (the from-space regions are about to be freed, so
+     * their -- now stale -- contents are skipped). */
+    for (uint64_t i = 0; i < g_shadow_top; i++) {
+        fixup_root(g_shadow[i]);
+    }
+    for (uint64_t idx = 0; idx < g_committed; idx++) {
+        if (g_from_set[idx]) {
+            continue;
+        }
+        uint8_t *base = region_at(idx);
+        uint8_t *top = (uint8_t *)(uintptr_t)g_region_top[idx];
+        if (top == base) {
+            continue;
+        }
+        fixup_region(base, top);
+    }
+
+    /* Free the vacated (now fully forwarded) from-space regions. */
+    for (uint64_t idx = 0; idx < g_committed; idx++) {
+        if (!g_from_set[idx]) {
+            continue;
+        }
+        uint8_t *base = region_at(idx);
+        *(uint8_t **)base = g_free_head;
+        g_free_head = base;
+        g_region_top[idx] = (uint64_t)(uintptr_t)base;
+        g_region_live[idx] = 0;
     }
 }
 
@@ -331,10 +538,12 @@ static void gc_mark_start(void) {
     g_phase = GC_PHASE_MARK;
 }
 
-/* MarkEnd: drain the frontier to fixpoint, sweep, return to Idle. */
+/* MarkEnd: drain the frontier to fixpoint, sweep, compact sparse regions,
+ * return to Idle. */
 static void gc_mark_end(void) {
     gc_drain();
     gc_sweep();
+    gc_relocate();
     g_phase = GC_PHASE_IDLE;
     g_bytes_since_cycle = 0;
 }
@@ -374,6 +583,7 @@ static void gc_driver(uint64_t total) {
 }
 
 uint64_t klassic_gc_collection_count(void) { return g_collections; }
+uint64_t klassic_gc_relocation_count(void) { return g_relocations; }
 
 uint64_t klassic_gc_live_region_count(void) {
     uint64_t live = 0;

--- a/runtime/gc/klassic_gc.c
+++ b/runtime/gc/klassic_gc.c
@@ -45,6 +45,15 @@ static uint64_t g_worklist_top;
 static uint64_t g_header_mark = KLASSIC_GC_HMARK1;
 static uint64_t g_collections;
 
+/* --- Incremental phase machine ----------------------------------- */
+#define GC_PHASE_IDLE 0
+#define GC_PHASE_MARK 1
+#define GC_QUANTUM_POPS 512   /* objects traced per mark quantum */
+#define GC_QUANTUM_BYTES 8192 /* allocation between mark quanta */
+static uint64_t g_phase = GC_PHASE_IDLE;
+static uint64_t g_bytes_since_cycle;   /* drives the proactive cycle start */
+static uint64_t g_bytes_since_quantum; /* drives a mark quantum */
+
 static int g_initialized;
 
 /* --- Colored pointers -------------------------------------------- */
@@ -127,6 +136,8 @@ static int grow_budget(void) {
     return 1;
 }
 
+static void gc_driver(uint64_t total); /* forward decl: incremental driver */
+
 void *klassic_gc_alloc(uint64_t size, uint64_t type_tag) {
     if (!g_initialized) {
         klassic_gc_init();
@@ -138,12 +149,22 @@ void *klassic_gc_alloc(uint64_t size, uint64_t type_tag) {
         fprintf(stderr, "klassic gc: object larger than a region is unsupported\n");
         exit(1);
     }
+    /* Drive the phase machine BEFORE the bump, so it observes only the
+     * mutator's already-rooted state (the object about to be allocated is
+     * not yet reachable from a root). None of the routines it calls
+     * allocate, so gc_alloc is not re-entered. */
+    gc_driver(total);
     for (;;) {
         if (g_heap_base && (uint64_t)(g_heap_end - g_heap_top) >= total) {
             uint8_t *block = g_heap_top;
             g_heap_top += total;
-            *(uint64_t *)block = total;           /* word0 = size, flags clear */
-            *(uint64_t *)(block + 8) = type_tag;  /* word1 = type tag */
+            *(uint64_t *)block = total;          /* word0 = size, flags clear */
+            *(uint64_t *)(block + 8) = type_tag; /* word1 = type tag */
+            /* Allocate-black: an object born during Mark is live this
+             * cycle, so the in-progress mark does not reclaim it. */
+            if (g_phase == GC_PHASE_MARK) {
+                *(uint64_t *)block |= g_header_mark;
+            }
             return block + 16;
         }
         if (acquire_region()) {
@@ -174,6 +195,8 @@ void klassic_gc_shadow_pop_n(uint64_t count) {
     g_shadow_top -= count;
 }
 
+static void mark_visit(void *user); /* forward decl */
+
 uint64_t klassic_gc_load_barrier_slow(uint64_t value, void **slot) {
     uint64_t raw = value & gc_strip_mask;
     /* Self-heal: store the good-colored pointer back so later barriered
@@ -181,6 +204,13 @@ uint64_t klassic_gc_load_barrier_slow(uint64_t value, void **slot) {
      * remap here first.) A plain store -- single mutator. */
     if (raw) {
         *slot = (void *)(raw | gc_good_color);
+    }
+    /* During Mark, the mutator has just pulled a raw pointer into a
+     * register, so it must be marked to keep the strong tricolor
+     * invariant (load-barrier-driven incremental update -- no store
+     * barrier, since klassic has no in-place heap mutation). */
+    if (g_phase == GC_PHASE_MARK) {
+        mark_visit((void *)raw);
     }
     return raw;
 }
@@ -217,8 +247,10 @@ static void mark_visit(void *user) {
 }
 
 /* Drain the worklist, marking every reachable pointer. */
-static void trace(void) {
-    while (g_worklist_top) {
+/* Trace up to `budget` worklist objects (a bounded mark quantum). */
+static void gc_trace(uint64_t budget) {
+    while (budget && g_worklist_top) {
+        budget--;
         void *user = g_worklist[--g_worklist_top];
         uint64_t *block = (uint64_t *)((uint8_t *)user - 16);
         uint64_t tag = block[1];
@@ -241,53 +273,103 @@ static void trace(void) {
     }
 }
 
-void klassic_gc_collect(void) {
-    if (!g_initialized) {
-        return;
+/* Drain the worklist to fixpoint. */
+static void gc_drain(void) {
+    while (g_worklist_top) {
+        gc_trace(GC_QUANTUM_POPS);
     }
-    g_collections++;
-    /* Flip the mark parity: this cycle marks with the other bit, and the
-     * sweep clears the now-stale parity, so liveness stays clean across
-     * cycles. */
-    g_header_mark ^= KLASSIC_GC_HMARK_BOTH;
-    uint64_t stale_clear = ~(uint64_t)(KLASSIC_GC_HMARK_BOTH ^ g_header_mark);
+}
 
-    /* Mark from the shadow-stack roots. */
-    g_worklist_top = 0;
+static void gc_mark_roots(void) {
     for (uint64_t i = 0; i < g_shadow_top; i++) {
         mark_visit(*g_shadow[i]);
     }
-    trace();
+}
 
-    /* Flush the current bump region's watermark so the sweep covers it. */
+/* Reclaim whole-dead regions; on a live block clear the stale mark bit. */
+static void gc_sweep(void) {
+    g_collections++;
     if (g_heap_base) {
         g_region_top[region_index(g_heap_base)] = (uint64_t)(uintptr_t)g_heap_top;
     }
-
-    /* Sweep: reclaim whole-dead regions; on a live block clear the stale
-     * mark bit (keep the current one). */
+    uint64_t stale_clear = ~(uint64_t)(KLASSIC_GC_HMARK_BOTH ^ g_header_mark);
     for (uint64_t idx = 0; idx < g_committed; idx++) {
         uint8_t *base = region_at(idx);
         uint8_t *top = (uint8_t *)(uintptr_t)g_region_top[idx];
         if (top == base) {
-            continue; /* empty / already free */
+            continue;
         }
         int any_live = 0;
         for (uint8_t *cur = base; cur < top;) {
             uint64_t *b = (uint64_t *)cur;
             uint64_t sz = block_size(b[0]);
             if (b[0] & g_header_mark) {
-                b[0] &= stale_clear; /* keep current mark, clear stale */
+                b[0] &= stale_clear;
                 any_live = 1;
             }
             cur += sz;
         }
         if (!any_live && base != g_heap_base) {
-            /* Reclaim: push onto the free pool, mark the region empty. */
             *(uint8_t **)base = g_free_head;
             g_free_head = base;
             g_region_top[idx] = (uint64_t)(uintptr_t)base;
         }
+    }
+}
+
+/* MarkStart: flip the mark color (M0<->M1) and header parity, scan roots,
+ * enter the Mark phase. The new bad mask catches the OLD good color | R,
+ * so pointers left from the previous cycle slow-path and are re-marked
+ * (incremental-update marking). */
+static void gc_mark_start(void) {
+    uint64_t old_good = gc_good_color;
+    gc_bad_mask = old_good | GC_COLOR_R;
+    gc_good_color = old_good ^ (GC_COLOR_M0 | GC_COLOR_M1);
+    g_header_mark ^= KLASSIC_GC_HMARK_BOTH;
+    g_worklist_top = 0;
+    gc_mark_roots();
+    g_phase = GC_PHASE_MARK;
+}
+
+/* MarkEnd: drain the frontier to fixpoint, sweep, return to Idle. */
+static void gc_mark_end(void) {
+    gc_drain();
+    gc_sweep();
+    g_phase = GC_PHASE_IDLE;
+    g_bytes_since_cycle = 0;
+}
+
+/* Synchronous full collection (exhaustion / explicit). If a cycle is in
+ * progress, finish it; otherwise a from-scratch stop-the-world mark. */
+void klassic_gc_collect(void) {
+    if (!g_initialized) {
+        return;
+    }
+    if (g_phase == GC_PHASE_MARK) {
+        gc_mark_end();
+        return;
+    }
+    gc_mark_start();
+    gc_mark_end();
+}
+
+/* Poll the phase machine from an allocation point: proactively start a
+ * cycle under memory pressure, and run a mark quantum during Mark. */
+static void gc_driver(uint64_t total) {
+    if (g_phase == GC_PHASE_MARK) {
+        g_bytes_since_quantum += total;
+        if (g_bytes_since_quantum >= GC_QUANTUM_BYTES) {
+            g_bytes_since_quantum = 0;
+            gc_trace(GC_QUANTUM_POPS);
+            if (g_worklist_top == 0) {
+                gc_mark_end();
+            }
+        }
+        return;
+    }
+    g_bytes_since_cycle += total;
+    if (g_bytes_since_cycle >= (g_budget << REGION_SHIFT) / 2) {
+        gc_mark_start();
     }
 }
 

--- a/runtime/gc/klassic_gc.c
+++ b/runtime/gc/klassic_gc.c
@@ -1,0 +1,260 @@
+/* klassic_gc.c -- non-moving region mark-sweep foundation (ZGC plan M4
+ * equivalent), in C. See klassic_gc.h for the object layout and the
+ * migration context. Colored pointers + load barrier, incremental
+ * marking, and moving evacuation land in later commits; this file is the
+ * base they build on.
+ */
+#define _DEFAULT_SOURCE /* for MAP_ANONYMOUS under -std=c11 */
+
+#include "klassic_gc.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+
+/* --- Region heap geometry ---------------------------------------- */
+#define REGION_SHIFT 17
+#define REGION_SIZE (1u << REGION_SHIFT) /* 128 KiB */
+#define RESERVE_REGIONS 512
+#define RESERVE_BYTES ((size_t)RESERVE_REGIONS * REGION_SIZE) /* 64 MiB */
+#define SHADOW_MAX (1u << 20)
+#define WORKLIST_MAX (1u << 18)
+
+/* The whole heap is one up-front reservation; Linux demand-pages it. A
+ * soft budget bounds how many regions the mutator touches before a
+ * collection. */
+static uint8_t *g_region_base;
+static uint64_t g_region_top[RESERVE_REGIONS]; /* per-region bump watermark */
+static uint64_t g_committed;                   /* high-water committed regions */
+static uint64_t g_budget = 8;                  /* soft budget, doubles on stall */
+static uint8_t *g_free_head;                    /* free-region pool, linked via base qword */
+
+/* The current bump region. */
+static uint8_t *g_heap_base;
+static uint8_t *g_heap_top;
+static uint8_t *g_heap_end;
+
+/* Precise roots and the mark worklist. */
+static void **g_shadow[SHADOW_MAX];
+static uint64_t g_shadow_top;
+static void *g_worklist[WORKLIST_MAX];
+static uint64_t g_worklist_top;
+
+/* The current-cycle header mark bit (alternates each collection). */
+static uint64_t g_header_mark = KLASSIC_GC_HMARK1;
+static uint64_t g_collections;
+
+static int g_initialized;
+
+static uint64_t align16(uint64_t n) { return (n + 15u) & ~(uint64_t)15u; }
+static uint64_t block_size(uint64_t word0) { return word0 & ~(uint64_t)15u; }
+
+void klassic_gc_init(void) {
+    if (g_initialized) {
+        return;
+    }
+    void *base = mmap(NULL, RESERVE_BYTES, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (base == MAP_FAILED) {
+        fprintf(stderr, "klassic gc: cannot reserve the heap\n");
+        exit(1);
+    }
+    g_region_base = (uint8_t *)base;
+    g_committed = 0;
+    g_free_head = NULL;
+    g_heap_base = g_heap_top = g_heap_end = NULL;
+    g_shadow_top = 0;
+    g_header_mark = KLASSIC_GC_HMARK1;
+    g_collections = 0;
+    g_initialized = 1;
+}
+
+static uint8_t *region_at(uint64_t index) {
+    return g_region_base + (size_t)index * REGION_SIZE;
+}
+static uint64_t region_index(const uint8_t *p) {
+    return (uint64_t)((p - g_region_base) >> REGION_SHIFT);
+}
+
+/* Acquire a fresh, zeroed bump region: reuse from the free pool, else
+ * commit the next tail region within the budget. Returns 0 on failure. */
+static int acquire_region(void) {
+    /* Flush the current region's watermark before switching. */
+    if (g_heap_base) {
+        g_region_top[region_index(g_heap_base)] = (uint64_t)(uintptr_t)g_heap_top;
+    }
+    uint8_t *base;
+    if (g_free_head) {
+        base = g_free_head;
+        g_free_head = *(uint8_t **)base; /* pop */
+        memset(base, 0, REGION_SIZE);    /* reused region: clear stale bytes */
+    } else if (g_committed < g_budget) {
+        base = region_at(g_committed);
+        g_committed++;
+        /* fresh mmap memory is already zero */
+    } else {
+        return 0;
+    }
+    g_heap_base = base;
+    g_heap_top = base;
+    g_heap_end = base + REGION_SIZE;
+    g_region_top[region_index(base)] = (uint64_t)(uintptr_t)base;
+    return 1;
+}
+
+static int grow_budget(void) {
+    if (g_budget >= RESERVE_REGIONS) {
+        return 0;
+    }
+    g_budget *= 2;
+    if (g_budget > RESERVE_REGIONS) {
+        g_budget = RESERVE_REGIONS;
+    }
+    return 1;
+}
+
+void *klassic_gc_alloc(uint64_t size, uint64_t type_tag) {
+    if (!g_initialized) {
+        klassic_gc_init();
+    }
+    uint64_t total = align16(size + 16);
+    if (total > REGION_SIZE) {
+        /* Large objects (contiguous region runs) are a later addition;
+         * the foundation's test objects are small. */
+        fprintf(stderr, "klassic gc: object larger than a region is unsupported\n");
+        exit(1);
+    }
+    for (;;) {
+        if (g_heap_base && (uint64_t)(g_heap_end - g_heap_top) >= total) {
+            uint8_t *block = g_heap_top;
+            g_heap_top += total;
+            *(uint64_t *)block = total;           /* word0 = size, flags clear */
+            *(uint64_t *)(block + 8) = type_tag;  /* word1 = type tag */
+            return block + 16;
+        }
+        if (acquire_region()) {
+            continue;
+        }
+        /* Budget exhausted: collect, then (if that frees nothing) grow. */
+        klassic_gc_collect();
+        if (acquire_region()) {
+            continue;
+        }
+        if (grow_budget() && acquire_region()) {
+            continue;
+        }
+        fprintf(stderr, "klassic gc: out of memory\n");
+        exit(1);
+    }
+}
+
+void klassic_gc_shadow_push(void **slot_addr) {
+    if (g_shadow_top >= SHADOW_MAX) {
+        fprintf(stderr, "klassic gc: shadow stack overflow\n");
+        exit(1);
+    }
+    g_shadow[g_shadow_top++] = slot_addr;
+}
+
+void klassic_gc_shadow_pop_n(uint64_t count) {
+    g_shadow_top -= count;
+}
+
+/* Mark `user` if unmarked this cycle, pushing it for tracing. */
+static void mark_visit(void *user) {
+    if (!user) {
+        return;
+    }
+    uint64_t *block = (uint64_t *)((uint8_t *)user - 16);
+    if (block[0] & g_header_mark) {
+        return; /* already marked this cycle */
+    }
+    block[0] |= g_header_mark;
+    if (g_worklist_top >= WORKLIST_MAX) {
+        fprintf(stderr, "klassic gc: mark worklist overflow\n");
+        exit(1);
+    }
+    g_worklist[g_worklist_top++] = user;
+}
+
+/* Drain the worklist, marking every reachable pointer. */
+static void trace(void) {
+    while (g_worklist_top) {
+        void *user = g_worklist[--g_worklist_top];
+        uint64_t *block = (uint64_t *)((uint8_t *)user - 16);
+        uint64_t tag = block[1];
+        if (tag < KLASSIC_GC_POINTER_RECORD) {
+            continue; /* raw bytes: no pointer payload */
+        }
+        uint64_t payload = block_size(block[0]) - 16;
+        void **fields = (void **)user;
+        uint64_t slots = payload / 8;
+        uint64_t start = (tag == KLASSIC_GC_POINTER_LIST) ? 1 : 0; /* skip length */
+        for (uint64_t i = start; i < slots; i++) {
+            mark_visit(fields[i]);
+        }
+    }
+}
+
+void klassic_gc_collect(void) {
+    if (!g_initialized) {
+        return;
+    }
+    g_collections++;
+    /* Flip the mark parity: this cycle marks with the other bit, and the
+     * sweep clears the now-stale parity, so liveness stays clean across
+     * cycles. */
+    g_header_mark ^= KLASSIC_GC_HMARK_BOTH;
+    uint64_t stale_clear = ~(uint64_t)(KLASSIC_GC_HMARK_BOTH ^ g_header_mark);
+
+    /* Mark from the shadow-stack roots. */
+    g_worklist_top = 0;
+    for (uint64_t i = 0; i < g_shadow_top; i++) {
+        mark_visit(*g_shadow[i]);
+    }
+    trace();
+
+    /* Flush the current bump region's watermark so the sweep covers it. */
+    if (g_heap_base) {
+        g_region_top[region_index(g_heap_base)] = (uint64_t)(uintptr_t)g_heap_top;
+    }
+
+    /* Sweep: reclaim whole-dead regions; on a live block clear the stale
+     * mark bit (keep the current one). */
+    for (uint64_t idx = 0; idx < g_committed; idx++) {
+        uint8_t *base = region_at(idx);
+        uint8_t *top = (uint8_t *)(uintptr_t)g_region_top[idx];
+        if (top == base) {
+            continue; /* empty / already free */
+        }
+        int any_live = 0;
+        for (uint8_t *cur = base; cur < top;) {
+            uint64_t *b = (uint64_t *)cur;
+            uint64_t sz = block_size(b[0]);
+            if (b[0] & g_header_mark) {
+                b[0] &= stale_clear; /* keep current mark, clear stale */
+                any_live = 1;
+            }
+            cur += sz;
+        }
+        if (!any_live && base != g_heap_base) {
+            /* Reclaim: push onto the free pool, mark the region empty. */
+            *(uint8_t **)base = g_free_head;
+            g_free_head = base;
+            g_region_top[idx] = (uint64_t)(uintptr_t)base;
+        }
+    }
+}
+
+uint64_t klassic_gc_collection_count(void) { return g_collections; }
+
+uint64_t klassic_gc_live_region_count(void) {
+    uint64_t live = 0;
+    for (uint64_t idx = 0; idx < g_committed; idx++) {
+        if ((uint8_t *)(uintptr_t)g_region_top[idx] != region_at(idx)) {
+            live++;
+        }
+    }
+    return live;
+}

--- a/runtime/gc/klassic_gc.c
+++ b/runtime/gc/klassic_gc.c
@@ -294,7 +294,11 @@ static void gc_mark_roots(void) {
     }
 }
 
-/* Reclaim whole-dead regions; on a live block clear the stale mark bit. */
+/* Reclaim whole-dead regions and clear the stale (previous-cycle) mark bit
+ * on every block. Clearing it on dead blocks too -- not just live ones --
+ * is essential: the two mark bits alternate, so a dead block that kept its
+ * old bit would be misread as live when that bit becomes current again two
+ * cycles later (a resurrection/leak). */
 static void gc_sweep(void) {
     g_collections++;
     if (g_heap_base) {
@@ -313,8 +317,9 @@ static void gc_sweep(void) {
         for (uint8_t *cur = base; cur < top;) {
             uint64_t *b = (uint64_t *)cur;
             uint64_t sz = block_size(b[0]);
-            if (b[0] & g_header_mark) {
-                b[0] &= stale_clear;
+            int is_live = (b[0] & g_header_mark) != 0;
+            b[0] &= stale_clear; /* drop the stale bit on live AND dead blocks */
+            if (is_live) {
                 any_live = 1;
                 live += sz;
             }

--- a/runtime/gc/klassic_gc.c
+++ b/runtime/gc/klassic_gc.c
@@ -403,9 +403,11 @@ static void fixup_field(void **slot) {
     }
 }
 
-/* Rewrite a raw root slot to follow forwarding (roots hold raw pointers). */
+/* Rewrite a raw root slot to follow forwarding. Roots hold raw pointers by
+ * contract; strip defensively anyway so this agrees with mark_visit and
+ * stays correct even if codegen ever stages a colored pointer in a slot. */
 static void fixup_root(void **slot) {
-    uint64_t raw = (uint64_t)*slot;
+    uint64_t raw = (uint64_t)*slot & gc_strip_mask;
     if (!raw) {
         return;
     }

--- a/runtime/gc/klassic_gc.h
+++ b/runtime/gc/klassic_gc.h
@@ -17,10 +17,12 @@
  *           payload; a POINTER_LIST skips a leading length qword.
  * The user pointer is block + 16.
  *
- * This header tracks the collector's growth milestone by milestone; the
- * current file implements the non-moving region mark-sweep foundation
- * (ZGC plan M4 equivalent). Colored pointers + load barrier, incremental
- * marking, and moving evacuation land in later commits.
+ * The collector is a ZGC-style region heap with colored pointers + a load
+ * barrier (M6b), incremental marking (M6c), and stop-the-world compacting
+ * evacuation with in-object forwarding (M6d): sparse regions are copied
+ * into a fresh to-space and every root and live field is rewritten to the
+ * moved location. Lazy/concurrent relocation via the R-color barrier is a
+ * later refinement (see docs/zgc-plan.md).
  */
 #ifndef KLASSIC_GC_H
 #define KLASSIC_GC_H
@@ -87,5 +89,6 @@ void klassic_gc_write(void **slot, void *value);
 /* Test/observability hooks. */
 uint64_t klassic_gc_collection_count(void);
 uint64_t klassic_gc_live_region_count(void);
+uint64_t klassic_gc_relocation_count(void); /* objects evacuated so far */
 
 #endif /* KLASSIC_GC_H */

--- a/runtime/gc/klassic_gc.h
+++ b/runtime/gc/klassic_gc.h
@@ -56,6 +56,34 @@ void klassic_gc_shadow_pop_n(uint64_t count);
 /* Force a collection (stop-the-world mark-sweep for now). */
 void klassic_gc_collect(void);
 
+/* --- Colored pointers + load barrier ----------------------------- *
+ * Heap-object SLOTS hold color-tagged pointers (bits 60-62); registers,
+ * roots, and the shadow stack hold raw (stripped) pointers. The mask
+ * cells are dso_local globals so the LLVM-emitted fast path folds the
+ * bad-mask load into a `testq` memory operand (see the M2 spike). A
+ * pointer whose color is "bad" is non-canonical, so an unbarriered
+ * dereference faults -- the barrier-coverage guarantee. These are the
+ * values the LLVM codegen's inline fast path reads; the slow path here
+ * is a normal C function (default memory semantics, never readnone, so
+ * clang cannot CSE a slot load across it). */
+extern uint64_t gc_good_color;  /* the good color stored pointers carry */
+extern uint64_t gc_bad_mask;    /* a pointer is "bad" iff (color & bad) != 0 */
+extern uint64_t gc_strip_mask;  /* AND with this to strip a color -> raw */
+
+/* Slow path: in: `value` = the bad-colored slot value, `slot` = the
+ * field address it was loaded from. Returns the raw (stripped, and in
+ * later milestones remapped) pointer, self-healing the slot to the good
+ * color. */
+uint64_t klassic_gc_load_barrier_slow(uint64_t value, void **slot);
+
+/* Read a heap pointer slot through the barrier (fast path inline, slow
+ * path out of line). The LLVM backend emits the fast path directly; this
+ * C entry point exists for the runtime and the tests. */
+void *klassic_gc_read(void **slot);
+
+/* Store a heap pointer into a slot, coloring it good (null stays null). */
+void klassic_gc_write(void **slot, void *value);
+
 /* Test/observability hooks. */
 uint64_t klassic_gc_collection_count(void);
 uint64_t klassic_gc_live_region_count(void);

--- a/runtime/gc/klassic_gc.h
+++ b/runtime/gc/klassic_gc.h
@@ -1,0 +1,63 @@
+/* klassic_gc.h -- the klassic garbage collector, in C.
+ *
+ * A C re-implementation of the ZGC-style region-based collector that the
+ * hand-emitted x86_64 backend carries as machine code (see
+ * docs/zgc-plan.md and the GC section of docs/architecture-rust.md, which
+ * are the spec). The LLVM backend calls these functions instead of
+ * emitting the collector inline; being C, the GC is debuggable with
+ * ASan/UBSan/Valgrind/gdb -- the point of the migration.
+ *
+ * Object layout: a 16-byte header precedes each user pointer.
+ *   word0 = [ size | flags ]  where the size is 16-aligned so the low 4
+ *           bits are flags: bit0 = FWD (forwarded; word0 then holds the
+ *           new user pointer | FWD), bits 1-2 = the two alternating mark
+ *           bits. size = word0 & -16.
+ *   word1 = type tag (KLASSIC_GC_RAW_BYTES / _POINTER_RECORD /
+ *           _POINTER_LIST). Tags >= POINTER_RECORD have an all-pointer
+ *           payload; a POINTER_LIST skips a leading length qword.
+ * The user pointer is block + 16.
+ *
+ * This header tracks the collector's growth milestone by milestone; the
+ * current file implements the non-moving region mark-sweep foundation
+ * (ZGC plan M4 equivalent). Colored pointers + load barrier, incremental
+ * marking, and moving evacuation land in later commits.
+ */
+#ifndef KLASSIC_GC_H
+#define KLASSIC_GC_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Type tags (word1). */
+#define KLASSIC_GC_RAW_BYTES 1
+#define KLASSIC_GC_POINTER_RECORD 2
+#define KLASSIC_GC_POINTER_LIST 4
+
+/* Header flag bits (low 4 bits of word0; size is 16-aligned). */
+#define KLASSIC_GC_FWD 1u
+#define KLASSIC_GC_HMARK0 2u
+#define KLASSIC_GC_HMARK1 4u
+#define KLASSIC_GC_HMARK_BOTH (KLASSIC_GC_HMARK0 | KLASSIC_GC_HMARK1)
+
+/* Initialize the heap (idempotent). Reserves the region address space. */
+void klassic_gc_init(void);
+
+/* Allocate `size` payload bytes for an object of `type_tag`; returns the
+ * user pointer (past the 16-byte header). Never returns NULL: on
+ * exhaustion it prints an error and exits. */
+void *klassic_gc_alloc(uint64_t size, uint64_t type_tag);
+
+/* Precise roots: push the ADDRESS of a stack slot holding a heap pointer,
+ * so the collector can both read and (once moving) update the root. Pop
+ * the last `count` entries when a scope exits. */
+void klassic_gc_shadow_push(void **slot_addr);
+void klassic_gc_shadow_pop_n(uint64_t count);
+
+/* Force a collection (stop-the-world mark-sweep for now). */
+void klassic_gc_collect(void);
+
+/* Test/observability hooks. */
+uint64_t klassic_gc_collection_count(void);
+uint64_t klassic_gc_live_region_count(void);
+
+#endif /* KLASSIC_GC_H */

--- a/runtime/gc/run_tests.sh
+++ b/runtime/gc/run_tests.sh
@@ -10,4 +10,16 @@ tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
 "$CC" -std=c11 -O1 -g -Wall -Wextra -Werror \
   -fsanitize=address,undefined -fno-omit-frame-pointer \
   "$here/klassic_gc.c" "$here/gc_test.c" -o "$tmp/gc_test"
-ASAN_OPTIONS=detect_leaks=0 "$tmp/gc_test"
+
+# Run with ASLR disabled. On some kernels (notably WSL2) an ASan binary's
+# shadow-memory setup nondeterministically faults during startup -- before
+# main() -- for certain ASLR placements; a trivial "int main" reproduces it
+# at ~20%. That flakiness is in the sanitizer runtime, not the collector, so
+# we pin the address-space layout with `setarch -R` to make the run
+# deterministic. Where setarch is unavailable (e.g. macOS) ASan is not flaky,
+# so fall back to a direct run.
+if command -v setarch >/dev/null 2>&1; then
+  ASAN_OPTIONS=detect_leaks=0 setarch "$(uname -m)" -R "$tmp/gc_test"
+else
+  ASAN_OPTIONS=detect_leaks=0 "$tmp/gc_test"
+fi

--- a/runtime/gc/run_tests.sh
+++ b/runtime/gc/run_tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Build and run the C GC unit tests under AddressSanitizer + UBSan.
+# Requires clang (KLASSIC_CLANG overrides; falls back to cc). Part of the
+# LLVM backend migration (docs/llvm-backend-plan.md, M6).
+set -euo pipefail
+CC="${KLASSIC_CLANG:-clang-15}"
+command -v "$CC" >/dev/null 2>&1 || CC=cc
+here="$(cd "$(dirname "$0")" && pwd)"
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+"$CC" -std=c11 -O1 -g -Wall -Wextra -Werror \
+  -fsanitize=address,undefined -fno-omit-frame-pointer \
+  "$here/klassic_gc.c" "$here/gc_test.c" -o "$tmp/gc_test"
+ASAN_OPTIONS=detect_leaks=0 "$tmp/gc_test"

--- a/tests/llvm_gc.rs
+++ b/tests/llvm_gc.rs
@@ -12,17 +12,19 @@ fn find_cc() -> Option<String> {
     if let Ok(explicit) = std::env::var("KLASSIC_CLANG") {
         return Some(explicit);
     }
-    ["clang-18", "clang-17", "clang-16", "clang-15", "clang", "cc"]
-        .into_iter()
-        .find(|name| {
-            Command::new(name)
-                .arg("--version")
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .is_ok_and(|status| status.success())
-        })
-        .map(str::to_owned)
+    [
+        "clang-18", "clang-17", "clang-16", "clang-15", "clang", "cc",
+    ]
+    .into_iter()
+    .find(|name| {
+        Command::new(name)
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    })
+    .map(str::to_owned)
 }
 
 #[test]

--- a/tests/llvm_gc.rs
+++ b/tests/llvm_gc.rs
@@ -1,0 +1,50 @@
+//! Runs the C garbage collector's own unit tests under
+//! AddressSanitizer + UBSan (`runtime/gc/run_tests.sh`) as part of
+//! `cargo test`. Part of the LLVM backend migration
+//! (`docs/llvm-backend-plan.md`, M6): the GC is C now, so it gets a
+//! memory sanitizer the hand-emitted collector never could. Gated on a
+//! C compiler being present so CI without one stays green.
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(explicit) = std::env::var("KLASSIC_CLANG") {
+        return Some(explicit);
+    }
+    ["clang-18", "clang-17", "clang-16", "clang-15", "clang", "cc"]
+        .into_iter()
+        .find(|name| {
+            Command::new(name)
+                .arg("--version")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .is_ok_and(|status| status.success())
+        })
+        .map(str::to_owned)
+}
+
+#[test]
+fn c_gc_passes_under_sanitizers() {
+    let Some(cc) = find_cc() else {
+        eprintln!("skipping: no C compiler found");
+        return;
+    };
+    let script = concat!(env!("CARGO_MANIFEST_DIR"), "/runtime/gc/run_tests.sh");
+    let output = Command::new("bash")
+        .arg(script)
+        .env("KLASSIC_CLANG", &cc)
+        .output()
+        .expect("run_tests.sh should run");
+    assert!(
+        output.status.success(),
+        "C GC sanitizer tests failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("ALL GC TESTS PASSED"),
+        "expected the GC tests to report success"
+    );
+}


### PR DESCRIPTION
## What

Adds the klassic garbage collector, rewritten in **C**, as the runtime the
LLVM backend will call into (LLVM backend migration, `docs/llvm-backend-plan.md`
M6). Moving the collector out of hand-emitted machine code into C is the whole
point of the migration: it can now be exercised under **AddressSanitizer +
UBSan**, which the asm version never could.

This PR is the collector and its sanitizer test harness only. Wiring the emitter
to call `gc_alloc` / the shadow stack / the load-barrier IR is the next
milestone (M7); nothing in the compile path changes here.

## The collector (`runtime/gc/klassic_gc.{c,h}`)

A ZGC-style region collector, built up in four green-at-each-step layers:

- **M6a — foundation.** 64 MiB up-front reservation, 128 KiB × 512 regions,
  bump allocation, a soft region budget, 16-byte object headers
  (`word0 = size | flags`, `word1 = type tag`), a precise shadow stack of root
  *slot addresses*, and a stop-the-world worklist mark + whole-dead-region
  sweep.
- **M6b — colored pointers + load barrier.** Heap slots carry a color in bits
  60–62; roots/registers stay raw. The mask cells (`gc_good_color` /
  `gc_bad_mask` / `gc_strip_mask`) are `dso_local` globals so the LLVM-emitted
  fast path folds the bad-mask test into a `testq` memory operand (the M2
  spike). The slow path strips + self-heals; `gc_write` colors on store.
- **M6c — incremental marking.** An Idle/Mark phase machine driven in quanta
  from `gc_alloc`: proactive `MarkStart` at half the region budget, bounded
  mark quanta, allocate-black, `MarkEnd`. No store barrier — the language has
  no in-place heap mutation, so the load barrier alone keeps the tricolor
  invariant.
- **M6d — moving.** Stop-the-world compacting evacuation: at `MarkEnd`, sparse
  regions (non-current, under half live) are copied into a fresh to-space with
  an in-object forwarding word (`word0 = new_user | FWD`), then every root and
  live field is rewritten to the moved location and the vacated regions are
  freed. The relocation set is capped by region count so to-space exhaustion is
  impossible. The mutator's colored-pointer model is unchanged; lazy/concurrent
  relocation via the R-color barrier is a documented later refinement.

## Tests

`runtime/gc/gc_test.c` (run by `runtime/gc/run_tests.sh` under
`-fsanitize=address,undefined`, and by `cargo test` via `tests/llvm_gc.rs` when
a C compiler is present) exercises the barrier's strip+heal, the incremental
driver keeping a survivor across many self-triggered cycles, a 500-node linked
structure surviving churn, garbage reclamation, and — for the moving layer —
that a rooted survivor is **physically relocated** (`relocation_count > 0`, its
root address changes) yet reads back intact, and that a 300-node linked
structure stays fully connected across compaction.

The test binary is run with ASLR pinned (`setarch -R`): on WSL2, an ASan
binary's shadow-memory setup nondeterministically faults during startup for
certain ASLR placements (a trivial `int main` reproduces it at ~20–27%; it
vanishes with ASLR off). That flakiness is in the sanitizer runtime, not the
collector.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
and the full `cargo test` suite are green. The GC sanitizer tests pass 90/90
under ASLR-pinned ASan + UBSan.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
