### PR TITLE
feat: wire the C GC into the LLVM backend -- heap records (M7)

### DIFF
--- a/crates/klassic-native/src/llvm.rs
+++ b/crates/klassic-native/src/llvm.rs
@@ -9,8 +9,16 @@
 //! comparison / logical operators, `val` / `mutable` / assignment,
 //! `if` / `while`, `println` of a scalar, and annotated top-level `def`s
 //! (including recursion). Locals become `alloca`s that clang's mem2reg
-//! promotes to SSA; control flow lowers to basic blocks. Strings, the
-//! heap, enums, closures, and the stdlib are later milestones.
+//! promotes to SSA; control flow lowers to basic blocks.
+//!
+//! M7 (heap): structural records go on the GC heap. A record is the
+//! uniform "every slot is a heap pointer" `POINTER_RECORD` the collector
+//! walks -- scalar fields are boxed into `RAW_BYTES` leaves -- allocated
+//! through `klassic_gc_alloc`, with fields stored colored
+//! (`klassic_gc_write`) and read through the inline load-barrier fast path
+//! (the M2 spike). Heap locals and construction intermediates are kept on
+//! the shadow stack so a moving collection updates them precisely. Enums,
+//! closures, strings, and the stdlib are later milestones.
 
 use klassic_span::{Diagnostic, Span};
 use klassic_syntax::{BinaryOp, Expr, UnaryOp};
@@ -28,6 +36,9 @@ enum LType {
     F64,
     I1,
     Unit,
+    /// A heap record pointer; the `usize` indexes `Emitter::shapes` for the
+    /// field layout. Its LLVM type is an opaque `ptr`.
+    Record(usize),
 }
 
 impl LType {
@@ -37,7 +48,13 @@ impl LType {
             LType::F64 => "double",
             LType::I1 => "i1",
             LType::Unit => "void",
+            LType::Record(_) => "ptr",
         }
+    }
+
+    /// A heap pointer whose barriered loads/stores go through the GC.
+    fn is_heap(self) -> bool {
+        matches!(self, LType::Record(_))
     }
 }
 
@@ -79,6 +96,10 @@ struct Emitter {
     current_block: String,
     /// lexical scopes: name -> (alloca pointer operand, type).
     scopes: Vec<Vec<(String, String, LType)>>,
+    /// per-scope count of shadow-stack roots pushed, popped on scope exit.
+    scope_roots: Vec<u32>,
+    /// interned record field layouts: shape id -> [(field name, field type)].
+    shapes: Vec<Vec<(String, LType)>>,
 }
 
 impl Emitter {
@@ -130,6 +151,51 @@ impl Emitter {
             }
         }
         None
+    }
+
+    /// Open a lexical scope with its own root count.
+    fn open_scope(&mut self) {
+        self.scopes.push(Vec::new());
+        self.scope_roots.push(0);
+    }
+
+    /// Close a lexical scope, emitting the paired shadow-stack pop for the
+    /// heap roots it declared. Must run on the block that reaches the scope
+    /// exit (control flow re-converges before a scope closes).
+    fn close_scope(&mut self) {
+        let count = self.scope_roots.pop().unwrap_or(0);
+        if count > 0 {
+            self.emit(&format!("call void @klassic_gc_shadow_pop_n(i64 {count})"));
+        }
+        self.scopes.pop();
+    }
+
+    /// Root a heap pointer held at `slot` (a `ptr` alloca) for the rest of
+    /// the current scope, so a collection during a later allocation updates
+    /// it in place.
+    fn push_root(&mut self, slot: &str) {
+        self.emit(&format!("call void @klassic_gc_shadow_push(ptr {slot})"));
+        if let Some(count) = self.scope_roots.last_mut() {
+            *count += 1;
+        }
+    }
+
+    /// A fresh entry-block `ptr` alloca for a transient shadow-stack slot
+    /// (staging a value across an allocation during record construction).
+    fn fresh_slot(&mut self) -> String {
+        let slot = format!("%s{}", self.next_temp);
+        self.next_temp += 1;
+        self.allocas.push_str(&format!("  {slot} = alloca ptr\n"));
+        slot
+    }
+
+    /// Intern a record field layout, returning its shape id.
+    fn intern_shape(&mut self, shape: Vec<(String, LType)>) -> usize {
+        if let Some(index) = self.shapes.iter().position(|existing| *existing == shape) {
+            return index;
+        }
+        self.shapes.push(shape);
+        self.shapes.len() - 1
     }
 
     /// Lower an expression to a value, appending any instructions.
@@ -205,12 +271,12 @@ impl Emitter {
                 let Some((last, leading)) = expressions.split_last() else {
                     return Err(unsupported(*span, "an empty block expression"));
                 };
-                self.scopes.push(Vec::new());
+                self.open_scope();
                 for statement in leading {
                     self.statement(statement)?;
                 }
                 let value = self.expr(last)?;
-                self.scopes.pop();
+                self.close_scope();
                 Ok(value)
             }
             Expr::Call {
@@ -218,6 +284,12 @@ impl Emitter {
                 arguments,
                 span,
             } => self.call(callee, arguments, *span),
+            Expr::RecordLiteral { fields, span } => self.record_literal(fields, *span),
+            Expr::FieldAccess {
+                target,
+                field,
+                span,
+            } => self.field_access(target, field, *span),
             other => Err(unsupported(other.span(), "expression")),
         }
     }
@@ -382,14 +454,177 @@ impl Emitter {
     }
 
     /// Lower a statement (value discarded).
+    /// Lower a structural record literal to a heap `POINTER_RECORD`: every
+    /// field is boxed into an 8-byte `RAW_BYTES` leaf (the uniform
+    /// all-pointers layout the collector walks), staged on the shadow stack
+    /// across the record allocation, then stored coloured. Returns a heap
+    /// pointer tagged with the record's interned shape.
+    fn record_literal(
+        &mut self,
+        fields: &[(String, Expr)],
+        span: Span,
+    ) -> Result<Value, Diagnostic> {
+        if fields.is_empty() {
+            return Err(unsupported(span, "an empty record"));
+        }
+        let n = fields.len();
+        let mut shape = Vec::with_capacity(n);
+        let mut slots = Vec::with_capacity(n);
+        for (name, value_expr) in fields {
+            let value = self.expr(value_expr)?;
+            let leaf = self.fresh();
+            self.emit(&format!(
+                "{leaf} = call ptr @klassic_gc_alloc(i64 8, i64 1)"
+            ));
+            match value.ty {
+                LType::I64 | LType::F64 => self.emit(&format!(
+                    "store {} {}, ptr {leaf}",
+                    value.ty.llvm(),
+                    value.operand
+                )),
+                LType::I1 => {
+                    let widened = self.fresh();
+                    self.emit(&format!("{widened} = zext i1 {} to i64", value.operand));
+                    self.emit(&format!("store i64 {widened}, ptr {leaf}"));
+                }
+                LType::Unit => {
+                    return Err(unsupported(value_expr.span(), "a unit record field"));
+                }
+                LType::Record(_) => {
+                    return Err(unsupported(
+                        value_expr.span(),
+                        "a record field that is itself a heap value",
+                    ));
+                }
+            }
+            let slot = self.fresh_slot();
+            self.emit(&format!("store ptr {leaf}, ptr {slot}"));
+            self.emit(&format!("call void @klassic_gc_shadow_push(ptr {slot})"));
+            shape.push((name.clone(), value.ty));
+            slots.push(slot);
+        }
+        let record = self.fresh();
+        self.emit(&format!(
+            "{record} = call ptr @klassic_gc_alloc(i64 {}, i64 2)",
+            8 * n
+        ));
+        for (index, slot) in slots.iter().enumerate() {
+            let leaf = self.fresh();
+            self.emit(&format!("{leaf} = load ptr, ptr {slot}"));
+            let field_addr = self.fresh();
+            self.emit(&format!(
+                "{field_addr} = getelementptr i8, ptr {record}, i64 {}",
+                8 * index
+            ));
+            self.emit(&format!(
+                "call void @klassic_gc_write(ptr {field_addr}, ptr {leaf})"
+            ));
+        }
+        self.emit(&format!("call void @klassic_gc_shadow_pop_n(i64 {n})"));
+        let shape_id = self.intern_shape(shape);
+        Ok(Value {
+            operand: record,
+            ty: LType::Record(shape_id),
+        })
+    }
+
+    /// Lower `target.field` to a barriered load of the record slot followed
+    /// by an unbox of the leaf it points at.
+    fn field_access(
+        &mut self,
+        target: &Expr,
+        field: &str,
+        span: Span,
+    ) -> Result<Value, Diagnostic> {
+        let target_value = self.expr(target)?;
+        let LType::Record(shape_id) = target_value.ty else {
+            return Err(unsupported(span, "a field access on a non-record value"));
+        };
+        let shape = self.shapes[shape_id].clone();
+        let mut found = None;
+        for (index, (name, ty)) in shape.iter().enumerate() {
+            if name == field {
+                found = Some((index, *ty));
+                break;
+            }
+        }
+        let Some((index, field_ty)) = found else {
+            return Err(unsupported(
+                span,
+                &format!("no field `{field}` on this record"),
+            ));
+        };
+        let field_addr = self.fresh();
+        self.emit(&format!(
+            "{field_addr} = getelementptr i8, ptr {}, i64 {}",
+            target_value.operand,
+            8 * index
+        ));
+        let raw = self.barrier_load(&field_addr);
+        let raw_ptr = self.fresh();
+        self.emit(&format!("{raw_ptr} = inttoptr i64 {raw} to ptr"));
+        let result = self.fresh();
+        match field_ty {
+            LType::I64 => self.emit(&format!("{result} = load i64, ptr {raw_ptr}")),
+            LType::F64 => self.emit(&format!("{result} = load double, ptr {raw_ptr}")),
+            LType::I1 => {
+                let widened = self.fresh();
+                self.emit(&format!("{widened} = load i64, ptr {raw_ptr}"));
+                self.emit(&format!("{result} = trunc i64 {widened} to i1"));
+            }
+            LType::Unit | LType::Record(_) => {
+                return Err(unsupported(span, "a field of an unsupported type"));
+            }
+        }
+        Ok(Value {
+            operand: result,
+            ty: field_ty,
+        })
+    }
+
+    /// Emit the inline load-barrier fast path for a colored heap-pointer slot
+    /// (validated in the M2 spike): load, test the bad-color mask, take the
+    /// out-of-line slow path if bad, then strip the color. Returns the raw
+    /// (stripped) pointer as an `i64` operand.
+    fn barrier_load(&mut self, slot: &str) -> String {
+        let value = self.fresh();
+        self.emit(&format!("{value} = load i64, ptr {slot}"));
+        let bad_mask = self.fresh();
+        self.emit(&format!("{bad_mask} = load i64, ptr @gc_bad_mask"));
+        let bad = self.fresh();
+        self.emit(&format!("{bad} = and i64 {value}, {bad_mask}"));
+        let is_bad = self.fresh();
+        self.emit(&format!("{is_bad} = icmp ne i64 {bad}, 0"));
+        let pred = self.current_block.clone();
+        let slow = self.fresh_label("bslow");
+        let ok = self.fresh_label("bok");
+        self.emit(&format!("br i1 {is_bad}, label %{slow}, label %{ok}"));
+        self.bind(&slow);
+        let healed = self.fresh();
+        self.emit(&format!(
+            "{healed} = call i64 @klassic_gc_load_barrier_slow(i64 {value}, ptr {slot})"
+        ));
+        self.emit(&format!("br label %{ok}"));
+        self.bind(&ok);
+        let merged = self.fresh();
+        self.emit(&format!(
+            "{merged} = phi i64 [ {value}, %{pred} ], [ {healed}, %{slow} ]"
+        ));
+        let strip_mask = self.fresh();
+        self.emit(&format!("{strip_mask} = load i64, ptr @gc_strip_mask"));
+        let raw = self.fresh();
+        self.emit(&format!("{raw} = and i64 {merged}, {strip_mask}"));
+        raw
+    }
+
     fn statement(&mut self, expr: &Expr) -> Result<(), Diagnostic> {
         match expr {
             Expr::Block { expressions, .. } => {
-                self.scopes.push(Vec::new());
+                self.open_scope();
                 for statement in expressions {
                     self.statement(statement)?;
                 }
-                self.scopes.pop();
+                self.close_scope();
                 Ok(())
             }
             Expr::VarDecl { name, value, .. } => {
@@ -401,6 +636,11 @@ impl Emitter {
                         value.ty.llvm(),
                         value.operand
                     ));
+                }
+                // A heap local is a precise root for the rest of its scope, so
+                // a collection during a later allocation updates it in place.
+                if value.ty.is_heap() {
+                    self.push_root(&ptr);
                 }
                 Ok(())
             }
@@ -502,6 +742,9 @@ impl Emitter {
                         ));
                     }
                     LType::Unit => return Err(unsupported(expr.span(), "printing unit")),
+                    LType::Record(_) => {
+                        return Err(unsupported(expr.span(), "printing a record"));
+                    }
                 }
                 Ok(())
             }
@@ -568,6 +811,18 @@ pub(crate) fn emit_llvm_program(expr: &Expr) -> Result<String, Diagnostic> {
     out.push_str("declare void @klassic_rt_println_f64(double)\n");
     out.push_str("declare void @klassic_rt_println_bool(i64)\n\n");
 
+    // Garbage collector ABI (runtime/gc/klassic_gc.c). The colour mask cells
+    // are `dso_local` globals so the emitted barrier fast path folds the
+    // bad-mask load into a single `testq` memory operand (the M2 spike);
+    // they are defined once in the C collector.
+    out.push_str("@gc_bad_mask   = external dso_local global i64\n");
+    out.push_str("@gc_strip_mask = external dso_local global i64\n");
+    out.push_str("declare ptr @klassic_gc_alloc(i64, i64)\n");
+    out.push_str("declare void @klassic_gc_shadow_push(ptr)\n");
+    out.push_str("declare void @klassic_gc_shadow_pop_n(i64)\n");
+    out.push_str("declare void @klassic_gc_write(ptr, ptr)\n");
+    out.push_str("declare i64 @klassic_gc_load_barrier_slow(i64, ptr)\n\n");
+
     // User functions. The subset treats a function body as a single
     // expression returned to the caller.
     let function_count = emitter.functions.len();
@@ -587,7 +842,8 @@ pub(crate) fn emit_llvm_program(expr: &Expr) -> Result<String, Diagnostic> {
         emitter.next_temp = 0;
         emitter.next_label = 0;
         emitter.scopes.clear();
-        emitter.scopes.push(Vec::new());
+        emitter.scope_roots.clear();
+        emitter.open_scope();
         emitter.current_block = "entry".to_owned();
         // Bind parameters: alloca + store the incoming SSA value.
         let mut param_sig = Vec::with_capacity(params.len());
@@ -608,6 +864,7 @@ pub(crate) fn emit_llvm_program(expr: &Expr) -> Result<String, Diagnostic> {
                 "a function body of a different type than its return annotation",
             ));
         }
+        emitter.close_scope();
         let mangled = format!("klassic_{name}");
         out.push_str(&format!(
             "define {} @{mangled}({}) {{\nentry:\n",
@@ -630,7 +887,8 @@ pub(crate) fn emit_llvm_program(expr: &Expr) -> Result<String, Diagnostic> {
     emitter.next_temp = 0;
     emitter.next_label = 0;
     emitter.scopes.clear();
-    emitter.scopes.push(Vec::new());
+    emitter.scope_roots.clear();
+    emitter.open_scope();
     emitter.current_block = "entry".to_owned();
     let statements: Vec<&Expr> = match expr {
         Expr::Block { expressions, .. } => expressions.iter().collect(),
@@ -639,6 +897,7 @@ pub(crate) fn emit_llvm_program(expr: &Expr) -> Result<String, Diagnostic> {
     for statement in statements {
         emitter.statement(statement)?;
     }
+    emitter.close_scope();
     out.push_str("define i32 @main() {\nentry:\n");
     out.push_str(&emitter.allocas);
     out.push_str(&emitter.body);

--- a/crates/klassic-native/src/llvm.rs
+++ b/crates/klassic-native/src/llvm.rs
@@ -508,22 +508,39 @@ impl Emitter {
             "{record} = call ptr @klassic_gc_alloc(i64 {}, i64 2)",
             8 * n
         ));
+        // Root the record itself across the color-on-store loop, and reload
+        // it (and each leaf) from its slot before every store. Today
+        // klassic_gc_write is a plain store, but rooting keeps the record
+        // relocatable if the store path ever becomes a safepoint -- the
+        // returned value is the record's final (post-move) location.
+        let record_slot = self.fresh_slot();
+        self.emit(&format!("store ptr {record}, ptr {record_slot}"));
+        self.emit(&format!(
+            "call void @klassic_gc_shadow_push(ptr {record_slot})"
+        ));
         for (index, slot) in slots.iter().enumerate() {
             let leaf = self.fresh();
             self.emit(&format!("{leaf} = load ptr, ptr {slot}"));
+            let base = self.fresh();
+            self.emit(&format!("{base} = load ptr, ptr {record_slot}"));
             let field_addr = self.fresh();
             self.emit(&format!(
-                "{field_addr} = getelementptr i8, ptr {record}, i64 {}",
+                "{field_addr} = getelementptr i8, ptr {base}, i64 {}",
                 8 * index
             ));
             self.emit(&format!(
                 "call void @klassic_gc_write(ptr {field_addr}, ptr {leaf})"
             ));
         }
-        self.emit(&format!("call void @klassic_gc_shadow_pop_n(i64 {n})"));
+        let result = self.fresh();
+        self.emit(&format!("{result} = load ptr, ptr {record_slot}"));
+        self.emit(&format!(
+            "call void @klassic_gc_shadow_pop_n(i64 {})",
+            n + 1
+        ));
         let shape_id = self.intern_shape(shape);
         Ok(Value {
-            operand: record,
+            operand: result,
             ty: LType::Record(shape_id),
         })
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,6 +128,20 @@ fn run(command: ParsedCommand) -> Result<(), u8> {
                 return build_with_c_backend(&input, &text, &output);
             }
             if command.config.llvm_backend {
+                // Gate the GC tuning flags rather than silently ignore them.
+                // The C collector always stores colored (non-canonical) heap
+                // pointers, so an unbarriered dereference already faults --
+                // --gc-poison is inherent. --gc-log / --gc-stress are not yet
+                // ported to the C collector.
+                if command.config.gc_log || command.config.gc_stress || command.config.gc_poison {
+                    eprintln!(
+                        "error: --gc-log / --gc-stress / --gc-poison are not accepted with \
+                         --backend llvm\n  note: the C collector always colors heap pointers, so \
+                         barrier coverage (the --gc-poison guarantee) is inherent; logging and \
+                         stress modes are not yet ported"
+                    );
+                    return Err(1);
+                }
                 return build_with_llvm_backend(&input, &text, &output);
             }
             // The default target is the detected host (macOS arm64 →
@@ -304,6 +318,30 @@ fn collect_user_modules(
 /// executable (release tarballs ship the library beside the binary,
 /// and a cargo build leaves it in the same `target/<profile>/`
 /// directory).
+/// Locate the C garbage collector's source (`runtime/gc/klassic_gc.c`) so
+/// clang can compile and link it into a heap-using program. `KLASSIC_GC_SRC`
+/// overrides; otherwise it is found relative to the source tree.
+fn find_gc_source() -> Option<std::path::PathBuf> {
+    if let Ok(explicit) = std::env::var("KLASSIC_GC_SRC") {
+        let path = std::path::PathBuf::from(explicit);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("runtime/gc/klassic_gc.c");
+    if manifest.is_file() {
+        return Some(manifest);
+    }
+    let exe = std::env::current_exe().ok()?;
+    let dir = exe.parent()?;
+    [
+        dir.join("runtime/gc/klassic_gc.c"),
+        dir.join("../../runtime/gc/klassic_gc.c"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.is_file())
+}
+
 fn find_runtime_staticlib() -> Option<std::path::PathBuf> {
     if let Ok(explicit) = std::env::var("KLASSIC_RT_LIB") {
         let path = std::path::PathBuf::from(explicit);
@@ -433,6 +471,20 @@ fn link_llvm_program(ir: &str, output: &Path) -> Result<(), u8> {
         .arg(output)
         .arg(&ir_path)
         .arg(&runtime);
+    // Programs that touch the heap call the C garbage collector; compile and
+    // link it in alongside the IR (clang builds the .c). Scalar programs never
+    // reference it, so it is only added when needed.
+    if ir.contains("@klassic_gc_alloc") {
+        let Some(gc_src) = find_gc_source() else {
+            eprintln!(
+                "error: runtime/gc/klassic_gc.c not found\n  help: set KLASSIC_GC_SRC to its \
+                 path, or pass an output ending in .ll and compile it yourself"
+            );
+            let _ = fs::remove_file(&ir_path);
+            return Err(1);
+        };
+        command.arg(&gc_src);
+    }
     if std::env::consts::OS == "linux" {
         command.args(["-lpthread", "-ldl", "-lm"]);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -472,9 +472,10 @@ fn link_llvm_program(ir: &str, output: &Path) -> Result<(), u8> {
         .arg(&ir_path)
         .arg(&runtime);
     // Programs that touch the heap call the C garbage collector; compile and
-    // link it in alongside the IR (clang builds the .c). Scalar programs never
-    // reference it, so it is only added when needed.
-    if ir.contains("@klassic_gc_alloc") {
+    // link it in alongside the IR (clang builds the .c). Key on an actual call
+    // site, not the (unconditional) declaration, so a scalar program is not
+    // forced to find the collector source it never uses.
+    if ir.contains("call ptr @klassic_gc_alloc(") {
         let Some(gc_src) = find_gc_source() else {
             eprintln!(
                 "error: runtime/gc/klassic_gc.c not found\n  help: set KLASSIC_GC_SRC to its \

--- a/tests/llvm_backend.rs
+++ b/tests/llvm_backend.rs
@@ -176,6 +176,21 @@ fn record_field_read_after_reassignment() {
 }
 
 #[test]
+fn record_with_bool_and_varied_arities() {
+    // A boolean field (boxed as i64, read back with a trunc), a single-field
+    // record, and a wider record exercise the box/unbox paths and slot
+    // indexing.
+    assert_llvm_matches_evaluator(
+        "val r = record { flag: true; n: 5 }\n\
+         println(if (r.flag) r.n else 99)\n\
+         val s = record { v: 42 }\n\
+         println(s.v)\n\
+         val big = record { a: 1; b: 2; c: 3; d: 4; e: 5 }\n\
+         println(big.a + big.c + big.e)\n",
+    );
+}
+
+#[test]
 fn record_survives_moving_collection() {
     // Churn enough short-lived records to force many moving collections while
     // a rooted survivor is kept; its fields must read back intact after being

--- a/tests/llvm_backend.rs
+++ b/tests/llvm_backend.rs
@@ -148,3 +148,45 @@ fn function_with_multiple_params_and_double() {
          println(avg(3.0, 4.0))\n",
     );
 }
+
+// --- Heap records through the garbage collector (M7) ------------------
+
+#[test]
+fn record_construct_and_field_access() {
+    assert_llvm_matches_evaluator(
+        "val r = record { x: 10; y: 20 }\n\
+         println(r.x + r.y)\n\
+         val p = record { a: 3.5; b: 1.25 }\n\
+         println(p.a + p.b)\n",
+    );
+}
+
+#[test]
+fn record_field_read_after_reassignment() {
+    // Fields are read through the load barrier; exercise several reads and
+    // arithmetic on a record held in a local.
+    assert_llvm_matches_evaluator(
+        "val point = record { x: 7; y: 11 }\n\
+         mutable sum = 0\n\
+         sum = sum + point.x\n\
+         sum = sum + point.y\n\
+         sum = sum + point.x * point.y\n\
+         println(sum)\n",
+    );
+}
+
+#[test]
+fn record_survives_moving_collection() {
+    // Churn enough short-lived records to force many moving collections while
+    // a rooted survivor is kept; its fields must read back intact after being
+    // relocated (the whole point of precise roots + the load barrier).
+    assert_llvm_matches_evaluator(
+        "val keeper = record { x: 314; y: 271 }\n\
+         mutable i = 0\n\
+         while (i < 200000) {\n\
+           val garbage = record { x: i; y: i }\n\
+           i = i + 1\n\
+         }\n\
+         println(keeper.x + keeper.y)\n",
+    );
+}

--- a/tests/llvm_gc_link.rs
+++ b/tests/llvm_gc_link.rs
@@ -1,0 +1,154 @@
+//! M7 foundation: proves the C garbage collector links and runs correctly
+//! when driven from clang-compiled LLVM IR through its real ABI -- the same
+//! calls the emitter will produce (`klassic_gc_init` / `klassic_gc_alloc` /
+//! shadow-stack push / color-on-store `klassic_gc_write` / a full collection
+//! / the inline load-barrier fast path validated in the M2 spike). The M2
+//! spike covered only the barrier; this exercises allocation, precise roots,
+//! and a whole mark/sweep/relocate cycle against the real collector. Gated on
+//! a clang >= 15 (opaque pointers) being present so CI without one stays green.
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(explicit) = std::env::var("KLASSIC_CLANG") {
+        return Some(explicit);
+    }
+    ["clang-18", "clang-17", "clang-16", "clang-15", "clang"]
+        .into_iter()
+        .find(|name| {
+            Command::new(name)
+                .arg("--version")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .is_ok_and(|status| status.success())
+        })
+        .map(str::to_owned)
+}
+
+/// Hand-written LLVM IR mirroring the emitter's eventual output: build a
+/// two-field record of two int leaves, keep them on the shadow stack, force a
+/// collection, then read a field back through the inline barrier fast path.
+/// RAW_BYTES = 1, POINTER_RECORD = 2 (see klassic_gc.h).
+const IR: &str = r#"
+target triple = "x86_64-pc-linux-gnu"
+
+@.fmt = private constant [5 x i8] c"%ld\0A\00"
+@gc_bad_mask   = external dso_local global i64
+@gc_strip_mask = external dso_local global i64
+
+declare void @klassic_gc_init()
+declare ptr @klassic_gc_alloc(i64, i64)
+declare void @klassic_gc_shadow_push(ptr)
+declare void @klassic_gc_shadow_pop_n(i64)
+declare void @klassic_gc_write(ptr, ptr)
+declare i64 @klassic_gc_load_barrier_slow(i64, ptr)
+declare void @klassic_gc_collect()
+declare i32 @printf(ptr, ...)
+
+define i32 @main() {
+entry:
+  call void @klassic_gc_init()
+
+  ; leaf_a = alloc(8, RAW_BYTES); *leaf_a = 100; root it
+  %la = call ptr @klassic_gc_alloc(i64 8, i64 1)
+  store i64 100, ptr %la
+  %slot_a = alloca ptr
+  store ptr %la, ptr %slot_a
+  call void @klassic_gc_shadow_push(ptr %slot_a)
+
+  ; leaf_b = alloc(8, RAW_BYTES); *leaf_b = 23; root it
+  %lb = call ptr @klassic_gc_alloc(i64 8, i64 1)
+  store i64 23, ptr %lb
+  %slot_b = alloca ptr
+  store ptr %lb, ptr %slot_b
+  call void @klassic_gc_shadow_push(ptr %slot_b)
+
+  ; pair = alloc(16, POINTER_RECORD); root it
+  %pair = call ptr @klassic_gc_alloc(i64 16, i64 2)
+  %slot_pair = alloca ptr
+  store ptr %pair, ptr %slot_pair
+  call void @klassic_gc_shadow_push(ptr %slot_pair)
+
+  ; color-on-store the fields (reload leaves from their roots first)
+  %la2 = load ptr, ptr %slot_a
+  %lb2 = load ptr, ptr %slot_b
+  %f0 = getelementptr i8, ptr %pair, i64 0
+  call void @klassic_gc_write(ptr %f0, ptr %la2)
+  %f1 = getelementptr i8, ptr %pair, i64 8
+  call void @klassic_gc_write(ptr %f1, ptr %lb2)
+
+  ; force a full mark/sweep/relocate cycle (roots get fixed)
+  call void @klassic_gc_collect()
+
+  ; reload the (possibly moved) pair from its root, read field 0 through the
+  ; inline load-barrier fast path, then dereference the leaf.
+  %pair2 = load ptr, ptr %slot_pair
+  %f0b = getelementptr i8, ptr %pair2, i64 0
+  %v = load i64, ptr %f0b
+  %bm = load i64, ptr @gc_bad_mask
+  %bad = and i64 %v, %bm
+  %isb = icmp ne i64 %bad, 0
+  br i1 %isb, label %slow, label %ok
+slow:
+  %healed = call i64 @klassic_gc_load_barrier_slow(i64 %v, ptr %f0b)
+  br label %ok
+ok:
+  %val = phi i64 [ %v, %entry ], [ %healed, %slow ]
+  %sm = load i64, ptr @gc_strip_mask
+  %raw = and i64 %val, %sm
+  %rawp = inttoptr i64 %raw to ptr
+  %leafval = load i64, ptr %rawp
+
+  call void @klassic_gc_shadow_pop_n(i64 3)
+  %r = call i32 (ptr, ...) @printf(ptr @.fmt, i64 %leafval)
+  ret i32 0
+}
+"#;
+
+#[test]
+fn c_gc_links_and_runs_from_llvm_ir() {
+    let Some(cc) = find_cc() else {
+        eprintln!("skipping: no clang >= 15 found");
+        return;
+    };
+    let gc_src = concat!(env!("CARGO_MANIFEST_DIR"), "/runtime/gc/klassic_gc.c");
+    let dir = std::env::temp_dir();
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    let ll = dir.join(format!("klassic-gc-link-{stamp}.ll"));
+    let exe = dir.join(format!("klassic-gc-link-{stamp}"));
+    std::fs::write(&ll, IR).expect("write IR");
+
+    let build = Command::new(&cc)
+        .args(["-O2", "-o"])
+        .arg(&exe)
+        .arg(&ll)
+        .arg(gc_src)
+        .args(["-lm"])
+        .output()
+        .expect("clang runs");
+    assert!(
+        build.status.success(),
+        "clang failed to build:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let run = Command::new(&exe).output().expect("program runs");
+    let _ = std::fs::remove_file(&ll);
+    let _ = std::fs::remove_file(&exe);
+    assert!(
+        run.status.success(),
+        "program crashed: {:?}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "100\n",
+        "the record's first field should read back as 100 after a collection"
+    );
+}


### PR DESCRIPTION
## What

Wires the C garbage collector (merged in #589) into the **LLVM backend**, giving
it its first heap type — structural records — and, with that, a moving garbage
collector running under `--backend llvm` (LLVM backend migration,
`docs/llvm-backend-plan.md`, M7). This is the milestone the migration was aiming
at: a heap-allocating klassic program compiled to LLVM IR, linked against the C
collector, survives many moving collections correctly.

## How records lower

A structural record becomes the collector's uniform "every slot is a heap
pointer" `POINTER_RECORD`:

- **Construction** (`record_literal`): each scalar field is boxed into an
  8-byte `RAW_BYTES` leaf via `klassic_gc_alloc`; each leaf is staged on the
  shadow stack before the next allocation; the record is then allocated and its
  fields stored *colored* through `klassic_gc_write`, reloading each leaf from
  its (possibly relocated) shadow slot first; the transient leaf roots are
  popped.
- **Field access** (`field_access`): a barriered load of the record slot — the
  inline fast path validated in the M2 spike (`load`, `and gc_bad_mask`, branch
  to the out-of-line `klassic_gc_load_barrier_slow`, `phi`, `and
  gc_strip_mask`) — followed by an unbox of the leaf.
- **Precise roots**: heap locals are pushed on the shadow stack at declaration
  and popped at scope close (balanced per loop iteration, so a churning loop's
  stack stays bounded), so a moving collection updates every live pointer in
  place.

## Build and flags

`link_llvm_program` compiles and links `runtime/gc/klassic_gc.c` (located via
`find_gc_source` / `KLASSIC_GC_SRC`) whenever the emitted IR references the
collector; scalar programs are unaffected. `--gc-log` / `--gc-stress` /
`--gc-poison` are gated with a clear diagnostic rather than silently ignored —
the C collector always stores colored (non-canonical) heap pointers, so barrier
coverage (the `--gc-poison` guarantee) is inherent, and logging/stress modes are
not yet ported.

## Tests

Differential tests (`eval == --backend llvm`) cover record construction, field
reads, boolean-field box/unbox, varied record arities, and — the payoff — a
200k-record churn that forces many moving collections while a rooted survivor's
fields read back intact. A separate integration test drives the full C-GC ABI
from hand-written IR. Verified `AddressSanitizer` + `UBSan` clean end to end
(ASLR pinned to dodge the WSL2 sanitizer-startup flakiness noted in #589).

Enums reuse the same wiring (a `POINTER_RECORD` with the tag in slot 0) and are
the natural next heap type; strings, closures, and the stdlib follow.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
and the full `cargo test` suite are green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
