### PR TITLE
feat: safepoint handshake + codegen polls (true-zgc M3)

### DIFF
--- a/crates/klassic-native/src/llvm.rs
+++ b/crates/klassic-native/src/llvm.rs
@@ -200,7 +200,14 @@ impl Emitter {
             return;
         }
         let flag = self.fresh();
-        self.emit(&format!("{flag} = load i64, ptr @gc_handshake_requested"));
+        // Atomic (relaxed) load: the GC thread raises/clears this flag with an
+        // atomic release store, so a plain load would be a data race (UB) once
+        // that thread exists -- worst case the poll never observes the request
+        // and the handshake deadlocks. `monotonic` suffices for the flag test;
+        // the handshake itself re-reads the phase with acquire ordering.
+        self.emit(&format!(
+            "{flag} = load atomic i64, ptr @gc_handshake_requested monotonic, align 8"
+        ));
         let need = self.fresh();
         self.emit(&format!("{need} = icmp ne i64 {flag}, 0"));
         let call = self.fresh_label("hscall");

--- a/crates/klassic-native/src/llvm.rs
+++ b/crates/klassic-native/src/llvm.rs
@@ -100,6 +100,9 @@ struct Emitter {
     scope_roots: Vec<u32>,
     /// interned record field layouts: shape id -> [(field name, field type)].
     shapes: Vec<Vec<(String, LType)>>,
+    /// whether to emit GC safepoint polls (only for heap-using programs,
+    /// which link the collector); scalar programs get none.
+    emit_polls: bool,
 }
 
 impl Emitter {
@@ -187,6 +190,26 @@ impl Emitter {
         self.next_temp += 1;
         self.allocas.push_str(&format!("  {slot} = alloca ptr\n"));
         slot
+    }
+
+    /// Emit a GC safepoint poll: if a handshake is pending, call the collector
+    /// to scan this thread's roots and ack. On the hot path this is a single
+    /// load + not-taken branch. No-op for scalar programs (no collector).
+    fn emit_poll(&mut self) {
+        if !self.emit_polls {
+            return;
+        }
+        let flag = self.fresh();
+        self.emit(&format!("{flag} = load i64, ptr @gc_handshake_requested"));
+        let need = self.fresh();
+        self.emit(&format!("{need} = icmp ne i64 {flag}, 0"));
+        let call = self.fresh_label("hscall");
+        let cont = self.fresh_label("hscont");
+        self.emit(&format!("br i1 {need}, label %{call}, label %{cont}"));
+        self.bind(&call);
+        self.emit("call void @klassic_gc_handshake()");
+        self.emit(&format!("br label %{cont}"));
+        self.bind(&cont);
     }
 
     /// Intern a record field layout, returning its shape id.
@@ -696,6 +719,7 @@ impl Emitter {
                 ));
                 self.bind(&body_label);
                 self.statement(body)?;
+                self.emit_poll(); /* safepoint at the loop back-edge */
                 self.emit(&format!("br label %{cond_label}"));
                 self.bind(&after_label);
                 Ok(())
@@ -816,10 +840,107 @@ fn collect_functions(expr: &Expr, emitter: &mut Emitter) -> Result<(), Diagnosti
     Ok(())
 }
 
+/// Emit every user function and `main` into an IR code string. Run once to
+/// detect heap use, then again with `emitter.emit_polls` set if the program
+/// allocates (so safepoint polls land in every function of a GC program).
+fn emit_functions_and_main(emitter: &mut Emitter, expr: &Expr) -> Result<String, Diagnostic> {
+    let mut code = String::new();
+    let function_count = emitter.functions.len();
+    for index in 0..function_count {
+        let (name, params, ret, body) = {
+            let function = &emitter.functions[index];
+            (
+                function.name.clone(),
+                function.params.clone(),
+                function.ret,
+                function.body.clone(),
+            )
+        };
+        emitter.allocas.clear();
+        emitter.body.clear();
+        emitter.next_temp = 0;
+        emitter.next_label = 0;
+        emitter.scopes.clear();
+        emitter.scope_roots.clear();
+        emitter.open_scope();
+        emitter.current_block = "entry".to_owned();
+        let mut param_sig = Vec::with_capacity(params.len());
+        for (param, ty) in &params {
+            let incoming = format!("%arg_{param}");
+            param_sig.push(format!("{} {incoming}", ty.llvm()));
+            let ptr = emitter.declare_local(param, *ty);
+            if *ty != LType::Unit {
+                emitter
+                    .body
+                    .push_str(&format!("  store {} {incoming}, ptr {ptr}\n", ty.llvm()));
+            }
+        }
+        emitter.emit_poll(); // safepoint at function entry
+        let value = emitter.expr(&body)?;
+        if value.ty != ret {
+            return Err(unsupported(
+                body.span(),
+                "a function body of a different type than its return annotation",
+            ));
+        }
+        emitter.close_scope();
+        let mangled = format!("klassic_{name}");
+        code.push_str(&format!(
+            "define {} @{mangled}({}) {{\nentry:\n",
+            ret.llvm(),
+            param_sig.join(", ")
+        ));
+        code.push_str(&emitter.allocas);
+        code.push_str(&emitter.body);
+        if ret == LType::Unit {
+            code.push_str("  ret void\n");
+        } else {
+            code.push_str(&format!("  ret {} {}\n", ret.llvm(), value.operand));
+        }
+        code.push_str("}\n\n");
+    }
+
+    // main: every non-def top-level statement, in order.
+    emitter.allocas.clear();
+    emitter.body.clear();
+    emitter.next_temp = 0;
+    emitter.next_label = 0;
+    emitter.scopes.clear();
+    emitter.scope_roots.clear();
+    emitter.open_scope();
+    emitter.current_block = "entry".to_owned();
+    emitter.emit_poll(); // safepoint at program entry
+    let statements: Vec<&Expr> = match expr {
+        Expr::Block { expressions, .. } => expressions.iter().collect(),
+        other => vec![other],
+    };
+    for statement in statements {
+        emitter.statement(statement)?;
+    }
+    emitter.close_scope();
+    code.push_str("define i32 @main() {\nentry:\n");
+    code.push_str(&emitter.allocas);
+    code.push_str(&emitter.body);
+    code.push_str("  ret i32 0\n}\n");
+    Ok(code)
+}
+
 /// Emit the whole program as an LLVM IR module.
 pub(crate) fn emit_llvm_program(expr: &Expr) -> Result<String, Diagnostic> {
     let mut emitter = Emitter::default();
     collect_functions(expr, &mut emitter)?;
+
+    // First pass with no polls detects whether the program allocates; if so,
+    // re-emit with safepoint polls (which reference the collector's handshake
+    // symbols, only linked for heap programs).
+    let code = emit_functions_and_main(&mut emitter, expr)?;
+    let uses_heap = code.contains("call ptr @klassic_gc_alloc(");
+    let code = if uses_heap {
+        emitter.emit_polls = true;
+        emit_functions_and_main(&mut emitter, expr)?
+    } else {
+        code
+    };
 
     let mut out = String::new();
     out.push_str("; generated by klassic --backend llvm\n");
@@ -838,88 +959,13 @@ pub(crate) fn emit_llvm_program(expr: &Expr) -> Result<String, Diagnostic> {
     out.push_str("declare void @klassic_gc_shadow_push(ptr)\n");
     out.push_str("declare void @klassic_gc_shadow_pop_n(i64)\n");
     out.push_str("declare void @klassic_gc_write(ptr, ptr)\n");
-    out.push_str("declare i64 @klassic_gc_load_barrier_slow(i64, ptr)\n\n");
-
-    // User functions. The subset treats a function body as a single
-    // expression returned to the caller.
-    let function_count = emitter.functions.len();
-    for index in 0..function_count {
-        let (name, params, ret, body) = {
-            let function = &emitter.functions[index];
-            (
-                function.name.clone(),
-                function.params.clone(),
-                function.ret,
-                // clone the body so the emitter can borrow &mut self
-                function.body.clone(),
-            )
-        };
-        emitter.allocas.clear();
-        emitter.body.clear();
-        emitter.next_temp = 0;
-        emitter.next_label = 0;
-        emitter.scopes.clear();
-        emitter.scope_roots.clear();
-        emitter.open_scope();
-        emitter.current_block = "entry".to_owned();
-        // Bind parameters: alloca + store the incoming SSA value.
-        let mut param_sig = Vec::with_capacity(params.len());
-        for (param, ty) in &params {
-            let incoming = format!("%arg_{param}");
-            param_sig.push(format!("{} {incoming}", ty.llvm()));
-            let ptr = emitter.declare_local(param, *ty);
-            if *ty != LType::Unit {
-                emitter
-                    .body
-                    .push_str(&format!("  store {} {incoming}, ptr {ptr}\n", ty.llvm()));
-            }
-        }
-        let value = emitter.expr(&body)?;
-        if value.ty != ret {
-            return Err(unsupported(
-                body.span(),
-                "a function body of a different type than its return annotation",
-            ));
-        }
-        emitter.close_scope();
-        let mangled = format!("klassic_{name}");
-        out.push_str(&format!(
-            "define {} @{mangled}({}) {{\nentry:\n",
-            ret.llvm(),
-            param_sig.join(", ")
-        ));
-        out.push_str(&emitter.allocas);
-        out.push_str(&emitter.body);
-        if ret == LType::Unit {
-            out.push_str("  ret void\n");
-        } else {
-            out.push_str(&format!("  ret {} {}\n", ret.llvm(), value.operand));
-        }
-        out.push_str("}\n\n");
+    out.push_str("declare i64 @klassic_gc_load_barrier_slow(i64, ptr)\n");
+    if uses_heap {
+        out.push_str("@gc_handshake_requested = external dso_local global i64\n");
+        out.push_str("declare void @klassic_gc_handshake()\n");
     }
-
-    // main: every non-def top-level statement, in order.
-    emitter.allocas.clear();
-    emitter.body.clear();
-    emitter.next_temp = 0;
-    emitter.next_label = 0;
-    emitter.scopes.clear();
-    emitter.scope_roots.clear();
-    emitter.open_scope();
-    emitter.current_block = "entry".to_owned();
-    let statements: Vec<&Expr> = match expr {
-        Expr::Block { expressions, .. } => expressions.iter().collect(),
-        other => vec![other],
-    };
-    for statement in statements {
-        emitter.statement(statement)?;
-    }
-    emitter.close_scope();
-    out.push_str("define i32 @main() {\nentry:\n");
-    out.push_str(&emitter.allocas);
-    out.push_str(&emitter.body);
-    out.push_str("  ret i32 0\n}\n");
-
+    out.push('\n');
+    out.push_str(&code);
     Ok(out)
 }
 

--- a/runtime/gc/klassic_gc.c
+++ b/runtime/gc/klassic_gc.c
@@ -94,6 +94,11 @@ uint64_t gc_bad_mask = GC_COLOR_M0 | GC_COLOR_M1;
 uint64_t gc_strip_mask = ~GC_COLOR_MASK;
 static uint64_t g_mark_color = GC_COLOR_M0; /* alternates M0<->M1 each mark */
 
+/* Safepoint handshake flag (dso_local: the emitted poll reads it). Raised by
+ * the background GC thread (M4) at a phase transition; each mutator acks at
+ * its next poll. Never set until the GC thread lands, so polls are no-ops. */
+uint64_t gc_handshake_requested = 0;
+
 /* Set the good color and derive the bad mask (the two other color bits). */
 static void gc_set_good(uint64_t good) {
     gc_good_color = good;
@@ -684,6 +689,26 @@ void klassic_gc_collect(void) {
         gc_mark_end(); /* -> Relocate or Idle */
     }
     gc_relocate_drain();
+}
+
+/* Safepoint handshake: called from a mutator's poll when gc_handshake_requested
+ * is set. Scans this thread's roots into the collector per the current phase
+ * (mark them during Mark, remap them during Relocate) -- the O(roots) work a
+ * phase transition needs from each mutator -- then acks by clearing the flag.
+ * Dormant until the GC thread (M4) raises the flag; M4 also makes the roots
+ * per-thread and the ack a barrier across all registered mutators. */
+void klassic_gc_handshake(void) {
+    uint64_t phase = __atomic_load_n(&g_phase, __ATOMIC_ACQUIRE);
+    if (phase == GC_PHASE_MARK) {
+        for (uint64_t i = 0; i < g_shadow_top; i++) {
+            mark_visit(*g_shadow[i]);
+        }
+    } else if (phase == GC_PHASE_RELOCATE) {
+        for (uint64_t i = 0; i < g_shadow_top; i++) {
+            relocate_root(g_shadow[i]);
+        }
+    }
+    __atomic_store_n(&gc_handshake_requested, 0, __ATOMIC_RELEASE); /* ack */
 }
 
 /* Poll the phase machine from an allocation point: proactively start a cycle

--- a/runtime/gc/klassic_gc.h
+++ b/runtime/gc/klassic_gc.h
@@ -97,6 +97,17 @@ void *klassic_gc_read(void **slot);
 /* Store a heap pointer into a slot, coloring it good (null stays null). */
 void klassic_gc_write(void **slot, void *value);
 
+/* --- Safepoint handshake (true-zgc M3) --------------------------- *
+ * The generated code polls `gc_handshake_requested` at loop back-edges and
+ * function entries (a dso_local global, so the poll is a single
+ * `cmpq $0, gc_handshake_requested(%rip); jne` and predicts not-taken).
+ * When a background GC thread (M4) needs a consistent root set at a phase
+ * transition it raises the flag; each mutator, at its next poll, calls
+ * klassic_gc_handshake() to scan its own roots and ack. Until the GC thread
+ * lands the flag is never set, so polls are no-ops. */
+extern uint64_t gc_handshake_requested;
+void klassic_gc_handshake(void);
+
 /* Test/observability hooks. */
 uint64_t klassic_gc_collection_count(void);
 uint64_t klassic_gc_live_region_count(void);

--- a/tests/llvm_backend.rs
+++ b/tests/llvm_backend.rs
@@ -191,6 +191,26 @@ fn record_with_bool_and_varied_arities() {
 }
 
 #[test]
+fn record_allocating_function_in_a_loop() {
+    // A function that allocates a record, called from a loop: exercises the
+    // GC safepoint polls emitted at the function entry and the loop back-edge
+    // (dormant here -- no handshake pending -- so output must be unchanged).
+    assert_llvm_matches_evaluator(
+        "def sumRec(a: Int, b: Int): Int = {\n\
+           val r = record { x: a; y: b }\n\
+           r.x + r.y\n\
+         }\n\
+         mutable total = 0\n\
+         mutable i = 0\n\
+         while (i < 1000) {\n\
+           total = total + sumRec(i, 1)\n\
+           i = i + 1\n\
+         }\n\
+         println(total)\n",
+    );
+}
+
+#[test]
 fn record_survives_moving_collection() {
     // Churn enough short-lived records to force many moving collections while
     // a rooted survivor is kept; its fields must read back intact after being


### PR DESCRIPTION
## What

true-ZGC M3 (`docs/true-zgc-plan.md`): lay the **safepoint infrastructure** a
background GC thread needs to rendezvous with the mutators. Everything is
dormant until the GC thread lands (M4) — no behavior change today.

## How

- **C side.** A `dso_local` `gc_handshake_requested` flag and
  `klassic_gc_handshake()`: when a mutator's poll finds the flag set, it scans
  *this thread's* roots into the collector per the current phase (mark during
  Mark, remap during Relocate) and acks by clearing the flag. Never set yet, so
  it never runs.
- **Emitter side.** The LLVM backend emits a poll — load `gc_handshake_requested`,
  a not-taken branch to a call of the handshake — at each **function entry** and
  **loop back-edge**, but only for programs that allocate. A two-pass emit keys
  on a real `call ptr @klassic_gc_alloc(` site (no false negatives), so scalar
  programs emit zero polls and never reference the handshake symbols, while heap
  programs — which already link the collector — get full coverage.

## Tests

Differential oracle (`eval == --backend llvm`) green, including a new
record-allocating function driven in a loop (exercises both poll sites). Scalar
programs emit zero polls (verified). The record churn runs correctly (585) and
is ASan-clean with polls present. `cargo fmt` / `clippy` / full `cargo test`
green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
