### PR TITLE
feat: --gc-log pause measurement — completes true-zgc (M6)

### DIFF
--- a/docs/true-zgc-plan.md
+++ b/docs/true-zgc-plan.md
@@ -1,12 +1,15 @@
 # Concurrent ZGC for klassic (the "true ZGC" plan)
 
-Status: **M5 landed — genuinely concurrent AND multi-mutator.** M1
-(incremental relocation), M2 (thread-safe shared state), M3 (safepoint polls),
-and M4 (background GC thread + concurrent mark/relocate) merged first; M5 makes
-the collector correct for N mutator threads: per-thread shadow stacks + TLABs
-(a thread table), a parked-count all-mutator handshake, and thread-safe init,
-verified under ThreadSanitizer with several mutator threads churning while the
-GC thread cycles. Remaining: M6 (pause measurement + `--gc-log`). Owner decision (2026-07-09): go all the way to a *truly
+Status: **COMPLETE — M1 through M6 are all on `main`.** The collector is a
+truly concurrent, multi-mutator ZGC: M1 (incremental relocation), M2
+(thread-safe shared state), M3 (safepoint polls), M4 (background GC thread +
+concurrent mark/relocate), M5 (per-thread shadow stacks/TLABs + a parked-count
+all-mutator handshake + thread-safe init), and M6 (`--gc-log` pause
+measurement). A background GC thread marks and relocates while N mutator
+threads keep running; the only stop-the-world windows are the two O(roots)
+phase-transition handshakes per cycle, and `--gc-log` reports their measured
+cost. What remains is not a milestone but ongoing tuning (make the sweep
+concurrent so even the handshake shrinks; trigger/backpressure tuning). Owner decision (2026-07-09): go all the way to a *truly
 concurrent* collector — a background GC thread that marks and relocates while
 the compiled program keeps running, with O(roots) pauses only at
 phase-transition handshakes. This is the execution model that makes ZGC ZGC,
@@ -238,10 +241,20 @@ verify on main. The evaluator stays the differential oracle for the LLVM path.
     and re-reading its own survivor across concurrent moves) is wired into
     `run_tests.sh`; clean under ASan+UBSan and TSan, including 12x parallel
     (48 concurrent mutators + 12 GC threads) with zero races or deadlocks.
-- **M6 — Pauses + observability.** Confirm pauses are O(roots) all-mutator
-  handshakes (measure with the clock shim); `--gc-log` reports collections,
-  bytes, and max/total handshake pause at exit. Tune the trigger and
-  backpressure so mutators rarely block.
+- **M6 — Pauses + observability. LANDED.** `--gc-log` is ported to the C
+  collector (behind a `-DKLASSIC_GC_LOG` compile define threaded from the CLI
+  flag through `link_llvm_program`, so a normal build carries no timing on the
+  transition path). `gc_rendezvous` times each stop-the-world window -- the
+  phase-transition `action()`, entered only once every mutator has parked --
+  with `clock_gettime(CLOCK_MONOTONIC)`, and an `atexit` handler reports
+  collections, relocations, bytes, and the pause count / max / total on stderr.
+  A 200k-record churn shows pauses in the tens of microseconds (e.g.
+  `pause_max=33314ns` across 68 handshakes), the evidence that the world stops
+  only for O(roots)-ish handshakes, not for the mark or relocate. The one
+  O(heap) component still inside the pause is the sweep (the documented M4
+  first-version simplification); making it concurrent is the next tuning step
+  and would shrink the measured max further. Covered by
+  `gc_log_reports_pause_statistics` in `tests/llvm_backend.rs`.
 
 ## Risks and honest caveats
 

--- a/runtime/gc/klassic_gc.c
+++ b/runtime/gc/klassic_gc.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
+#include <time.h> /* clock_gettime for --gc-log pause measurement */
 
 /* --- Region heap geometry ---------------------------------------- */
 #define REGION_SHIFT 17
@@ -71,6 +72,40 @@ static uint64_t g_worklist_top;
 /* The current-cycle header mark bit (alternates each collection). */
 static uint64_t g_header_mark = KLASSIC_GC_HMARK1;
 static uint64_t g_collections;
+
+/* --- Optional statistics (--gc-log; compiled only with -DKLASSIC_GC_LOG) --- *
+ * The point of a concurrent collector is O(roots) pauses: the mutators are
+ * stopped only for a phase-transition handshake (mask flip + root scan +
+ * sweep/select), never for the whole mark or relocate. We time each such
+ * stop-the-world window (the GC-side action, entered only once every mutator
+ * has parked) and, at exit, report the collection count, bytes allocated, and
+ * the max / total pause -- the evidence that the pauses are small and bounded.
+ * Guarded so a normal build carries no clock_gettime on the transition path. */
+#ifdef KLASSIC_GC_LOG
+static uint64_t g_stat_bytes;         /* total bytes handed out by gc_alloc */
+static uint64_t g_stat_pause_ns_max;  /* longest single STW handshake (ns) */
+static uint64_t g_stat_pause_ns_total; /* summed STW handshake time (ns) */
+static uint64_t g_stat_pauses;        /* number of STW handshakes */
+
+static uint64_t gc_now_ns(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+}
+
+static void gc_log_atexit(void) {
+    fprintf(stderr,
+            "klassic gc: collections=%llu relocations=%llu bytes=%llu "
+            "pauses=%llu pause_max=%lluns pause_total=%lluns\n",
+            (unsigned long long)__atomic_load_n(&g_collections, __ATOMIC_RELAXED),
+            (unsigned long long)__atomic_load_n(&g_relocations, __ATOMIC_RELAXED),
+            (unsigned long long)__atomic_load_n(&g_stat_bytes, __ATOMIC_RELAXED),
+            (unsigned long long)__atomic_load_n(&g_stat_pauses, __ATOMIC_RELAXED),
+            (unsigned long long)__atomic_load_n(&g_stat_pause_ns_max, __ATOMIC_RELAXED),
+            (unsigned long long)__atomic_load_n(&g_stat_pause_ns_total,
+                                                __ATOMIC_RELAXED));
+}
+#endif
 
 /* --- Incremental phase machine ----------------------------------- *
  * Idle -> MarkStart -> Mark (quanta) -> MarkEnd -> Relocate (quanta) ->
@@ -201,6 +236,9 @@ static void gc_init_once(void) {
     g_free_head = NULL;
     g_header_mark = KLASSIC_GC_HMARK1;
     g_collections = 0;
+#ifdef KLASSIC_GC_LOG
+    atexit(gc_log_atexit); /* report collection/pause stats when the program ends */
+#endif
     __atomic_store_n(&g_initialized, 1, __ATOMIC_RELEASE);
     if (pthread_create(&g_gc_thread, NULL, gc_worker, NULL) != 0) {
         fprintf(stderr, "klassic gc: cannot start the GC thread\n");
@@ -380,6 +418,9 @@ void *klassic_gc_alloc(uint64_t size, uint64_t type_tag) {
         fprintf(stderr, "klassic gc: object larger than a region is unsupported\n");
         exit(1);
     }
+#ifdef KLASSIC_GC_LOG
+    __atomic_add_fetch(&g_stat_bytes, total, __ATOMIC_RELAXED);
+#endif
     /* Park if the GC thread is waiting for a safepoint, then -- under memory
      * pressure -- ask it (asynchronously) for a cycle and keep running: the
      * mutator marks via its barrier and parks at polls while the GC thread
@@ -668,7 +709,7 @@ static void flush_all_tlabs(void) {
  * old bit would be misread as live when that bit becomes current again two
  * cycles later (a resurrection/leak). */
 static void gc_sweep(void) {
-    g_collections++;
+    __atomic_fetch_add(&g_collections, 1, __ATOMIC_RELAXED);
     flush_all_tlabs();
     uint64_t stale_clear = ~(uint64_t)(KLASSIC_GC_HMARK_BOTH ^ g_header_mark);
     for (uint64_t idx = 0; idx < g_committed; idx++) {
@@ -1031,7 +1072,20 @@ static void gc_rendezvous(void (*action)(void)) {
     while (g_hs_parked_cnt < expected) {
         pthread_cond_wait(&g_hs_cond, &g_hs_lock);
     }
+    /* Every mutator is now parked: the stop-the-world window is exactly the
+     * phase-transition action (O(roots): mask flip + root scan + sweep/select). */
+#ifdef KLASSIC_GC_LOG
+    uint64_t t0 = gc_now_ns();
+#endif
     action();
+#ifdef KLASSIC_GC_LOG
+    uint64_t ns = gc_now_ns() - t0;
+    __atomic_add_fetch(&g_stat_pause_ns_total, ns, __ATOMIC_RELAXED);
+    __atomic_add_fetch(&g_stat_pauses, 1, __ATOMIC_RELAXED);
+    if (ns > __atomic_load_n(&g_stat_pause_ns_max, __ATOMIC_RELAXED)) {
+        __atomic_store_n(&g_stat_pause_ns_max, ns, __ATOMIC_RELAXED);
+    }
+#endif
     __atomic_store_n(&gc_handshake_requested, 0, __ATOMIC_RELEASE);
     pthread_cond_broadcast(&g_hs_cond);
     pthread_mutex_unlock(&g_hs_lock);

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,12 @@ fn build_with_c_backend(input: &Path, text: &str, output: &Path) -> Result<(), u
 /// the output name ends in `.ll`, compile and link it with clang against
 /// the bundled runtime staticlib (migration plan
 /// `docs/llvm-backend-plan.md`).
-fn build_with_llvm_backend(input: &Path, text: &str, output: &Path) -> Result<(), u8> {
+fn build_with_llvm_backend(
+    input: &Path,
+    text: &str,
+    output: &Path,
+    gc_log: bool,
+) -> Result<(), u8> {
     let ir = match compile_source_to_llvm(&input.display().to_string(), text) {
         Ok(ir) => ir,
         Err(error) => {
@@ -59,7 +64,7 @@ fn build_with_llvm_backend(input: &Path, text: &str, output: &Path) -> Result<()
         }
         return Ok(());
     }
-    link_llvm_program(&ir, output)
+    link_llvm_program(&ir, output, gc_log)
 }
 
 fn write_executable_output(output: &Path, bytes: &[u8]) -> Result<(), u8> {
@@ -129,20 +134,19 @@ fn run(command: ParsedCommand) -> Result<(), u8> {
             }
             if command.config.llvm_backend {
                 // Gate the GC tuning flags rather than silently ignore them.
-                // The C collector always stores colored (non-canonical) heap
-                // pointers, so an unbarriered dereference already faults --
-                // --gc-poison is inherent. --gc-log / --gc-stress are not yet
-                // ported to the C collector.
-                if command.config.gc_log || command.config.gc_stress || command.config.gc_poison {
+                // --gc-log is supported (below); the C collector always stores
+                // colored (non-canonical) heap pointers, so an unbarriered
+                // dereference already faults -- --gc-poison is inherent. Only
+                // --gc-stress is not yet ported to the C collector.
+                if command.config.gc_stress || command.config.gc_poison {
                     eprintln!(
-                        "error: --gc-log / --gc-stress / --gc-poison are not accepted with \
-                         --backend llvm\n  note: the C collector always colors heap pointers, so \
-                         barrier coverage (the --gc-poison guarantee) is inherent; logging and \
-                         stress modes are not yet ported"
+                        "error: --gc-stress / --gc-poison are not accepted with --backend llvm\n  \
+                         note: the C collector always colors heap pointers, so barrier coverage \
+                         (the --gc-poison guarantee) is inherent; --gc-stress is not yet ported"
                     );
                     return Err(1);
                 }
-                return build_with_llvm_backend(&input, &text, &output);
+                return build_with_llvm_backend(&input, &text, &output, command.config.gc_log);
             }
             // The default target is the detected host (macOS arm64 →
             // the direct Mach-O backend, Linux x86_64 → direct ELF);
@@ -440,7 +444,7 @@ fn find_opaque_pointer_clang() -> Option<String> {
 
 /// Compile a textual LLVM IR module with clang and link it against the
 /// bundled runtime staticlib (migration plan `docs/llvm-backend-plan.md`).
-fn link_llvm_program(ir: &str, output: &Path) -> Result<(), u8> {
+fn link_llvm_program(ir: &str, output: &Path, gc_log: bool) -> Result<(), u8> {
     let Some(runtime) = find_runtime_staticlib() else {
         eprintln!(
             "error: libklassic_runtime.a not found\n  help: set KLASSIC_RT_LIB to its path, or \
@@ -485,6 +489,11 @@ fn link_llvm_program(ir: &str, output: &Path) -> Result<(), u8> {
             return Err(1);
         };
         command.arg(&gc_src);
+        // --gc-log compiles the collector's statistics + at-exit report in
+        // (zero cost otherwise: the timing lives behind this define).
+        if gc_log {
+            command.arg("-DKLASSIC_GC_LOG=1");
+        }
     }
     if std::env::consts::OS == "linux" {
         command.args(["-lpthread", "-ldl", "-lm"]);

--- a/tests/llvm_backend.rs
+++ b/tests/llvm_backend.rs
@@ -225,3 +225,65 @@ fn record_survives_moving_collection() {
          println(keeper.x + keeper.y)\n",
     );
 }
+
+#[test]
+fn gc_log_reports_pause_statistics() {
+    // --gc-log builds the C collector with its statistics + at-exit report
+    // compiled in (true-zgc M6). The churn forces collections; the program's
+    // stdout must be unchanged and a single stats line must appear on stderr
+    // reporting the collection count and the O(roots) handshake pauses.
+    let Some(clang) = find_clang() else {
+        eprintln!("skipping: no clang >= 15 found");
+        return;
+    };
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let src = dir.join(format!("klassic_gclog_{stamp}.kl"));
+    let bin = dir.join(format!("klassic_gclog_{stamp}.bin"));
+    let source = "val keeper = record { x: 1; y: 2 }\n\
+                  mutable i = 0\n\
+                  while (i < 100000) {\n\
+                    val garbage = record { x: i; y: i }\n\
+                    i = i + 1\n\
+                  }\n\
+                  println(keeper.x + keeper.y)\n";
+    std::fs::write(&src, source).expect("write temp source");
+
+    let build = Command::new(klassic_bin())
+        .env("KLASSIC_CLANG", &clang)
+        .args(["--backend", "llvm", "--gc-log", "build"])
+        .arg(&src)
+        .arg("-o")
+        .arg(&bin)
+        .output()
+        .expect("llvm --gc-log build runs");
+    assert!(
+        build.status.success(),
+        "--backend llvm --gc-log build failed\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let run = Command::new(&bin).output().expect("compiled binary runs");
+    let _ = std::fs::remove_file(&src);
+    let _ = std::fs::remove_file(&bin);
+    assert!(
+        run.status.success(),
+        "compiled binary crashed\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "3\n",
+        "stdout unchanged"
+    );
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    assert!(
+        stderr.contains("klassic gc:")
+            && stderr.contains("collections=")
+            && stderr.contains("pause_max="),
+        "expected a GC stats line on stderr, got:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## true-zgc M6 — `--gc-log` pause measurement (completes the plan)

The final milestone of `docs/true-zgc-plan.md`. With M1–M5 on `main`, the
collector is already a truly concurrent, multi-mutator ZGC — a background GC
thread marks and relocates while N mutator threads run, stopping the world only
for two O(roots) phase-transition handshakes per cycle. M6 makes that pause
**observable**, which is what the whole design exists to minimize.

### What changed

- `--gc-log` is ported to the C collector. `gc_rendezvous` times each
  stop-the-world window — the phase-transition `action()`, entered only once
  every mutator has parked, so it is exactly the O(roots) work (mask flip +
  root scan + sweep/select) — with `clock_gettime(CLOCK_MONOTONIC)`. An
  `atexit` handler prints one line on stderr: collections, relocations, bytes,
  and pause count / max / total.
- All of it sits behind `-DKLASSIC_GC_LOG`, so a normal build carries no timing
  on the transition path. The CLI `--gc-log` flag threads the define through
  `link_llvm_program`; `--backend llvm` now accepts `--gc-log` (only
  `--gc-stress` / `--gc-poison` remain gated).
- `g_collections` becomes a relaxed atomic (the reporter reads it across
  threads).

### Evidence

A 200k-record churn reports e.g.:

```
klassic gc: collections=34 relocations=104 bytes=19200096 pauses=68 pause_max=33314ns pause_total=1013182ns
```

Pauses in the tens of microseconds across dozens of handshakes — the world
stops only for O(roots)-ish handshakes, not for the mark or relocate phases.
The one O(heap) component still inside the pause is the sweep (the documented
M4 first-version simplification); making it concurrent is the next tuning step
and would shrink the measured max further.

### Verification

- New `gc_log_reports_pause_statistics` (`tests/llvm_backend.rs`): builds a
  churn program with `--backend llvm --gc-log`, asserts the stats line appears
  on stderr and stdout is unchanged.
- `runtime/gc/run_tests.sh` (non-logging build — single + multi-mutator, ASan
  and TSan), the `llvm_backend` differential suite, `llvm_gc`, full
  `cargo test`, `cargo fmt --check`, and `clippy -D warnings` all green.

With this merged, the entire `docs/true-zgc-plan.md` (M1–M6) is on `main`: a
complete truly-concurrent ZGC for klassic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
