### PR TITLE
fix: moving-collector safepoint contract — poll-free barriers + harness discipline

### DIFF
--- a/runtime/gc/gc_mt_test.c
+++ b/runtime/gc/gc_mt_test.c
@@ -30,10 +30,23 @@ static int64_t *make_leaf(int64_t v) {
     p[0] = v;
     return p;
 }
+/* The pair's own allocation is a safepoint: with a MOVING collector the GC
+ * may relocate a and b's targets during it and update every ROOTED slot --
+ * but not unrooted copies. So the parameters themselves must be rooted across
+ * the allocation and re-read from their (GC-updated) slots afterwards. This is
+ * exactly the discipline the compiled backend follows: record_literal stages
+ * every field value in a shadow slot and reloads it from that slot after the
+ * record's allocation. Holding a pre-safepoint copy instead is a
+ * precise-rooting violation that leaves a stale from-space pointer in the new
+ * record's field -- an allocate-black record is never traced, so nothing would
+ * ever remap it, and the from-space region is later freed under it. */
 static void **make_pair(void *a, void *b) {
+    klassic_gc_shadow_push(&a);
+    klassic_gc_shadow_push(&b);
     void **p = (void **)klassic_gc_alloc(16, KLASSIC_GC_POINTER_RECORD);
-    klassic_gc_write(&p[0], a);
-    klassic_gc_write(&p[1], b);
+    klassic_gc_write(&p[0], *(void *volatile *)&a); /* reload after safepoint */
+    klassic_gc_write(&p[1], *(void *volatile *)&b);
+    klassic_gc_shadow_pop_n(2);
     return p;
 }
 static void *pair_field(void **p, int i) { return klassic_gc_read(&p[i]); }
@@ -43,6 +56,10 @@ static void **pair_of_leaves(int64_t av, int64_t bv) {
     klassic_gc_shadow_push(&b);
     a = make_leaf(av);
     b = make_leaf(bv);
+    /* a and b are re-read from their rooted slots here (their addresses
+     * escaped via shadow_push, so the compiler reloads them after the
+     * make_leaf calls); make_pair then roots its own copies across the pair's
+     * allocation. */
     void **p = make_pair(a, b);
     klassic_gc_shadow_pop_n(2);
     return p;
@@ -62,6 +79,13 @@ static void *mutator_main(void *arg) {
     void **keeper = pair_of_leaves(av, bv);
     klassic_gc_shadow_push((void **)&keeper); /* root it in this thread's stack */
     for (int i = 0; i < ITERS; i++) {
+        /* Explicit safepoint at the loop top (the hand-written analogue of the
+         * back-edge poll the backend emits). Every raw heap pointer is
+         * re-derived from a rooted slot below it: `keeper` is reloaded from its
+         * shadow-pushed slot (its address escaped, so the compiler re-reads it
+         * after any call), and la/lb are derived and dereferenced with no
+         * safepoint in between -- klassic_gc_read is poll-free by contract. */
+        klassic_gc_safepoint();
         void **garbage = pair_of_leaves(i, i);
         (void)garbage;
         if ((i & 1023) == 0) {

--- a/runtime/gc/gc_test.c
+++ b/runtime/gc/gc_test.c
@@ -28,40 +28,52 @@ static int64_t *make_leaf(int64_t v) {
     return p;
 }
 
-/* A pair record with two pointer fields. `a` and `b` must already be live
- * in the caller's rooted slots (they must survive this allocation);
- * stored through the write barrier so the slots carry the good color. */
+/* A pair record with two pointer fields. The pair's own allocation is a
+ * safepoint: with a MOVING collector the GC may relocate a and b's targets
+ * during it and update every ROOTED slot -- but not these parameter copies.
+ * So the parameters are rooted across the allocation and re-read from their
+ * (GC-updated) slots afterwards, the discipline the compiled backend follows
+ * (record_literal reloads each staged value from its shadow slot after the
+ * record's allocation). */
 static void **make_pair(void *a, void *b) {
+    klassic_gc_shadow_push(&a);
+    klassic_gc_shadow_push(&b);
     void **p = (void **)klassic_gc_alloc(16, KLASSIC_GC_POINTER_RECORD);
-    klassic_gc_write(&p[0], a);
-    klassic_gc_write(&p[1], b);
+    klassic_gc_write(&p[0], *(void *volatile *)&a); /* reload after safepoint */
+    klassic_gc_write(&p[1], *(void *volatile *)&b);
+    klassic_gc_shadow_pop_n(2);
     return p;
 }
 
-/* Read a pointer field through the load barrier (strips the color). */
+/* Read a pointer field through the load barrier (strips the color).
+ * klassic_gc_read is NOT a safepoint, so `p` (and the returned pointer, until
+ * the caller's next safepoint) stays valid across the call. */
 static void *pair_field(void **p, int i) { return klassic_gc_read(&p[i]); }
 
 /* Build a pair of two fresh int leaves, staging each intermediate in a
- * rooted slot so a collection mid-construction cannot strand it. */
+ * rooted slot so a collection mid-construction cannot strand it (and so the
+ * slots track relocation: a and b are re-read from them after each alloc). */
 static void **pair_of_leaves(int64_t av, int64_t bv) {
     void *a = 0, *b = 0;
     klassic_gc_shadow_push(&a);
     klassic_gc_shadow_push(&b);
-    a = make_leaf(av); /* a rooted; survives b's allocation */
+    a = make_leaf(av); /* a rooted; survives (and tracks) b's allocation */
     b = make_leaf(bv); /* b rooted; a still rooted */
     void **p = make_pair(a, b);
     klassic_gc_shadow_pop_n(2);
     return p;
 }
 
-/* A cons cell [leaf(head)][tail]. `tail` must be live in the caller's
- * rooted slot; the fresh head leaf is staged in a rooted slot here. */
+/* A cons cell [leaf(head)][tail]. `tail` is rooted here across the two
+ * allocations (the caller's rooted slot keeps the LIST alive, but this copy
+ * must also track relocation), and the fresh head leaf is staged likewise. */
 static void **cons(int64_t head, void **tail) {
     void *leaf = 0;
+    klassic_gc_shadow_push((void **)&tail);
     klassic_gc_shadow_push(&leaf);
     leaf = make_leaf(head);
-    void **p = make_pair(leaf, tail);
-    klassic_gc_shadow_pop_n(1);
+    void **p = make_pair(leaf, tail); /* both re-read from rooted slots */
+    klassic_gc_shadow_pop_n(2);
     return p;
 }
 

--- a/runtime/gc/klassic_gc.c
+++ b/runtime/gc/klassic_gc.c
@@ -487,24 +487,41 @@ uint64_t klassic_gc_load_barrier_slow(uint64_t value, void **slot) {
 }
 
 void *klassic_gc_read(void **slot) {
-    /* A thread that touches the heap must be a registered mutator, or its poll
-     * below would increment the parked count for a rendezvous that never
-     * counted it (breaking the all-mutator handshake), and its barrier work
-     * would evacuate/heal with no shadow stack to root its own pointers.
-     * Uniform with klassic_gc_alloc / klassic_gc_shadow_push. */
+    /* A thread that touches the heap must be a registered mutator (its barrier
+     * work may evacuate/heal, which needs its shadow stack; and only registered
+     * threads may park). Uniform with klassic_gc_alloc / klassic_gc_shadow_push. */
     if (!g_self) {
         klassic_gc_register_thread();
     }
-    /* Safepoint: the compiled backend polls at loop back-edges (M3), so a
-     * read-only loop parks for the GC thread's handshakes even when it never
-     * allocates. This C entry point (used by the runtime and the unit tests)
-     * polls here so a hand-written read loop behaves the same. */
-    gc_poll();
+    /* NOT a safepoint -- deliberately. With a moving collector, `slot` was
+     * computed by the caller from a heap pointer that is only valid until the
+     * next safepoint; polling here (between the caller deriving `slot` and this
+     * load using it) would let the GC relocate the underlying object and free
+     * its region mid-call, making both the load and the self-heal below write
+     * into reused memory. The emitted code has the same shape: its polls sit at
+     * function entries and loop back-edges, and every heap address is re-derived
+     * from a rooted slot after each poll, with the inline barrier fast path and
+     * the slow-path call poll-free in between. Hand-written mutators poll via
+     * klassic_gc_alloc or an explicit klassic_gc_safepoint() at their loop tops
+     * and must re-derive heap pointers from rooted slots afterwards. */
     uint64_t value = __atomic_load_n((uint64_t *)slot, __ATOMIC_RELAXED);
     if (value & gc_bad_mask) {
         return (void *)klassic_gc_load_barrier_slow(value, slot);
     }
     return (void *)(value & gc_strip_mask);
+}
+
+/* Explicit safepoint for hand-written mutators (the C analogue of the polls
+ * the backend emits at function entries and loop back-edges). Call it at loop
+ * tops so a read-only loop still parks for the GC thread's handshakes -- and
+ * treat every raw heap pointer as invalidated across it: re-derive them from
+ * rooted (shadow-pushed) slots afterwards, because a rendezvous may have
+ * relocated their targets and updated only the rooted slots. */
+void klassic_gc_safepoint(void) {
+    if (!g_self) {
+        klassic_gc_register_thread();
+    }
+    gc_poll();
 }
 
 void klassic_gc_write(void **slot, void *value) {
@@ -643,6 +660,7 @@ static void flush_all_tlabs(void) {
         }
     }
 }
+
 
 /* Reclaim whole-dead regions and clear the stale (previous-cycle) mark bit
  * on every block. Clearing it on dead blocks too -- not just live ones --

--- a/runtime/gc/klassic_gc.h
+++ b/runtime/gc/klassic_gc.h
@@ -99,11 +99,37 @@ uint64_t klassic_gc_load_barrier_slow(uint64_t value, void **slot);
 
 /* Read a heap pointer slot through the barrier (fast path inline, slow
  * path out of line). The LLVM backend emits the fast path directly; this
- * C entry point exists for the runtime and the tests. */
+ * C entry point exists for the runtime and the tests. NOT a safepoint:
+ * `slot` is derived from a raw heap pointer that a safepoint would
+ * invalidate, so this call must stay poll-free (see the safepoint
+ * contract below). */
 void *klassic_gc_read(void **slot);
 
-/* Store a heap pointer into a slot, coloring it good (null stays null). */
+/* Store a heap pointer into a slot, coloring it good (null stays null).
+ * NOT a safepoint (same contract as klassic_gc_read). */
 void klassic_gc_write(void **slot, void *value);
+
+/* --- The safepoint contract (a MOVING, CONCURRENT collector) ------ *
+ * The GC thread relocates objects while mutators run. At a safepoint a
+ * mutator may park for one or more whole collection cycles, during which
+ * objects move and their old regions are freed and reused. The collector
+ * updates ROOTED slots (registered with klassic_gc_shadow_push); it cannot
+ * see copies in registers, parameters, or unrooted locals. Therefore every
+ * raw heap pointer a mutator holds is invalidated by every safepoint, and
+ * must be re-derived from a rooted slot after it.
+ *
+ * Safepoints: klassic_gc_alloc (entry), klassic_gc_collect,
+ * klassic_gc_safepoint, and -- in compiled code -- the polls the backend
+ * emits at function entries and loop back-edges.
+ * NOT safepoints: klassic_gc_read, klassic_gc_write,
+ * klassic_gc_shadow_push/pop_n.
+ *
+ * The compiled backend obeys this by construction (every klassic value
+ * lives in a slot and is reloaded after each call/poll). Hand-written C
+ * mutators (the test harnesses) must do the same: root every live heap
+ * pointer, poll at loop tops via klassic_gc_safepoint(), and never carry a
+ * pre-safepoint copy across one. */
+void klassic_gc_safepoint(void);
 
 /* --- Safepoint handshake (true-zgc M3) --------------------------- *
  * The generated code polls `gc_handshake_requested` at loop back-edges and


### PR DESCRIPTION
## fix: the moving-collector safepoint contract

CI's TSan caught a rare N-mutator race on PR #597's test job. CI-side bisection
(a diagnostic branch looping the MT suite with free-site instrumentation on
GitHub runners, where the race reproduces reliably) root-caused it to **two
violations of one contract** — with a moving concurrent collector, every raw
heap pointer a mutator holds is invalidated at every safepoint (it may park
through whole collection cycles: objects move, only **rooted** slots are
updated, old regions are freed and reused), so it must be re-derived from a
rooted slot afterwards:

1. **`klassic_gc_read` polled at entry** (added in M4b-2) — i.e. *between* the
   caller deriving `slot` from a raw heap pointer and the load using it. A
   mutator parking there across cycles could then load from and **self-heal
   into another thread's freshly reused region**. The read/write barriers are
   now documented as NOT safepoints and the entry poll is removed; emitted code
   already has this shape (polls at function entries/loop back-edges, heap
   addresses re-derived from rooted slots after each, barrier calls poll-free
   in between). `klassic_gc_safepoint()` is the new explicit poll for
   hand-written mutators' loop tops, and `klassic_gc.h` states the contract.

2. **The C test harnesses held unrooted copies across safepoints**:
   `make_pair`'s parameters crossed the pair's own allocation — the value then
   written into an allocate-black record's field is never traced, so never
   remapped, and the from-space region it pointed into was later freed under
   the live field (the observed use-after-free). `cons`'s `tail` crossed its
   allocations the same way. Both now root their parameters and reload them
   after the safepoint — the discipline the compiled backend follows by
   construction (`record_literal` reloads every staged value from its shadow
   slot after the record's allocation).

**The collector's algorithm is untouched.** Bisection on the unmodified
collector with disciplined harnesses showed no premature free (an instrumented
"no live reference into a freed region" check stayed silent through CI loops),
and candidate collector-side "fixes" (a store barrier, root re-remap at mark,
a region reuse quarantine) were each isolated on CI and shown unnecessary —
the store barrier variant even introduced a new race of its own.

### Verification

- CI repro loop on the diagnostic branch: 80× TSan + 120× ASan+instrumentation,
  `tsan_reproduced=0`, `debug_caught=0` (previously reproduced at iteration
  3–40).
- An independent audit of the MT harness confirmed the `make_pair` fix sound
  and independently flagged the read-entry poll as the remaining hazard.
- Local: MT/ST harness × ASan+UBSan/TSan all clean; `run_tests.sh`, full
  `cargo test`, `cargo fmt --check`, `clippy -D warnings` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
