### PR TITLE
refactor: make the hand-written ZGC architecture-independent via a PortableAsm trait

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,35 +5,45 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project Overview
 
 Klassic is a statically typed object-functional programming language implemented
-as a Rust 2024 Cargo workspace. The default developer path is Cargo-based and
-builds the `klassic` executable. The language has Hindley-Milner inference,
-row-polymorphic records, type classes (incl. higher-kinded examples), and a
-lightweight theorem / trust / axiom surface.
+as a Rust 2024 Cargo workspace (crate version 0.7.0). The `klassic` executable is
+both an evaluator/REPL and a native compiler that writes executables **byte by
+byte** — ELF64 on Linux x86_64, ad-hoc-signed Mach-O on Apple Silicon, PE64 on
+Windows x86_64 — with no `cc`/`as`/`ld`/`codesign`/`link.exe` in the loop. The
+language has Hindley-Milner inference, algebraic data types with exhaustive
+`match`, row-polymorphic records, type classes (incl. higher-kinded), a standard
+library written in Klassic itself, a precise/moving garbage collector inside
+every native binary, and a lightweight theorem / trust / axiom surface.
 
 ## Common Commands
 
 ```bash
 cargo build                                          # debug build
 cargo build --release                                # release build
-cargo test                                           # full test suite
-cargo test --test cli_smoke <test_name>              # single integration test
-cargo test -p klassic-macro-peg                      # macro-PEG crate only
+cargo test                                           # full workspace suite
+cargo test --test cli_smoke <test_name>              # one integration test in a file
+cargo test -p klassic-macro-peg                      # a single crate's tests
 cargo fmt --check                                    # formatting gate
-cargo clippy --all-targets --all-features -- -D warnings
+cargo clippy --all-targets --all-features -- -D warnings   # lint gate (warnings are errors)
 cargo run -- -e "1 + 2"                              # evaluate an expression
-cargo run -- path/to/program.kl                      # evaluate a file
-cargo run -- -f path/to/program.kl                   # equivalent to above
+cargo run -- path/to/program.kl                      # evaluate a file (also: -f path)
 cargo run                                            # REPL (`:history`, `:exit`)
 cargo run -- build path/to/program.kl -o program     # native build (host-detected target)
-cargo run -- targets                                  # list known native targets
-cargo run -- --backend c build program.kl -o program.c  # portable C backend (subset)
-cargo run -- --target x86_64-unknown-linux-gnu build path/to/program.kl -o program
-cargo run -- --warn-trust path/to/program.kl         # report trusted proofs
-cargo run -- --deny-trust path/to/program.kl         # reject trusted proofs
+cargo run -- targets                                  # print the live target matrix
+cargo run -- --target x86_64-pc-windows-msvc build program.kl -o program.exe   # cross-build
+cargo run -- --backend c build program.kl -o program.c     # portable C source (subset)
+cargo run -- --backend llvm build program.kl -o program    # LLVM IR -> clang (needs clang >= 15)
+cargo run -- --warn-trust program.kl                 # report trusted proofs
+cargo run -- --deny-trust program.kl                 # reject trusted proofs
 cargo run -- --gc-log build program.kl -o program    # GC stats to stderr at exit
 cargo run -- --gc-stress build program.kl -o program # collect before every alloc (bug-shaker)
 cargo run -- --gc-poison build program.kl -o program # bad-color heap ptrs; unbarriered deref faults
+runtime/gc/run_tests.sh                              # standalone C-GC tests (single + multi-thread)
 ```
+
+The three GC flags apply to the hand-emitted x86_64 ELF backend. The LLVM/C-GC
+tests (`tests/llvm_gc*.rs`, `tests/llvm_backend.rs`) are gated on a `clang >= 15`
+being present (set `KLASSIC_CLANG` to pick one); without clang they skip so CI
+stays green.
 
 ## Architecture
 
@@ -45,14 +55,15 @@ cargo run -- --gc-poison build program.kl -o program # bad-color heap ptrs; unba
 4. `klassic-rewrite`: placeholder desugaring and syntax normalization
 5. `klassic-types`: HM inference, record typing, typeclass constraints, proof checks
 6. `klassic-eval`: evaluator, runtime builtins, modules, REPL/session state
-7. `klassic-native`: native compiler — emits ELF64 for Linux x86_64 AND ad-hoc-signed Mach-O arm64 for Apple Silicon, both without `cc`/`as`/`ld`
-8. Root `src/`: CLI argument handling and diagnostic presentation
+7. `klassic-native`: native code generation (multiple backends — see below)
+8. Root `src/`: CLI argument handling (`src/cli.rs`) and diagnostic presentation
 
-The evaluator (`klassic-eval`) is the reference implementation. The native
-compiler (`klassic-native`) reuses parse → rewrite → typecheck → proof analysis
-and lowers a growing subset of programs to ELF executables. When a construct is
-not yet supported by native codegen, it fails at build time with a
-source-located diagnostic — there is no fallback to the evaluator.
+The evaluator (`klassic-eval`) is the **reference implementation** and semantic
+oracle. Every native backend reuses parse → rewrite → typecheck → proof analysis
+and lowers a *subset* of programs. When a construct is not yet supported by a
+backend, it fails at build time with a source-located `Diagnostic` — there is no
+fallback to the evaluator and never wrong code. Differential testing
+(`eval == native`) is the correctness backstop.
 
 ### Crates
 
@@ -60,47 +71,99 @@ source-located diagnostic — there is no fallback to the evaluator.
 - `crates/klassic-syntax` — parser + AST
 - `crates/klassic-rewrite` — rewrite passes
 - `crates/klassic-types` — static checking
-- `crates/klassic-eval` — evaluator + builtins + REPL state
-- `crates/klassic-native` — native code generator + ELF writer, and Mach-O arm64 writer (Apple Silicon)
+- `crates/klassic-eval` — evaluator + builtins + REPL state (the oracle)
+- `crates/klassic-native` — all native code generation (see backends below)
 - `crates/klassic-runtime` — shared runtime crate scaffold
 - `crates/klassic-macro-peg` — standalone macro PEG parser/evaluator
+
+### Native backends (`crates/klassic-native/src/`)
+
+Klassic has grown from one hand-emitted backend into several; they are separate
+files, not one monolith:
+
+- `lib.rs` — the **default** backend: a hand-emitted x86_64 direct-ELF code
+  generator (~40k lines, intentionally one large file). Contains the by-pointer
+  enum ABI and the complete hand-written **ZGC-style garbage collector** (colored
+  pointers, an inline load barrier, a region heap, incremental marking, and
+  moving evacuation). This is where the `--gc-*` flags live. Note: this GC is
+  x86_64-only machine code; extracting its architecture-independent parts behind
+  a `PortableAsm` emitter trait (so a future AArch64 backend can share the design)
+  is an active refactoring direction — see `docs/superpowers/specs/` if present.
+- `pe.rs` — PE64 writer (Windows x86_64), reusing `lib.rs`'s x86_64 codegen.
+- `macho.rs` + `aarch64.rs` — Mach-O writer + AArch64 codegen (Apple Silicon).
+  This is a **wholly separate** backend with no GC of its own.
+- `cbackend.rs` — `--backend c`: emits a portable C translation unit (a subset).
+- `llvm.rs` — `--backend llvm`: emits textual LLVM IR that `clang` compiles and
+  links against `libklassic_runtime.a`, using the **C garbage collector** in
+  `runtime/gc/`. Coverage grows milestone by milestone (`docs/llvm-backend-plan.md`);
+  the hand-emitted backend stays default and untouched.
+
+### The two garbage collectors
+
+There are two distinct GC implementations — do not confuse them:
+
+- **Hand-written ZGC in `lib.rs`** (x86_64 ELF/PE backend). Design in
+  `docs/zgc-plan.md`. Object header is 16 bytes `[size | mark@bit63][type_tag]`;
+  pointers are *colored* (bits 60-62) and non-canonical until stripped by the
+  load barrier. Observability/debug flags: `--gc-log`, `--gc-stress`, `--gc-poison`.
+  The ~25 `emit_gc_*_runtime` functions in `lib.rs` are the hand-emitted machine
+  code for this collector.
+- **C garbage collector** `runtime/gc/klassic_gc.{c,h}`, driven by the LLVM
+  backend through the `klassic_gc_*` ABI (`klassic_gc_init`/`_alloc`/`_write`/
+  `_read`/`_collect`/`shadow_push`/`shadow_pop_n`, the inline load-barrier fast
+  path, and a `safepoint`/`handshake` protocol for the concurrent, N-mutator
+  design). Its own C tests are `gc_test.c` / `gc_mt_test.c` (multi-thread) run by
+  `runtime/gc/run_tests.sh`. Design in `docs/true-zgc-plan.md`.
 
 ### Tests
 
 - Rust unit tests live inside each crate.
 - Integration tests under `tests/`:
-  - `tests/cli_smoke.rs` — CLI + native build behavior (largest; one test per scenario, often with temp `.kl` source and ELF output).
-  - `tests/sample_programs.rs` — runs every program in `test-programs/` through both the evaluator and the native compiler when on Linux x86_64.
+  - `tests/cli_smoke.rs` — CLI + hand-emitted native build behavior (largest; one
+    test per scenario, usually a temp `.kl` source compiled to an executable whose
+    stdout/stderr/exit code is asserted). Use temp paths keyed on `SystemTime`.
+  - `tests/sample_programs.rs` — runs every program in `test-programs/` through
+    both the evaluator and the native compiler on Linux x86_64.
   - `tests/language_regressions.rs` — language-level regression suite.
-- Klassic sample programs live under `test-programs/` (and `examples/`).
-- `klassic-native` integration tests are gated: the ELF path uses `#[cfg(all(target_os = "linux", target_arch = "x86_64"))]` and the Mach-O path uses `#[cfg(all(target_os = "macos", target_arch = "aarch64"))]`.
+  - `tests/llvm_backend.rs`, `tests/llvm_gc.rs`, `tests/llvm_gc_link.rs` — the LLVM
+    backend and its C-GC linking (gated on clang; see Common Commands).
+  - `tests/cross-exec/` — cross-target execution fixtures.
+- Klassic sample programs live under `test-programs/` and `examples/`.
+- Native integration tests are cfg-gated by host: ELF path `#[cfg(all(target_os
+  = "linux", target_arch = "x86_64"))]`, Mach-O path `#[cfg(all(target_os =
+  "macos", target_arch = "aarch64"))]`.
 
-### Roadmap
+### Docs
 
-Long-term direction — multi-target native backends and a shared
-standard library between evaluator and native — is captured in
-`docs/roadmap-targets-stdlib.md`. The PR-sized execution plan that
-sits alongside it is `klassic_claude_code_plan.md`. Read both before
-starting work that touches the native target abstraction, the stdlib
-module layout, or the builtin registry.
+- `docs/architecture-rust.md` — running log of the hand-emitted backend's covered
+  paths (append one or two sentences per native change).
+- `docs/native-coverage.md`, `docs/native-backend-strategy.md` — native scope.
+- `docs/zgc-plan.md` — the hand-written x86_64 GC plan (M0-M8, complete).
+- `docs/true-zgc-plan.md` — the concurrent/N-mutator C GC plan.
+- `docs/llvm-backend-plan.md` — the LLVM backend migration plan.
+- `docs/roadmap-targets-stdlib.md` — long-term multi-target + shared-stdlib
+  direction. Read it before touching the native target abstraction, the stdlib
+  module layout, or the builtin registry.
+- `docs/book/` — the user-facing Klassic Book.
 
-## Native Compiler Development Pattern
+## Native Compiler Development Pattern (hand-emitted `lib.rs`)
 
-Most recent commit history is a long stream of small, focused additions to
-`klassic-native`, each titled "Support X" or "Cover X" with one new
-integration test in `tests/cli_smoke.rs` and a one-paragraph addendum to
+The commit history is largely small, focused additions to `lib.rs`, each with one
+new integration test in `tests/cli_smoke.rs` and a one-paragraph addendum to
 `docs/architecture-rust.md`. When extending native coverage:
 
 1. Probe with a small `.kl` snippet through `cargo run -- build` to find a gap.
-2. Add the minimal native codegen change in `crates/klassic-native/src/lib.rs`.
-3. Add a focused integration test in `tests/cli_smoke.rs` that asserts the generated executable's stdout/stderr (use temp paths keyed on `SystemTime`).
-4. Update `docs/architecture-rust.md` with one or two sentences describing the new path.
-5. Run `cargo fmt --check` and `cargo test`.
+2. Add the minimal codegen change in `crates/klassic-native/src/lib.rs`.
+3. Add a focused test in `tests/cli_smoke.rs` asserting the executable's output.
+4. Update `docs/architecture-rust.md` with a sentence or two.
+5. `cargo fmt --check && cargo test`.
 
-`crates/klassic-native/src/lib.rs` is intentionally a single very large file
-(~40k lines). Stay consistent with that organization rather than splitting it.
-Prefer `unsupported(span, "<feature>")` returning a `Diagnostic` for paths that
-remain unimplemented.
+`lib.rs` is intentionally a single very large file — stay consistent with that
+organization rather than splitting existing instruction-emission function bodies.
+(New, genuinely separable files alongside it — `aarch64.rs`, `cbackend.rs`,
+`llvm.rs`, `pe.rs` — are the normal way to add a separable concern.) Prefer
+`unsupported(span, "<feature>")` returning a `Diagnostic` for paths that remain
+unimplemented. The same discipline applies to the LLVM backend (`llvm.rs`).
 
 ## Workflow For Language Changes
 
@@ -109,36 +172,53 @@ When adding syntax or semantics:
 1. Update `klassic-syntax` for parsing and AST shape.
 2. Add or adjust rewrite behavior in `klassic-rewrite` when needed.
 3. Extend `klassic-types` for static behavior.
-4. Extend `klassic-eval` for evaluator behavior.
-5. Extend `klassic-native` for native codegen (or leave it unsupported with a clear diagnostic).
-6. Add focused tests in the relevant crate plus integration tests where the user-visible surface changes.
+4. Extend `klassic-eval` for evaluator behavior (the oracle moves first).
+5. Extend the native backends for codegen (or leave unsupported with a clear
+   diagnostic).
+6. Add focused tests in the relevant crate plus integration tests where the
+   user-visible surface changes.
 7. `cargo fmt --check && cargo test`.
 
 ## Conventions
 
 - Rust 2024 edition. Avoid `unsafe` unless documented.
 - Keep diagnostics source-span aware end-to-end.
-- Tests must be hermetic; use temp directories for filesystem behavior. Do not hardcode sample outputs in the evaluator.
+- Tests must be hermetic; use temp directories for filesystem behavior. Do not
+  hardcode sample outputs in the evaluator.
 - Default to ASCII in source and docs unless the file already justifies Unicode.
 - Prefer `rg` for source search.
 - The default build and runtime path is native Rust — keep it that way.
-- Commit subjects: imperative mood, under ~72 characters.
+- Commit subjects: imperative mood, under ~72 characters. CI must be green on the
+  Rust-native path.
 
 ## Language Surface (quick reference)
 
 - `val` (immutable) / `mutable` (reassignable) bindings.
-- `def f(x) = ...` and `(x) => ...` lambdas; placeholders like `_ + 1`. Top-level defs may forward-reference each other (mutual recursion); `else` may start a continuation line.
-- Space- / comma- / newline-separated collection literals: `[1 2 3]`, `%["a":1 "b":2]`, `%(1 2 3)`.
+- `def f(x) = ...` and `(x) => ...` lambdas; placeholders like `_ + 1`. Top-level
+  defs may forward-reference each other (mutual recursion); `else` may start a
+  continuation line.
+- Space- / comma- / newline-separated collection literals: `[1 2 3]`,
+  `%["a":1 "b":2]`, `%(1 2 3)`.
 - String interpolation: `"Hello #{name}"`.
 - `cleanup { ... }` clauses run after the associated expression.
 - `module foo.bar { ... }` plus selective / aliased imports.
-- Structural records (`record { x: 1; y: 2 }`) and nominal record declarations (`record Point { x: Int; y: Int }`), constructed positionally as `#Point(1, 2)`.
-- Algebraic data types: `enum Option<a> { case Some(value: a); case None }` and Scala-style postfix pattern matching (`o match { case Some(v) => v; case None => 0 }`). Enums are real nominal types in the checker (match exhaustiveness and unreachable arms are diagnosed), and native builds compile monomorphic and shape-tracked generic enums — including recursion — through a per-frame by-pointer ABI; remaining native gaps (e.g. list-of-enum payloads) fail with source-located diagnostics.
-- Extension methods: `extension <a>(this: List<a>) { def headOr(d) = ... }` adds dot-callable methods to existing types. Stdlib leans on this for `std.string`, `std.list`, `std.math`, `std.option`, `std.result`, `std.map`, `std.set`, `std.time`, `std.json`, `std.path`, `std.cli`, `std.dir`, `std.env`, `std.file`, `std.process`, `std.test`.
+- Structural records (`record { x: 1; y: 2 }`) and nominal record declarations
+  (`record Point { x: Int; y: Int }`), constructed positionally as `#Point(1, 2)`.
+- Algebraic data types: `enum Option<a> { case Some(value: a); case None }` and
+  Scala-style postfix pattern matching (`o match { case Some(v) => v; case None
+  => 0 }`). Enums are real nominal types in the checker (match exhaustiveness and
+  unreachable arms are diagnosed); native builds compile monomorphic and
+  shape-tracked generic enums — including recursion — through a per-frame
+  by-pointer ABI.
+- Extension methods: `extension <a>(this: List<a>) { def headOr(d) = ... }` adds
+  dot-callable methods. The stdlib (written in Klassic) leans on this for
+  `std.string`, `std.list`, `std.math`, `std.option`, `std.result`, `std.map`,
+  `std.set`, `std.time`, `std.json`, `std.path`, `std.cli`, `std.dir`, `std.env`,
+  `std.file`, `std.process`, `std.test`.
 - Type classes with constraints, including higher-kinded examples.
 - Arithmetic operators are type-class-constrained, so unannotated generic
   arithmetic infers a polymorphic signature: `def add(x, y) = x + y` is
   `(a, a) -> a where Plus<a>` (works at Int / Double / String), and
-  `def diff(x, y) = x - y` is `Num<a>` (numbers only). `add(true, false)`
-  is a compile error (`missing instance for Plus<Boolean>`).
+  `def diff(x, y) = x - y` is `Num<a>` (numbers only). `add(true, false)` is a
+  compile error (`missing instance for Plus<Boolean>`).
 - Proof surface: `axiom`, `theorem`, with `--warn-trust` / `--deny-trust` flags.

--- a/crates/klassic-native/src/gc_layout.rs
+++ b/crates/klassic-native/src/gc_layout.rs
@@ -1,0 +1,135 @@
+//! Architecture-independent GC design constants and object-format ABI.
+//!
+//! This module is the single, non-x86-64 home for the collector's
+//! *design*: every value here is a number or a documented convention,
+//! never an instruction sequence. The actual code generation (register
+//! allocation, addressing modes, syscall/shim encoding) stays in
+//! `lib.rs`, which is currently the only backend that emits this
+//! collector. If a future direct-ELF AArch64 backend (or any other
+//! architecture) ever adopts the same precise/moving collector, this
+//! file is exactly the set of facts it must agree on to stay
+//! object-format compatible with the x86-64 backend -- the constants
+//! below and the layout described in prose where a value cannot stand
+//! alone.
+//!
+//! This is a deliberately narrow slice of "architecture independence":
+//! the numbers and the format they describe, extracted out of the
+//! instruction-emission code. A full shared instruction-emission
+//! abstraction that both backends lower through (see
+//! `docs/superpowers/specs/` and `docs/zgc-plan.md`) is a separate,
+//! larger effort; what belongs *here* is only the part that is already
+//! truly independent of any instruction set.
+//!
+//! ## Object header layout
+//!
+//! Every heap allocation is `[block]`, addressed by its own start; the
+//! pointer handed to user code (the "user pointer") is `block + 16`:
+//!
+//! ```text
+//! [block +  0] : u64  total_size (16-aligned) | header low bits (see below)
+//! [block +  8] : u64  type_tag  (see the GC_TYPE_* constants)
+//! [block + 16 .. total_size] : payload (user pointer starts here)
+//! ```
+//!
+//! `total_size` includes the 16-byte header and is 16-aligned, so the
+//! low 4 bits of header word0 are free and repurposed (see `GC_FWD` /
+//! `GC_HMARK0` / `GC_HMARK1`). The size is recovered with `and reg, -16`.
+//!
+//! ## Pointer coloring (bits 60-62 of a *value*, not the header)
+//!
+//! Every heap pointer stored in a heap slot carries a color in bits
+//! 60-62 of the pointer *value* (real Linux x86-64 heap/mmap addresses
+//! are <= 47 bits, so these bits are free). A colored pointer is
+//! non-canonical, so dereferencing one without stripping the color
+//! faults -- that fault is the load-barrier coverage guarantee. The load
+//! barrier masks the color off (`GC_COLOR_STRIP`) and, on a bad color
+//! (`GC_COLOR_BAD_MASK`), runs its slow path. This is a value-level
+//! property of pointers in heap slots, entirely distinct from the
+//! per-object *mark* bits that live in the header word (below).
+
+/// Region granularity for the region-based heap. Objects bump-allocate
+/// within a region; whole dead regions are the unit of reclamation.
+pub const GC_REGION_SIZE: u64 = 1 << 17; // 128 KiB
+pub const GC_REGION_SHIFT: u8 = 17;
+
+/// The heap is one up-front virtual reservation of this many regions
+/// (64 MiB). Linux demand-pages it, so only touched regions cost
+/// physical memory; the soft budget below bounds how many the mutator
+/// may touch before a collection.
+pub const GC_RESERVE_REGIONS: u64 = 512;
+pub const GC_RESERVE_BYTES: u64 = GC_REGION_SIZE * GC_RESERVE_REGIONS;
+
+/// Initial soft budget: 8 regions = 1 MiB. Doubles on allocation stall,
+/// capped at `GC_RESERVE_REGIONS`.
+pub const GC_INITIAL_BUDGET_REGIONS: u64 = 8;
+
+/// The mark worklist holds the breadth-first frontier of the live object
+/// graph; deep recursion with per-frame heap values makes the live set
+/// proportional to recursion depth.
+pub const GC_MARK_WORKLIST_LEN: usize = 262144;
+
+/// Maximum number of stack-frame heap-pointer slots tracked at once.
+/// Sized for deep recursion (every live frame with heap-pointer
+/// parameters holds roots here); the GC tables are lazily-backed mmap,
+/// so a large cap reserves address space without committing pages until
+/// used. Sized to comfortably exceed the C-call-stack frame count, so a
+/// deep recursion trips the stack-overflow probe (a clean diagnostic)
+/// before this cap.
+pub const GC_SHADOW_STACK_LEN: usize = 262144;
+
+/// Total bytes for the single mmap backing the GC's runtime tables: the
+/// shadow stack (the sole root source) and the mark worklist.
+pub const GC_TABLES_BYTES: u64 = ((GC_SHADOW_STACK_LEN + GC_MARK_WORKLIST_LEN) * 8) as u64;
+
+pub const GC_MAX_PAYLOAD_SIZE: u64 = i64::MAX as u64 - 31 - 4095;
+pub const GC_MAX_STRING_ALLOC_SIZE: u64 = GC_MAX_PAYLOAD_SIZE - 15;
+pub const GC_MAX_POINTER_SLOT_COUNT: u64 = GC_MAX_PAYLOAD_SIZE / 8;
+pub const GC_MAX_LIST_LENGTH: u64 = (GC_MAX_PAYLOAD_SIZE - 8) / 8;
+
+/// Type tag stored in the second header word. 0 marks a free block, 1
+/// marks a raw-bytes payload (no pointer fields), 2 marks a "pointer
+/// record" whose payload is a packed array of heap pointers the mark
+/// phase recurses into.
+pub const GC_TYPE_RAW_BYTES: u64 = 1;
+pub const GC_TYPE_POINTER_RECORD: u64 = 2;
+/// Heap-backed pointer list: payload is `[len: i64, ptr_0, ptr_1, ...]`.
+/// The first qword is an integer length the mark phase must skip; the
+/// remaining payload is a packed pointer table traced like a record.
+pub const GC_TYPE_POINTER_LIST: u64 = 4;
+
+/// ZGC colored-pointer bits (bits 60-62; see the module doc). Any
+/// pointer with one set is non-canonical, so an unbarriered dereference
+/// faults -- the barrier-coverage guarantee.
+pub const GC_COLOR_M0: u64 = 1 << 60;
+pub const GC_COLOR_M1: u64 = 1 << 61;
+pub const GC_COLOR_R: u64 = 1 << 62;
+pub const GC_COLOR_MASK: u64 = 7 << 60;
+/// Strip mask: clears the color bits, leaving the raw address.
+pub const GC_COLOR_STRIP: u64 = !GC_COLOR_MASK;
+/// Bad-color test mask: a good (M0) pointer ANDs to zero; a poisoned
+/// (M1) or relocation-flagged (R) pointer ANDs non-zero and takes the
+/// load-barrier slow path.
+pub const GC_COLOR_BAD_MASK: u64 = GC_COLOR_M1 | GC_COLOR_R;
+
+/// M6 incremental-marking tuning. A mark quantum traces up to
+/// `GC_QUANTUM_POPS` worklist objects; the driver runs one quantum per
+/// `GC_QUANTUM_BYTES` allocated during the Mark phase. A cycle starts
+/// proactively when live regions exceed 5/8 of the soft budget.
+pub const GC_QUANTUM_POPS: u64 = 512;
+pub const GC_QUANTUM_BYTES: u64 = 8192;
+
+pub const GC_PHASE_IDLE: u64 = 0;
+pub const GC_PHASE_MARK: u64 = 1;
+/// M7 relocation phase: live objects are evacuated out of the sparsest
+/// regions so those regions can be freed (heap compaction).
+pub const GC_PHASE_RELOCATE: u64 = 2;
+
+/// M7 object-header low bits (size is 16-aligned, so bits 0-3 of header
+/// word0 are free). bit0 = forwarded (word0 then holds the new user
+/// pointer `| GC_FWD`); bits 1-2 = the two alternating mark bits (which
+/// parity is "current" this cycle lives in the `gc_header_mark` cell).
+/// The mark bit moved off bit 63 so word0 can hold a forwarding pointer.
+pub const GC_FWD: u64 = 1;
+pub const GC_HMARK0: u64 = 1 << 1;
+pub const GC_HMARK1: u64 = 1 << 2;
+pub const GC_HMARK_BOTH: u64 = GC_HMARK0 | GC_HMARK1;

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -496,6 +496,7 @@ mod llvm;
 mod aarch64;
 mod macho;
 mod pe;
+mod portable_asm;
 
 /// Compile `text` to a portable C translation unit (`--backend c`).
 /// The supported subset is deliberately small (see `cbackend`);
@@ -40283,50 +40284,16 @@ impl NativeCodeGenerator {
     /// rax = 1 if the budget could grow enough, rax = 0 if even the whole
     /// reservation cannot hold the request. Leaf routine.
     fn emit_gc_grow_budget_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_grow_budget);
-        let have = self.asm.create_text_label();
-        let set = self.asm.create_text_label();
-        let fail = self.asm.create_text_label();
-
-        // rcx = N = ceil(total / REGION_SIZE).
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rdi);
-        self.asm
-            .add_reg_imm32(Reg::Rcx, (Self::GC_REGION_SIZE - 1) as i32);
-        self.asm.shr_reg_imm8(Reg::Rcx, Self::GC_REGION_SHIFT);
-        // r8 = committed + N (the minimum budget the request needs).
-        self.asm.mov_data_addr(Reg::R10, self.gc_committed_count);
-        self.asm.load_ptr_disp32(Reg::R8, Reg::R10, 0);
-        self.asm.add_reg_reg(Reg::R8, Reg::Rcx);
-        // rax = budget * 2.
-        self.asm.mov_data_addr(Reg::R10, self.gc_budget_regions);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.shl_reg_imm8(Reg::Rax, 1);
-        // rax = max(2*budget, committed+N).
-        self.asm.cmp_reg_reg(Reg::Rax, Reg::R8);
-        self.asm.jcc_label(Condition::AboveOrEqual, have);
-        self.asm.mov_reg_reg(Reg::Rax, Reg::R8);
-        self.asm.bind_text_label(have);
-        // Cap at GC_RESERVE_REGIONS (unsigned region counts).
-        let over_cap = self.asm.create_text_label();
-        self.asm
-            .cmp_reg_imm32(Reg::Rax, Self::GC_RESERVE_REGIONS as i32);
-        self.asm.jcc_label(Condition::Above, over_cap);
-        self.asm.jmp_label(set); // rax <= reserve: use it as-is
-        self.asm.bind_text_label(over_cap);
-        // Over the cap: the request fits only if committed+N <= reserve.
-        self.asm
-            .cmp_reg_imm32(Reg::R8, Self::GC_RESERVE_REGIONS as i32);
-        self.asm.jcc_label(Condition::Above, fail);
-        self.asm.mov_imm64(Reg::Rax, Self::GC_RESERVE_REGIONS);
-        self.asm.bind_text_label(set);
-        self.asm.mov_data_addr(Reg::R10, self.gc_budget_regions);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.mov_imm64(Reg::Rax, 1);
-        self.asm.ret();
-
-        self.asm.bind_text_label(fail);
-        self.asm.mov_imm64(Reg::Rax, 0);
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait: the
+        // routine's logic is now architecture-independent (a future
+        // AArch64 backend would provide a `PortableAsm` impl and reuse
+        // this exact function); only the x86-64 instruction encoding is
+        // per-backend. Behavior is byte-identical -- the x86-64
+        // `PortableAsm` impl is a 1:1 thin wrapper over `Assembler`.
+        let entry = self.gc_grow_budget;
+        let committed = self.gc_committed_count;
+        let budget = self.gc_budget_regions;
+        portable_asm::emit_gc_grow_budget(&mut self.asm, entry, committed, budget);
     }
 
     /// `gc_bounds_error` is a non-returning subroutine that prints a

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -39426,65 +39426,24 @@ impl NativeCodeGenerator {
     /// slot still references a ghost (soundness invariant III). Freed
     /// regions are zeroed on reuse, erasing stale forwarding words.
     fn emit_gc_free_ghost_regions_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_free_ghost_regions);
-        self.asm.push_reg(Reg::Rbp);
-        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
-        self.asm.sub_reg_imm8(Reg::Rsp, 16);
-        self.asm.mov_data_addr(Reg::R10, self.gc_committed_count);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.store_rbp_slot(16, Reg::Rax); // bound
-        self.asm.mov_imm64(Reg::Rax, 0);
-        self.asm.store_rbp_slot(8, Reg::Rax); // idx
-        let loop_l = self.asm.create_text_label();
-        let done_l = self.asm.create_text_label();
-        let next_l = self.asm.create_text_label();
-        self.asm.bind_text_label(loop_l);
-        self.asm.load_rbp_slot(Reg::Rax, 8);
-        self.asm.load_rbp_slot(Reg::Rcx, 16);
-        self.asm.cmp_reg_reg(Reg::Rax, Reg::Rcx);
-        self.asm.jcc_label(Condition::AboveOrEqual, done_l);
-        // fromspace[idx]?
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-        self.asm.shl_reg_imm8(Reg::Rcx, 3);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_fromspace);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rcx);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-        self.asm.test_reg_reg(Reg::R11, Reg::R11);
-        self.asm.jcc_label(Condition::Equal, next_l);
-        // base = region_base + (idx << SHIFT)
-        self.asm.load_rbp_slot(Reg::Rax, 8);
-        self.asm.shl_reg_imm8(Reg::Rax, Self::GC_REGION_SHIFT);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_base);
-        self.asm.load_ptr_disp32(Reg::R10, Reg::R10, 0);
-        self.asm.add_reg_reg(Reg::Rax, Reg::R10); // rax = base
-        // push onto free pool: [base] = free_head; free_head = base
-        self.asm.mov_data_addr(Reg::R10, self.gc_free_region_head);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-        self.asm.store_ptr_disp32(Reg::Rax, 0, Reg::R11);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        // idx*8 in rcx for the three arrays.
-        self.asm.load_rbp_slot(Reg::Rcx, 8);
-        self.asm.shl_reg_imm8(Reg::Rcx, 3);
-        // region_top[idx] = base (empty)
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_top);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rcx);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        // fromspace[idx] = 0 ; live[idx] = 0
-        self.asm.mov_imm64(Reg::R11, 0);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_fromspace);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rcx);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R11);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_live);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rcx);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R11);
-        self.asm.bind_text_label(next_l);
-        self.asm.load_rbp_slot(Reg::Rax, 8);
-        self.asm.add_reg_imm32(Reg::Rax, 1);
-        self.asm.store_rbp_slot(8, Reg::Rax);
-        self.asm.jmp_label(loop_l);
-        self.asm.bind_text_label(done_l);
-        self.asm.leave();
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper).
+        let entry = self.gc_free_ghost_regions;
+        let tables = portable_asm::RegionTables {
+            heap_base: self.gc_heap_base,
+            heap_top: self.gc_heap_top,
+            region_base: self.gc_region_base,
+            region_top: self.gc_region_top,
+            committed_count: self.gc_committed_count,
+            region_fromspace: self.gc_region_fromspace,
+        };
+        portable_asm::emit_gc_free_ghost_regions(
+            self,
+            entry,
+            tables,
+            self.gc_free_region_head,
+            self.gc_region_live,
+        );
     }
 
     /// Acquire a fresh to-space region into the dedicated evacuation bump

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -39722,37 +39722,26 @@ impl NativeCodeGenerator {
     /// to Idle. From-space regions stay flagged (freed at the next
     /// MarkEnd, once the next mark confirms nothing references them).
     fn emit_gc_relocate_finish_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_relocate_finish);
-        self.asm.push_reg(Reg::Rbp);
-        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
-        // Flush the final to-space region's watermark.
-        self.asm.mov_data_addr(Reg::R10, self.gc_evac_region_base);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        let no_flush = self.asm.create_text_label();
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        self.asm.jcc_label(Condition::Equal, no_flush);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_base);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-        self.asm.sub_reg_reg(Reg::Rax, Reg::R11);
-        self.asm.shr_reg_imm8(Reg::Rax, Self::GC_REGION_SHIFT);
-        self.asm.shl_reg_imm8(Reg::Rax, 3);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_top);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rax);
-        self.asm.mov_data_addr(Reg::R8, self.gc_evac_top);
-        self.asm.load_ptr_disp32(Reg::Rdx, Reg::R8, 0);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rdx);
-        self.asm.mov_imm64(Reg::Rax, 0);
-        self.asm.mov_data_addr(Reg::R10, self.gc_evac_region_base);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.bind_text_label(no_flush);
-        self.asm.mov_data_addr(Reg::R10, self.gc_phase);
-        self.asm.mov_imm64(Reg::Rax, Self::GC_PHASE_IDLE);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.mov_data_addr(Reg::R10, self.gc_bytes_since_cycle);
-        self.asm.mov_imm64(Reg::Rax, 0);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.leave();
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper).
+        let entry = self.gc_relocate_finish;
+        let tables = portable_asm::RegionTables {
+            heap_base: self.gc_heap_base,
+            heap_top: self.gc_heap_top,
+            region_base: self.gc_region_base,
+            region_top: self.gc_region_top,
+            committed_count: self.gc_committed_count,
+            region_fromspace: self.gc_region_fromspace,
+        };
+        portable_asm::emit_gc_relocate_finish(
+            self,
+            entry,
+            tables,
+            self.gc_evac_region_base,
+            self.gc_evac_top,
+            self.gc_phase,
+            self.gc_bytes_since_cycle,
+        );
     }
 
     /// RelocateStart (fused into the MarkEnd pause). Selects the sparsest

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -38606,86 +38606,18 @@ impl NativeCodeGenerator {
     /// reached for a non-null pointer (a null slot ANDs to zero against
     /// the bad mask and takes the fast path).
     fn emit_gc_load_barrier_slow_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_load_barrier_slow);
-        self.asm.and_reg_reg(Reg::Rax, Reg::R13); // strip -> raw P
-        let healed = self.asm.create_text_label();
-        let not_fwd = self.asm.create_text_label();
-        let done = self.asm.create_text_label();
-        // Follow forwarding: if P's header is a forwarding word, P is a
-        // ghost -- redirect rax to the to-space copy. Covers a load that
-        // reaches a not-yet-freed ghost in any phase. Inert while evac is
-        // off (FWD never set). Uses `bt` so the FWD test needs no scratch
-        // register -- the slow path must preserve every caller-saved
-        // register in the Idle path (its M5/M6 clobber set was rax/r10/
-        // r11 only), or callers holding a live value across an
-        // Idle-phase barriered load would be corrupted.
-        self.asm.load_ptr_disp32(Reg::R11, Reg::Rax, -16);
-        self.asm.bt_reg_imm8(Reg::R11, 0); // CF = FWD bit
-        self.asm.jcc_label(Condition::AboveOrEqual, not_fwd); // CF clear
-        self.asm.and_reg_imm32(Reg::R11, -16); // to-space user ptr
-        self.asm.mov_reg_reg(Reg::Rax, Reg::R11);
-        self.asm.jmp_label(healed);
-        self.asm.bind_text_label(not_fwd);
-        // Relocate: evacuate-on-demand. If P is in a from-space region,
-        // copy it now and follow the fresh forwarding word. Non-recursive
-        // (gc_evacuate only copies into the to-space bump). r10 (the field
-        // address) must be preserved through the self-heal, so the phase
-        // is read via r11 -- NOT r10, which still holds the field address.
-        self.asm.mov_data_addr(Reg::R11, self.gc_phase);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R11, 0);
-        self.asm
-            .cmp_reg_imm8(Reg::R11, Self::GC_PHASE_RELOCATE as i8);
-        self.asm.jcc_label(Condition::NotEqual, healed);
-        // idx = (P - region_base) >> SHIFT ; from-space?
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-        self.asm.mov_data_addr(Reg::R11, self.gc_region_base);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R11, 0);
-        self.asm.sub_reg_reg(Reg::Rcx, Reg::R11);
-        self.asm.shr_reg_imm8(Reg::Rcx, Self::GC_REGION_SHIFT);
-        self.asm.shl_reg_imm8(Reg::Rcx, 3);
-        self.asm.mov_data_addr(Reg::R11, self.gc_region_fromspace);
-        self.asm.add_reg_reg(Reg::R11, Reg::Rcx);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R11, 0);
-        self.asm.test_reg_reg(Reg::R11, Reg::R11);
-        self.asm.jcc_label(Condition::Equal, healed);
-        // Preserve across the evacuation call the registers the Idle/Mark
-        // slow path leaves untouched but gc_evacuate clobbers: r10 (the
-        // field address, needed for the self-heal), and rdx/rsi (which a
-        // pointer-typed barriered read preserves in every other phase, so
-        // a caller may hold a live value in them). Four pushes keep rsp
-        // 16-aligned; r11 is a throwaway pad (recomputed at the self-heal).
-        self.asm.push_reg(Reg::R10);
-        self.asm.push_reg(Reg::Rdx);
-        self.asm.push_reg(Reg::Rsi);
-        self.asm.push_reg(Reg::R11);
-        self.asm.mov_reg_reg(Reg::Rdi, Reg::Rax);
-        self.asm.call_label(self.gc_evacuate); // rax = to-space
-        self.asm.pop_reg(Reg::R11);
-        self.asm.pop_reg(Reg::Rsi);
-        self.asm.pop_reg(Reg::Rdx);
-        self.asm.pop_reg(Reg::R10);
-        self.asm.bind_text_label(healed);
-        // Self-heal: write the good-colored (remapped) pointer back to the
-        // slot. r10 = the field address, carried from the barrier fast
-        // path (and preserved across gc_evacuate above).
-        self.asm.mov_reg_reg(Reg::R11, Reg::Rax);
-        self.asm.or_reg_reg(Reg::R11, Reg::R14); // recolor to good
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R11); // self-heal
-        // During Mark, the mutator has just loaded a raw pointer into a
-        // register, so it must be marked to keep the strong tricolor
-        // invariant (load-barrier-driven incremental update). rax (the raw
-        // result) is preserved across the mark call; the only caller has
-        // just rax live, so the wider clobber set is safe.
-        self.asm.mov_data_addr(Reg::R10, self.gc_phase);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-        self.asm.cmp_reg_imm8(Reg::R11, Self::GC_PHASE_MARK as i8);
-        self.asm.jcc_label(Condition::NotEqual, done);
-        self.asm.push_reg(Reg::Rax);
-        self.asm.mov_reg_reg(Reg::Rdi, Reg::Rax);
-        self.asm.call_label(self.gc_mark_visit);
-        self.asm.pop_reg(Reg::Rax);
-        self.asm.bind_text_label(done);
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper).
+        let entry = self.gc_load_barrier_slow;
+        portable_asm::emit_gc_load_barrier_slow(
+            self,
+            entry,
+            self.gc_phase,
+            self.gc_region_base,
+            self.gc_region_fromspace,
+            self.gc_evacuate,
+            self.gc_mark_visit,
+        );
     }
 
     /// `gc_deep_equal(a, b)` (rdi = a, rsi = b) compares two heap values

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -37891,7 +37891,8 @@ impl NativeCodeGenerator {
     const GC_COLOR_BAD_MASK: u64 = crate::gc_layout::GC_COLOR_BAD_MASK;
     const GC_QUANTUM_POPS: u64 = crate::gc_layout::GC_QUANTUM_POPS;
     const GC_QUANTUM_BYTES: u64 = crate::gc_layout::GC_QUANTUM_BYTES;
-    const GC_PHASE_IDLE: u64 = crate::gc_layout::GC_PHASE_IDLE;
+    // GC_PHASE_IDLE's last lib.rs user moved to the portable emitter;
+    // reference crate::gc_layout::GC_PHASE_IDLE directly if needed here.
     const GC_PHASE_MARK: u64 = crate::gc_layout::GC_PHASE_MARK;
     const GC_PHASE_RELOCATE: u64 = crate::gc_layout::GC_PHASE_RELOCATE;
     const GC_FWD: u64 = crate::gc_layout::GC_FWD;
@@ -38987,189 +38988,38 @@ impl NativeCodeGenerator {
     /// Relocate phase. If evacuation is compiled off, or nothing worth
     /// evacuating is selected, it just closes the cycle to Idle (M6).
     fn emit_gc_relocate_start_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_relocate_start);
-        self.asm.push_reg(Reg::Rbp);
-        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
-        let mark_only = self.asm.create_text_label();
-        if !self.gc_evac_off {
-            // slots: 8=idx, 16=committed, 24=cap_bytes, 32=selected_live,
-            // 40=cur_bump_idx.
-            self.asm.sub_reg_imm8(Reg::Rsp, 48);
-            // Idle/Relocate color config: good = R, bad = M0|M1 (or
-            // COLOR_MASK under poison). Applies to both the Relocate entry
-            // and the mark-only fallback (both end at good = R).
-            self.asm.mov_imm64(Reg::Rax, Self::GC_COLOR_R);
-            self.asm.mov_data_addr(Reg::R10, self.gc_good_color);
-            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-            if self.gc_poison {
-                self.asm.mov_imm64(Reg::Rax, Self::GC_COLOR_MASK);
-            } else {
-                self.asm
-                    .mov_imm64(Reg::Rax, Self::GC_COLOR_M0 | Self::GC_COLOR_M1);
-            }
-            self.asm.mov_data_addr(Reg::R10, self.gc_bad_mask);
-            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-            self.asm.mov_data_addr(Reg::R14, self.gc_good_color);
-            self.asm.load_ptr_disp32(Reg::R14, Reg::R14, 0);
-            self.asm.mov_data_addr(Reg::R15, self.gc_bad_mask);
-            self.asm.load_ptr_disp32(Reg::R15, Reg::R15, 0);
-            // free_regions = (budget - committed) + free-pool count.
-            self.asm.mov_imm64(Reg::Rcx, 0);
-            self.asm.mov_data_addr(Reg::R10, self.gc_free_region_head);
-            self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-            let fp_loop = self.asm.create_text_label();
-            let fp_done = self.asm.create_text_label();
-            self.asm.bind_text_label(fp_loop);
-            self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-            self.asm.jcc_label(Condition::Equal, fp_done);
-            self.asm.add_reg_imm32(Reg::Rcx, 1);
-            self.asm.load_ptr_disp32(Reg::Rax, Reg::Rax, 0);
-            self.asm.jmp_label(fp_loop);
-            self.asm.bind_text_label(fp_done);
-            self.asm.mov_data_addr(Reg::R10, self.gc_budget_regions);
-            self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-            self.asm.mov_data_addr(Reg::R10, self.gc_committed_count);
-            self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-            self.asm.sub_reg_reg(Reg::Rax, Reg::R11);
-            self.asm.add_reg_reg(Reg::Rax, Reg::Rcx); // rax = free_regions
-            // cap_bytes = (free_regions >= 2) ? (free_regions-2)<<(SHIFT-1)
-            // : 0. The cap bounds evacuated LIVE BYTES, but evacuation
-            // consumes whole to-space REGIONS by bump-packing, and packing
-            // sparse mid-size objects wastes space (an object just over
-            // REGION_SIZE/3 packs 2 per region ~= 67% efficiency). Using
-            // half the free bytes as the cap keeps the region count within
-            // free_regions-2 even at ~50% packing, so gc_acquire_evac_
-            // region can always satisfy an evacuation without running past
-            // the reservation.
-            let have_cap = self.asm.create_text_label();
-            let store_cap = self.asm.create_text_label();
-            self.asm.cmp_reg_imm8(Reg::Rax, 2);
-            self.asm.jcc_label(Condition::AboveOrEqual, have_cap);
-            self.asm.mov_imm64(Reg::Rax, 0);
-            self.asm.jmp_label(store_cap);
-            self.asm.bind_text_label(have_cap);
-            self.asm.sub_reg_imm8(Reg::Rax, 2);
-            self.asm.shl_reg_imm8(Reg::Rax, Self::GC_REGION_SHIFT - 1);
-            self.asm.bind_text_label(store_cap);
-            self.asm.store_rbp_slot(24, Reg::Rax); // cap_bytes
-            // cur_bump_idx = (heap_base - region_base) >> SHIFT.
-            self.asm.mov_data_addr(Reg::R10, self.gc_heap_base);
-            self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-            self.asm.mov_data_addr(Reg::R10, self.gc_region_base);
-            self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-            self.asm.sub_reg_reg(Reg::Rax, Reg::R11);
-            self.asm.shr_reg_imm8(Reg::Rax, Self::GC_REGION_SHIFT);
-            self.asm.store_rbp_slot(40, Reg::Rax);
-            self.asm.mov_data_addr(Reg::R10, self.gc_committed_count);
-            self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-            self.asm.store_rbp_slot(16, Reg::Rax); // committed bound
-            self.asm.mov_imm64(Reg::Rax, 0);
-            self.asm.store_rbp_slot(8, Reg::Rax); // idx
-            self.asm.store_rbp_slot(32, Reg::Rax); // selected_live
-            let sel_loop = self.asm.create_text_label();
-            let sel_next = self.asm.create_text_label();
-            let sel_done = self.asm.create_text_label();
-            self.asm.bind_text_label(sel_loop);
-            self.asm.load_rbp_slot(Reg::Rax, 8);
-            self.asm.load_rbp_slot(Reg::Rcx, 16);
-            self.asm.cmp_reg_reg(Reg::Rax, Reg::Rcx);
-            self.asm.jcc_label(Condition::AboveOrEqual, sel_done);
-            // skip the current bump region.
-            self.asm.load_rbp_slot(Reg::Rcx, 40);
-            self.asm.cmp_reg_reg(Reg::Rax, Reg::Rcx);
-            self.asm.jcc_label(Condition::Equal, sel_next);
-            // base = region_base + idx<<SHIFT ; top = region_top[idx].
-            self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-            self.asm.shl_reg_imm8(Reg::Rcx, Self::GC_REGION_SHIFT);
-            self.asm.mov_data_addr(Reg::R10, self.gc_region_base);
-            self.asm.load_ptr_disp32(Reg::R10, Reg::R10, 0);
-            self.asm.add_reg_reg(Reg::Rcx, Reg::R10); // base (rcx)
-            self.asm.load_rbp_slot(Reg::R8, 8);
-            self.asm.shl_reg_imm8(Reg::R8, 3);
-            self.asm.mov_data_addr(Reg::R10, self.gc_region_top);
-            self.asm.add_reg_reg(Reg::R10, Reg::R8);
-            self.asm.load_ptr_disp32(Reg::R8, Reg::R10, 0); // top (r8)
-            // empty (top == base)?
-            self.asm.cmp_reg_reg(Reg::R8, Reg::Rcx);
-            self.asm.jcc_label(Condition::Equal, sel_next);
-            // large (top - base > REGION_SIZE)?
-            self.asm.sub_reg_reg(Reg::R8, Reg::Rcx); // used bytes
-            self.asm.cmp_reg_imm32(Reg::R8, Self::GC_REGION_SIZE as i32);
-            self.asm.jcc_label(Condition::Above, sel_next);
-            // live = gc_region_live[idx].
-            self.asm.load_rbp_slot(Reg::R8, 8);
-            self.asm.shl_reg_imm8(Reg::R8, 3);
-            self.asm.mov_data_addr(Reg::R10, self.gc_region_live);
-            self.asm.add_reg_reg(Reg::R10, Reg::R8);
-            self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0); // live (r11)
-            // not sparse (live >= REGION_SIZE/2)?
-            self.asm
-                .cmp_reg_imm32(Reg::R11, (Self::GC_REGION_SIZE / 2) as i32);
-            self.asm.jcc_label(Condition::AboveOrEqual, sel_next);
-            // headroom (selected_live + live > cap)?
-            self.asm.load_rbp_slot(Reg::Rax, 32);
-            self.asm.add_reg_reg(Reg::Rax, Reg::R11);
-            self.asm.load_rbp_slot(Reg::Rcx, 24);
-            self.asm.cmp_reg_reg(Reg::Rax, Reg::Rcx);
-            self.asm.jcc_label(Condition::Above, sel_next);
-            // select: fromspace[idx] = 1 ; selected_live += live.
-            self.asm.store_rbp_slot(32, Reg::Rax); // selected_live += live
-            self.asm.load_rbp_slot(Reg::R8, 8);
-            self.asm.shl_reg_imm8(Reg::R8, 3);
-            self.asm.mov_data_addr(Reg::R10, self.gc_region_fromspace);
-            self.asm.add_reg_reg(Reg::R10, Reg::R8);
-            self.asm.mov_imm64(Reg::Rax, 1);
-            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-            self.asm.bind_text_label(sel_next);
-            self.asm.load_rbp_slot(Reg::Rax, 8);
-            self.asm.add_reg_imm32(Reg::Rax, 1);
-            self.asm.store_rbp_slot(8, Reg::Rax);
-            self.asm.jmp_label(sel_loop);
-            self.asm.bind_text_label(sel_done);
-            // Nothing selected -> mark-only close.
-            self.asm.load_rbp_slot(Reg::Rax, 32);
-            self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-            self.asm.jcc_label(Condition::Equal, mark_only);
-            // Reset the evacuation bump so the first copy acquires a fresh
-            // to-space region -- gc_relocate_finish only clears
-            // gc_evac_region_base, so gc_evac_top/end would otherwise be
-            // stale from the previous cycle and the first gc_evacuate
-            // would write into that (now freed/reused) region.
-            self.asm.mov_imm64(Reg::Rax, 0);
-            self.asm.mov_data_addr(Reg::R10, self.gc_evac_region_base);
-            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-            self.asm.mov_data_addr(Reg::R10, self.gc_evac_top);
-            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-            self.asm.mov_data_addr(Reg::R10, self.gc_evac_end);
-            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-            // Fix roots, reset the relocate cursor + quantum pacer, enter
-            // the Relocate phase.
-            self.asm.call_label(self.gc_relocate_fix_roots);
-            self.asm.mov_imm64(Reg::Rax, 0);
-            self.asm.mov_data_addr(Reg::R10, self.gc_reloc_scan_idx);
-            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-            self.asm.mov_data_addr(Reg::R10, self.gc_reloc_block);
-            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-            self.asm
-                .mov_data_addr(Reg::R10, self.gc_bytes_since_quantum);
-            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-            self.asm.mov_data_addr(Reg::R10, self.gc_phase);
-            self.asm.mov_imm64(Reg::Rax, Self::GC_PHASE_RELOCATE);
-            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-            self.asm.leave();
-            self.asm.ret();
-        }
-        // Mark-only close (evac off, or nothing selected): back to Idle,
-        // reset the proactive counter.
-        self.asm.bind_text_label(mark_only);
-        self.asm.mov_data_addr(Reg::R10, self.gc_phase);
-        self.asm.mov_imm64(Reg::Rax, Self::GC_PHASE_IDLE);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.mov_data_addr(Reg::R10, self.gc_bytes_since_cycle);
-        self.asm.mov_imm64(Reg::Rax, 0);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.leave();
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper). The
+        // evac_off / poison codegen flags are passed through.
+        let entry = self.gc_relocate_start;
+        let cells = portable_asm::RelocateStartCells {
+            good_color: self.gc_good_color,
+            bad_mask: self.gc_bad_mask,
+            free_region_head: self.gc_free_region_head,
+            budget_regions: self.gc_budget_regions,
+            committed_count: self.gc_committed_count,
+            heap_base: self.gc_heap_base,
+            region_base: self.gc_region_base,
+            region_top: self.gc_region_top,
+            region_live: self.gc_region_live,
+            region_fromspace: self.gc_region_fromspace,
+            evac_region_base: self.gc_evac_region_base,
+            evac_top: self.gc_evac_top,
+            evac_end: self.gc_evac_end,
+            reloc_scan_idx: self.gc_reloc_scan_idx,
+            reloc_block: self.gc_reloc_block,
+            bytes_since_quantum: self.gc_bytes_since_quantum,
+            phase: self.gc_phase,
+            bytes_since_cycle: self.gc_bytes_since_cycle,
+        };
+        portable_asm::emit_gc_relocate_start(
+            self,
+            entry,
+            cells,
+            self.gc_relocate_fix_roots,
+            self.gc_evac_off,
+            self.gc_poison,
+        );
     }
 
     /// `gc_alloc_large(rdi = total, rsi = tag)`: allocate an object bigger

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -38135,33 +38135,22 @@ impl NativeCodeGenerator {
     /// there, so a pause simply reads 0). Emitted at the start of each
     /// STW pause (MarkStart, MarkEnd, and the synchronous full collect).
     fn emit_gc_pause_start(&mut self) {
-        if self.gc_log && !self.is_windows {
-            self.emit_read_monotonic_ns_to_rax();
-            self.asm.mov_data_addr(Reg::R10, self.gc_pause_start_ns);
-            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        }
+        // Delegated to the portable emitter; the `--gc-log`-and-not-Windows
+        // gate stays here (it is host-config state, not codegen), and the
+        // clock read is a `PortableAsm` platform primitive. Byte-identical.
+        let timing = self.gc_log && !self.is_windows;
+        let start = self.gc_pause_start_ns;
+        portable_asm::emit_gc_pause_start(self, timing, start);
     }
 
     /// Fold the elapsed pause (now - gc_pause_start_ns) into the max and
     /// total pause accumulators. Emitted at the end of each STW pause.
     fn emit_gc_pause_end(&mut self) {
-        if self.gc_log && !self.is_windows {
-            self.emit_read_monotonic_ns_to_rax();
-            self.asm.mov_data_addr(Reg::R10, self.gc_pause_start_ns);
-            self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-            self.asm.sub_reg_reg(Reg::Rax, Reg::R11); // rax = delta ns
-            self.asm.mov_data_addr(Reg::R10, self.gc_pause_total_ns);
-            self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-            self.asm.add_reg_reg(Reg::R11, Reg::Rax);
-            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R11);
-            self.asm.mov_data_addr(Reg::R10, self.gc_pause_max_ns);
-            self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-            self.asm.cmp_reg_reg(Reg::Rax, Reg::R11);
-            let keep_max = self.asm.create_text_label();
-            self.asm.jcc_label(Condition::LessEqual, keep_max);
-            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-            self.asm.bind_text_label(keep_max);
-        }
+        let timing = self.gc_log && !self.is_windows;
+        let start = self.gc_pause_start_ns;
+        let total = self.gc_pause_total_ns;
+        let max = self.gc_pause_max_ns;
+        portable_asm::emit_gc_pause_end(self, timing, start, total, max);
     }
 
     fn emit_gc_alloc_runtime(&mut self) {

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -38806,83 +38806,18 @@ impl NativeCodeGenerator {
     /// STW re-mark must start from a fully-clear state. Own frame:
     /// [rbp-8] = region index, [rbp-16] = committed bound.
     fn emit_gc_clear_all_marks_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_clear_all_marks);
-        self.asm.push_reg(Reg::Rbp);
-        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
-        self.asm.sub_reg_imm8(Reg::Rsp, 16);
-        // Flush the current region's watermark so its blocks are covered.
-        self.asm.mov_data_addr(Reg::R10, self.gc_heap_base);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_base);
-        self.asm.load_ptr_disp32(Reg::R10, Reg::R10, 0);
-        self.asm.sub_reg_reg(Reg::R11, Reg::R10);
-        self.asm.shr_reg_imm8(Reg::R11, Self::GC_REGION_SHIFT);
-        self.asm.shl_reg_imm8(Reg::R11, 3);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_top);
-        self.asm.add_reg_reg(Reg::R10, Reg::R11);
-        self.asm.mov_data_addr(Reg::R8, self.gc_heap_top);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R8, 0);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        // bound = committed_count; idx = 0.
-        self.asm.mov_data_addr(Reg::R10, self.gc_committed_count);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.store_rbp_slot(16, Reg::Rax);
-        self.asm.mov_imm64(Reg::Rax, 0);
-        self.asm.store_rbp_slot(8, Reg::Rax);
-
-        let region_loop = self.asm.create_text_label();
-        let region_done = self.asm.create_text_label();
-        let block_loop = self.asm.create_text_label();
-        let next_region = self.asm.create_text_label();
-        self.asm.bind_text_label(region_loop);
-        self.asm.load_rbp_slot(Reg::Rax, 8);
-        self.asm.load_rbp_slot(Reg::Rcx, 16);
-        self.asm.cmp_reg_reg(Reg::Rax, Reg::Rcx);
-        self.asm.jcc_label(Condition::AboveOrEqual, region_done);
-        // base (rsi) = region_base + idx<<SHIFT; top (r8) = region_top[idx].
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-        self.asm.shl_reg_imm8(Reg::Rcx, Self::GC_REGION_SHIFT);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_base);
-        self.asm.load_ptr_disp32(Reg::R10, Reg::R10, 0);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rcx);
-        self.asm.mov_reg_reg(Reg::Rsi, Reg::R10);
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-        self.asm.shl_reg_imm8(Reg::Rcx, 3);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_top);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rcx);
-        self.asm.load_ptr_disp32(Reg::R8, Reg::R10, 0);
-        self.asm.cmp_reg_reg(Reg::R8, Reg::Rsi);
-        self.asm.jcc_label(Condition::Equal, next_region);
-        // M7: skip from-space (ghost) regions (inert while evac is off).
-        // clear_all_marks can run during a degrade while previous-cycle
-        // ghosts still exist; their forwarding words must not be masked.
-        self.asm.load_rbp_slot(Reg::Rax, 8);
-        self.asm.shl_reg_imm8(Reg::Rax, 3);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_fromspace);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rax);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        self.asm.jcc_label(Condition::NotEqual, next_region);
-        // Walk blocks base..top, clearing both mark bits on each header
-        // word0 (`and -16` also clears FWD, which is always 0 here since
-        // no block is forwarded when the from-scratch mark runs).
-        self.asm.mov_reg_reg(Reg::R11, Reg::Rsi);
-        self.asm.bind_text_label(block_loop);
-        self.asm.cmp_reg_reg(Reg::R11, Reg::R8);
-        self.asm.jcc_label(Condition::AboveOrEqual, next_region);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R11, 0);
-        self.asm.and_reg_imm32(Reg::Rax, -16); // size, marks cleared
-        self.asm.store_ptr_disp32(Reg::R11, 0, Reg::Rax);
-        self.asm.add_reg_reg(Reg::R11, Reg::Rax);
-        self.asm.jmp_label(block_loop);
-        self.asm.bind_text_label(next_region);
-        self.asm.load_rbp_slot(Reg::Rax, 8);
-        self.asm.add_reg_imm32(Reg::Rax, 1);
-        self.asm.store_rbp_slot(8, Reg::Rax);
-        self.asm.jmp_label(region_loop);
-        self.asm.bind_text_label(region_done);
-        self.asm.leave();
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper).
+        let entry = self.gc_clear_all_marks;
+        let tables = portable_asm::RegionTables {
+            heap_base: self.gc_heap_base,
+            heap_top: self.gc_heap_top,
+            region_base: self.gc_region_base,
+            region_top: self.gc_region_top,
+            committed_count: self.gc_committed_count,
+            region_fromspace: self.gc_region_fromspace,
+        };
+        portable_asm::emit_gc_clear_all_marks(self, entry, tables);
     }
 
     /// From-scratch STW mark to fixpoint (the collector's IDLE-cycle and

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -37895,11 +37895,12 @@ impl NativeCodeGenerator {
     const GC_PHASE_MARK: u64 = crate::gc_layout::GC_PHASE_MARK;
     const GC_PHASE_RELOCATE: u64 = crate::gc_layout::GC_PHASE_RELOCATE;
     const GC_FWD: u64 = crate::gc_layout::GC_FWD;
-    // GC_HMARK0 has no direct `Self::` use in this file (its only prior
-    // reference was inside GC_HMARK_BOTH's definition, now in gc_layout);
-    // reference it via `crate::gc_layout::GC_HMARK0` if ever needed.
+    // GC_HMARK0 / GC_HMARK_BOTH have no direct `Self::` use left in this
+    // file: HMARK0's only reference was inside HMARK_BOTH's definition
+    // (now in gc_layout), and HMARK_BOTH's last user (gc_mark_start) moved
+    // to the portable emitter. Reference them via `crate::gc_layout::` if
+    // ever needed here again.
     const GC_HMARK1: u64 = crate::gc_layout::GC_HMARK1;
-    const GC_HMARK_BOTH: u64 = crate::gc_layout::GC_HMARK_BOTH;
 
     /// Initialize the reserved color registers once, before any user
     /// code or collector routine runs. r13 = strip mask, r14 = good
@@ -38856,82 +38857,34 @@ impl NativeCodeGenerator {
     /// reload the reserved color-register caches, reset the worklist,
     /// scan roots, and enter the Mark phase. O(roots).
     fn emit_gc_mark_start_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_mark_start);
-        self.asm.push_reg(Reg::Rbp);
-        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
-        self.emit_gc_pause_start(); // MarkStart is a short STW pause (O(roots)).
-        // M7: toggle the header mark parity (bits 1-2) so this cycle marks
-        // with the OTHER bit than the last cycle -- a live object surviving
-        // multiple cycles is thus re-marked each cycle, and the sweep
-        // clears the now-stale parity. Must precede gc_mark_roots (which
-        // sets the current mark bit on roots).
-        self.asm.mov_data_addr(Reg::R10, self.gc_header_mark);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.mov_imm64(Reg::R11, Self::GC_HMARK_BOTH);
-        self.asm.xor_reg_reg(Reg::Rax, Reg::R11);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        // Enter the Mark phase's color config. The mark color toggles
-        // M0<->M1 each cycle. Good becomes the new mark color; bad catches
-        // the other two colors so any pointer NOT at the new mark color
-        // (an R-colored Idle pointer, or a stale old-mark-color pointer)
-        // slow-paths and is remapped + marked (incremental update).
-        if self.gc_evac_off {
-            // M6 scheme: good flips M0<->M1 directly via gc_good_color.
-            self.asm.mov_data_addr(Reg::R10, self.gc_good_color);
-            self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0); // old good
-            if self.gc_poison {
-                self.asm.mov_imm64(Reg::Rcx, Self::GC_COLOR_MASK);
-            } else {
-                self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-                self.asm.mov_imm64(Reg::R11, Self::GC_COLOR_R);
-                self.asm.or_reg_reg(Reg::Rcx, Reg::R11); // old_good | R
-            }
-            self.asm.mov_data_addr(Reg::R11, self.gc_bad_mask);
-            self.asm.store_ptr_disp32(Reg::R11, 0, Reg::Rcx);
-            self.asm
-                .mov_imm64(Reg::Rcx, Self::GC_COLOR_M0 | Self::GC_COLOR_M1);
-            self.asm.xor_reg_reg(Reg::Rax, Reg::Rcx);
-            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        } else {
-            // R scheme: toggle the persistent mark color, then good =
-            // mark color, bad = (M0|M1|R) ^ mark color.
-            self.asm.mov_data_addr(Reg::R10, self.gc_mark_color);
-            self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-            self.asm
-                .mov_imm64(Reg::Rcx, Self::GC_COLOR_M0 | Self::GC_COLOR_M1);
-            self.asm.xor_reg_reg(Reg::Rax, Reg::Rcx); // new mark color
-            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-            self.asm.mov_data_addr(Reg::R10, self.gc_good_color);
-            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax); // good = mark color
-            if self.gc_poison {
-                self.asm.mov_imm64(Reg::Rcx, Self::GC_COLOR_MASK);
-            } else {
-                self.asm.mov_imm64(
-                    Reg::Rcx,
-                    Self::GC_COLOR_M0 | Self::GC_COLOR_M1 | Self::GC_COLOR_R,
-                );
-                self.asm.xor_reg_reg(Reg::Rcx, Reg::Rax); // (M0|M1|R) ^ mark
-            }
-            self.asm.mov_data_addr(Reg::R11, self.gc_bad_mask);
-            self.asm.store_ptr_disp32(Reg::R11, 0, Reg::Rcx);
-        }
-        // Reload the caches from the cells.
-        self.asm.mov_data_addr(Reg::R14, self.gc_good_color);
-        self.asm.load_ptr_disp32(Reg::R14, Reg::R14, 0);
-        self.asm.mov_data_addr(Reg::R15, self.gc_bad_mask);
-        self.asm.load_ptr_disp32(Reg::R15, Reg::R15, 0);
-        // Reset the worklist and scan roots into it (marked new-color).
-        self.asm.mov_data_addr(Reg::R10, self.gc_mark_worklist_top);
-        self.asm.mov_imm64(Reg::Rax, 0);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.call_label(self.gc_mark_roots);
-        // Enter the Mark phase.
-        self.asm.mov_data_addr(Reg::R10, self.gc_phase);
-        self.asm.mov_imm64(Reg::Rax, Self::GC_PHASE_MARK);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.emit_gc_pause_end();
-        self.asm.leave();
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper). The two
+        // host-config flags that selected inline `if` branches -- evac_off
+        // and poison -- are passed through so the same code is chosen.
+        let entry = self.gc_mark_start;
+        let timing = self.gc_log && !self.is_windows;
+        let pause = self.gc_pause_cells();
+        let cells = portable_asm::MarkStartCells {
+            header_mark: self.gc_header_mark,
+            good_color: self.gc_good_color,
+            bad_mask: self.gc_bad_mask,
+            mark_color: self.gc_mark_color,
+            worklist_top: self.gc_mark_worklist_top,
+            phase: self.gc_phase,
+        };
+        let mode = portable_asm::MarkColorMode {
+            evac_off: self.gc_evac_off,
+            poison: self.gc_poison,
+        };
+        portable_asm::emit_gc_mark_start(
+            self,
+            entry,
+            timing,
+            pause,
+            cells,
+            self.gc_mark_roots,
+            mode,
+        );
     }
 
     /// MarkEnd (short STW pause): finish the cycle. If the worklist

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -38881,89 +38881,27 @@ impl NativeCodeGenerator {
     /// only copies, never allocates through gc_alloc. Preserves the
     /// reserved color registers.
     fn emit_gc_evacuate_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_evacuate);
-        self.asm.push_reg(Reg::Rbp);
-        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
-        self.asm.sub_reg_imm8(Reg::Rsp, 16); // [rbp-8]=oldP, [rbp-16]=size
-        let copy = self.asm.create_text_label();
-        let epilogue = self.asm.create_text_label();
-        let retry = self.asm.create_text_label();
-        let fits = self.asm.create_text_label();
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::Rdi, -16);
-        // Already forwarded? rax & FWD.
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-        self.asm.and_reg_imm32(Reg::Rcx, Self::GC_FWD as i32);
-        self.asm.test_reg_reg(Reg::Rcx, Reg::Rcx);
-        self.asm.jcc_label(Condition::Equal, copy);
-        self.asm.and_reg_imm32(Reg::Rax, -16); // to-space user ptr
-        self.asm.jmp_label(epilogue);
-        self.asm.bind_text_label(copy);
-        self.asm.store_rbp_slot(8, Reg::Rdi); // oldP
-        self.asm.and_reg_imm32(Reg::Rax, -16); // size S
-        self.asm.store_rbp_slot(16, Reg::Rax);
-        // An object that does not fit one to-space region can never be
-        // evacuated (the refill loop below would spin forever). Selection
-        // guarantees this never happens (large objects are excluded and
-        // from-space objects are < REGION_SIZE/2), so treat it as an
-        // invariant violation and abort cleanly rather than hang.
-        let evac_size_ok = self.asm.create_text_label();
-        let evac_oversized = self.asm.create_text_label();
-        self.asm
-            .cmp_reg_imm32(Reg::Rax, Self::GC_REGION_SIZE as i32);
-        self.asm.jcc_label(Condition::Above, evac_oversized);
-        self.asm.jmp_label(evac_size_ok);
-        self.asm.bind_text_label(evac_oversized);
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper). The
+        // oversized-diagnostic label and stderr fd are resolved here.
+        let entry = self.gc_evacuate;
         let msg = b"klassic gc: evacuation object exceeds a region\n";
         let txt = self.asm.data_label_with_bytes(msg);
-        self.emit_write_data(self.platform.stderr_fd(), txt, msg.len());
-        self.emit_exit_code(1);
-        self.asm.bind_text_label(evac_size_ok);
-        let need_refill = self.asm.create_text_label();
-        self.asm.bind_text_label(retry);
-        self.asm.mov_data_addr(Reg::R10, self.gc_evac_top);
-        self.asm.load_ptr_disp32(Reg::R8, Reg::R10, 0); // dst = evac_top
-        self.asm.load_rbp_slot(Reg::Rdx, 16); // S
-        self.asm.mov_reg_reg(Reg::R9, Reg::R8);
-        self.asm.add_reg_reg(Reg::R9, Reg::Rdx); // new_top = dst + S
-        self.asm.mov_data_addr(Reg::R10, self.gc_evac_end);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-        self.asm.cmp_reg_reg(Reg::R9, Reg::R11);
-        self.asm.jcc_label(Condition::Above, need_refill); // new_top > end
-        self.asm.jmp_label(fits);
-        // Refill to-space (never fails: headroom invariant).
-        self.asm.bind_text_label(need_refill);
-        self.asm.load_rbp_slot(Reg::Rdi, 16); // size
-        self.asm.call_label(self.gc_acquire_evac_region);
-        self.asm.jmp_label(retry);
-        self.asm.bind_text_label(fits);
-        self.asm.mov_data_addr(Reg::R10, self.gc_evac_top);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R9); // bump
-        // memcpy S bytes: rsi = oldP-16, rdi = dst (r8), rcx = S.
-        self.asm.load_rbp_slot(Reg::Rsi, 8);
-        self.asm.sub_reg_imm8(Reg::Rsi, 16);
-        self.asm.mov_reg_reg(Reg::Rdi, Reg::R8);
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rdx);
-        self.asm.rep_movsb(); // clobbers rsi/rdi/rcx; r8 survives
-        // n_user = dst + 16.
-        self.asm.mov_reg_reg(Reg::Rax, Reg::R8);
-        self.asm.add_reg_imm32(Reg::Rax, 16);
-        // Install forwarding in the OLD header: [oldP-16] = n_user | FWD.
-        self.asm.load_rbp_slot(Reg::R11, 8); // oldP
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-        self.asm.mov_imm64(Reg::Rdx, Self::GC_FWD);
-        self.asm.or_reg_reg(Reg::Rcx, Reg::Rdx);
-        self.asm.store_ptr_disp32(Reg::R11, -16, Reg::Rcx);
-        // [oldP-8] = S (word1, size for the relocate walk).
-        self.asm.load_rbp_slot(Reg::Rcx, 16);
-        self.asm.store_ptr_disp32(Reg::R11, -8, Reg::Rcx);
-        // Count this evacuation (--gc-log). rax = n_user must survive.
-        self.asm.mov_data_addr(Reg::R10, self.gc_relocated_count);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-        self.asm.add_reg_imm32(Reg::R11, 1);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R11);
-        self.asm.bind_text_label(epilogue);
-        self.asm.leave();
-        self.asm.ret();
+        let stderr_fd = self.platform.stderr_fd();
+        let cells = portable_asm::EvacBumpCells {
+            evac_top: self.gc_evac_top,
+            evac_end: self.gc_evac_end,
+            relocated_count: self.gc_relocated_count,
+        };
+        portable_asm::emit_gc_evacuate(
+            self,
+            entry,
+            cells,
+            self.gc_acquire_evac_region,
+            txt,
+            msg.len(),
+            stderr_fd,
+        );
     }
 
     /// Fix up all roots at RelocateStart: walk the shadow stack and, for

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -38930,19 +38930,12 @@ impl NativeCodeGenerator {
     /// Drain the mark worklist to fixpoint by running quanta back to
     /// back. Used by the STW paths (gc_stw_mark_complete, gc_mark_end).
     fn emit_gc_drain_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_drain);
-        self.asm.push_reg(Reg::Rbp);
-        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
-        let drain_loop = self.asm.create_text_label();
-        self.asm.bind_text_label(drain_loop);
-        self.asm.mov_imm64(Reg::Rdi, Self::GC_QUANTUM_POPS);
-        self.asm.call_label(self.gc_trace);
-        self.asm.mov_data_addr(Reg::R10, self.gc_mark_worklist_top);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        self.asm.jcc_label(Condition::NotEqual, drain_loop);
-        self.asm.leave();
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper).
+        let entry = self.gc_drain;
+        let trace = self.gc_trace;
+        let worklist_top = self.gc_mark_worklist_top;
+        portable_asm::emit_gc_drain(self, entry, trace, worklist_top);
     }
 
     /// MarkStart (short STW pause): flip the mark color to the new cycle,

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -38928,134 +38928,30 @@ impl NativeCodeGenerator {
     /// evacuating each live, not-yet-forwarded block, until the budget is
     /// spent or all from-space is drained -> gc_relocate_finish.
     fn emit_gc_relocate_quantum_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_relocate_quantum);
-        self.asm.push_reg(Reg::Rbp);
-        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
-        self.asm.sub_reg_imm8(Reg::Rsp, 32); // 8=budget,16=cur,24=top
-        self.asm.store_rbp_slot(8, Reg::Rdi);
-        let region_scan = self.asm.create_text_label();
-        let block_loop = self.asm.create_text_label();
-        let advance_region = self.asm.create_text_label();
-        let not_fwd = self.asm.create_text_label();
-        let after_block = self.asm.create_text_label();
-        let saved_cur = self.asm.create_text_label();
-        self.asm.bind_text_label(region_scan);
-        // idx = gc_reloc_scan_idx; if idx >= committed -> finish.
-        self.asm.mov_data_addr(Reg::R10, self.gc_reloc_scan_idx);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.mov_data_addr(Reg::R10, self.gc_committed_count);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-        self.asm.cmp_reg_reg(Reg::Rax, Reg::R11);
-        self.asm.jcc_label(Condition::AboveOrEqual, saved_cur);
-        // fromspace[idx]? if not, advance to next region.
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-        self.asm.shl_reg_imm8(Reg::Rcx, 3);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_fromspace);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rcx);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-        self.asm.test_reg_reg(Reg::R11, Reg::R11);
-        self.asm.jcc_label(Condition::Equal, advance_region);
-        // base = region_base + (idx << SHIFT) ; top = region_top[idx].
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-        self.asm.shl_reg_imm8(Reg::Rcx, Self::GC_REGION_SHIFT);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_base);
-        self.asm.load_ptr_disp32(Reg::R10, Reg::R10, 0);
-        self.asm.add_reg_reg(Reg::Rcx, Reg::R10); // base
-        self.asm.mov_reg_reg(Reg::R8, Reg::Rax);
-        self.asm.shl_reg_imm8(Reg::R8, 3);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_top);
-        self.asm.add_reg_reg(Reg::R10, Reg::R8);
-        self.asm.load_ptr_disp32(Reg::R8, Reg::R10, 0); // top
-        self.asm.store_rbp_slot(24, Reg::R8);
-        // cur = gc_reloc_block; if 0 use base.
-        self.asm.mov_data_addr(Reg::R10, self.gc_reloc_block);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        let have_cur = self.asm.create_text_label();
-        self.asm.jcc_label(Condition::NotEqual, have_cur);
-        self.asm.mov_reg_reg(Reg::Rax, Reg::Rcx); // cur = base
-        self.asm.bind_text_label(have_cur);
-        self.asm.store_rbp_slot(16, Reg::Rax);
-        self.asm.bind_text_label(block_loop);
-        self.asm.load_rbp_slot(Reg::Rax, 16); // cur
-        self.asm.load_rbp_slot(Reg::R8, 24); // top
-        self.asm.cmp_reg_reg(Reg::Rax, Reg::R8);
-        self.asm.jcc_label(Condition::AboveOrEqual, advance_region);
-        // budget <= 0 ? save cur and return.
-        self.asm.load_rbp_slot(Reg::Rcx, 8);
-        self.asm.test_reg_reg(Reg::Rcx, Reg::Rcx);
-        self.asm.jcc_label(Condition::Equal, saved_cur);
-        self.asm.cmp_reg_imm8(Reg::Rcx, 0);
-        self.asm.jcc_label(Condition::Less, saved_cur);
-        // word0 = [cur].
-        self.asm.load_ptr_disp32(Reg::R11, Reg::Rax, 0);
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::R11);
-        self.asm.and_reg_imm32(Reg::Rcx, Self::GC_FWD as i32);
-        self.asm.test_reg_reg(Reg::Rcx, Reg::Rcx);
-        self.asm.jcc_label(Condition::Equal, not_fwd);
-        // Forwarded: size from word1 = [cur+8].
-        self.asm.load_ptr_disp32(Reg::Rcx, Reg::Rax, 8);
-        self.asm.jmp_label(after_block);
-        self.asm.bind_text_label(not_fwd);
-        // size = word0 & -16.
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::R11);
-        self.asm.and_reg_imm32(Reg::Rcx, -16);
-        // live? (word0 & current mark bit)
-        self.asm.mov_data_addr(Reg::R10, self.gc_header_mark);
-        self.asm.load_ptr_disp32(Reg::R8, Reg::R10, 0);
-        self.asm.test_reg_reg(Reg::R11, Reg::R8);
-        self.asm.jcc_label(Condition::Equal, after_block);
-        // Live: evacuate(cur+16). Preserve cur/size in slots; the call
-        // clobbers rax/rcx/etc. budget -= size.
-        self.asm.store_rbp_slot(16, Reg::Rax); // (cur unchanged, keep)
-        self.asm.mov_reg_reg(Reg::Rdi, Reg::Rax);
-        self.asm.add_reg_imm32(Reg::Rdi, 16); // user ptr
-        // stash size in a callee-preserved-ish slot before the call.
-        self.asm.push_reg(Reg::Rcx); // size (16-byte align: one push, then call — realign)
-        self.asm.push_reg(Reg::Rcx); // pad to keep rsp 16-aligned
-        self.asm.call_label(self.gc_evacuate);
-        self.asm.pop_reg(Reg::Rcx);
-        self.asm.pop_reg(Reg::Rcx); // rcx = size
-        // budget -= size
-        self.asm.load_rbp_slot(Reg::Rax, 8);
-        self.asm.sub_reg_reg(Reg::Rax, Reg::Rcx);
-        self.asm.store_rbp_slot(8, Reg::Rax);
-        self.asm.bind_text_label(after_block);
-        // cur += size (rcx). Reload cur, advance, store.
-        self.asm.load_rbp_slot(Reg::Rax, 16);
-        self.asm.add_reg_reg(Reg::Rax, Reg::Rcx);
-        self.asm.store_rbp_slot(16, Reg::Rax);
-        self.asm.jmp_label(block_loop);
-        self.asm.bind_text_label(advance_region);
-        // gc_reloc_scan_idx++ ; gc_reloc_block = 0 ; rescan.
-        self.asm.mov_data_addr(Reg::R10, self.gc_reloc_scan_idx);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.add_reg_imm32(Reg::Rax, 1);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.mov_data_addr(Reg::R10, self.gc_reloc_block);
-        self.asm.mov_imm64(Reg::Rax, 0);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.jmp_label(region_scan);
-        self.asm.bind_text_label(saved_cur);
-        // Save the block cursor for resumption. If we fell here from the
-        // region-scan-done path (idx>=committed), cur slot may be stale;
-        // gc_relocate_finish is called only when idx>=committed.
-        self.asm.mov_data_addr(Reg::R10, self.gc_reloc_scan_idx);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.mov_data_addr(Reg::R10, self.gc_committed_count);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-        self.asm.cmp_reg_reg(Reg::Rax, Reg::R11);
-        let just_save = self.asm.create_text_label();
-        self.asm.jcc_label(Condition::Below, just_save);
-        self.asm.call_label(self.gc_relocate_finish);
-        self.asm.leave();
-        self.asm.ret();
-        self.asm.bind_text_label(just_save);
-        self.asm.load_rbp_slot(Reg::Rax, 16);
-        self.asm.mov_data_addr(Reg::R10, self.gc_reloc_block);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.leave();
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper).
+        let entry = self.gc_relocate_quantum;
+        let tables = portable_asm::RegionTables {
+            heap_base: self.gc_heap_base,
+            heap_top: self.gc_heap_top,
+            region_base: self.gc_region_base,
+            region_top: self.gc_region_top,
+            committed_count: self.gc_committed_count,
+            region_fromspace: self.gc_region_fromspace,
+        };
+        let cells = portable_asm::RelocQuantumCells {
+            reloc_scan_idx: self.gc_reloc_scan_idx,
+            reloc_block: self.gc_reloc_block,
+            header_mark: self.gc_header_mark,
+        };
+        portable_asm::emit_gc_relocate_quantum(
+            self,
+            entry,
+            tables,
+            cells,
+            self.gc_evacuate,
+            self.gc_relocate_finish,
+        );
     }
 
     /// Finish relocation: flush the final evacuation watermark and return

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -39518,69 +39518,18 @@ impl NativeCodeGenerator {
     /// the root points at the to-space copy. Roots are raw (uncolored);
     /// the shadow stack holds slot ADDRESSES, so the rewrite is in place.
     fn emit_gc_relocate_fix_roots_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_relocate_fix_roots);
-        self.asm.push_reg(Reg::Rbp);
-        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
-        self.asm.sub_reg_imm8(Reg::Rsp, 16); // [rbp-8]=cursor, [rbp-16]=end
-        self.asm.mov_data_addr(Reg::R10, self.gc_shadow_stack);
-        self.asm.load_ptr_disp32(Reg::R10, Reg::R10, 0);
-        self.asm.store_rbp_slot(8, Reg::R10);
-        self.asm.mov_data_addr(Reg::R8, self.gc_shadow_stack_top);
-        self.asm.load_ptr_disp32(Reg::Rcx, Reg::R8, 0);
-        self.asm.shl_reg_imm8(Reg::Rcx, 3);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rcx);
-        self.asm.store_rbp_slot(16, Reg::R10);
-        let loop_l = self.asm.create_text_label();
-        let done_l = self.asm.create_text_label();
-        let next_l = self.asm.create_text_label();
-        let do_evac = self.asm.create_text_label();
-        let store_root = self.asm.create_text_label();
-        self.asm.bind_text_label(loop_l);
-        self.asm.load_rbp_slot(Reg::R10, 8);
-        self.asm.load_rbp_slot(Reg::R11, 16);
-        self.asm.cmp_reg_reg(Reg::R10, Reg::R11);
-        self.asm.jcc_label(Condition::AboveOrEqual, done_l);
-        // slotaddr = [cursor]; val = [slotaddr].
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.load_ptr_disp32(Reg::Rdi, Reg::Rax, 0);
-        self.asm.test_reg_reg(Reg::Rdi, Reg::Rdi);
-        self.asm.jcc_label(Condition::Equal, next_l);
-        // idx = (val - region_base) >> SHIFT ; from-space?
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rdi);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_base);
-        self.asm.load_ptr_disp32(Reg::R10, Reg::R10, 0);
-        self.asm.sub_reg_reg(Reg::Rcx, Reg::R10);
-        self.asm.shr_reg_imm8(Reg::Rcx, Self::GC_REGION_SHIFT);
-        self.asm.shl_reg_imm8(Reg::Rcx, 3);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_fromspace);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rcx);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-        self.asm.test_reg_reg(Reg::R11, Reg::R11);
-        self.asm.jcc_label(Condition::Equal, next_l);
-        // val in from-space: new = (word0 & FWD) ? word0 & -16 : evacuate(val)
-        self.asm.load_ptr_disp32(Reg::R11, Reg::Rdi, -16);
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::R11);
-        self.asm.and_reg_imm32(Reg::Rcx, Self::GC_FWD as i32);
-        self.asm.test_reg_reg(Reg::Rcx, Reg::Rcx);
-        self.asm.jcc_label(Condition::Equal, do_evac);
-        self.asm.and_reg_imm32(Reg::R11, -16);
-        self.asm.mov_reg_reg(Reg::Rax, Reg::R11); // new
-        self.asm.jmp_label(store_root);
-        self.asm.bind_text_label(do_evac);
-        self.asm.call_label(self.gc_evacuate); // rdi = val -> rax = to-space
-        self.asm.bind_text_label(store_root);
-        // [slotaddr] = new. slotaddr was clobbered by the call; reload it.
-        self.asm.load_rbp_slot(Reg::R10, 8);
-        self.asm.load_ptr_disp32(Reg::R10, Reg::R10, 0); // slotaddr
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.bind_text_label(next_l);
-        self.asm.load_rbp_slot(Reg::R10, 8);
-        self.asm.add_reg_imm32(Reg::R10, 8);
-        self.asm.store_rbp_slot(8, Reg::R10);
-        self.asm.jmp_label(loop_l);
-        self.asm.bind_text_label(done_l);
-        self.asm.leave();
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper).
+        let entry = self.gc_relocate_fix_roots;
+        portable_asm::emit_gc_relocate_fix_roots(
+            self,
+            entry,
+            self.gc_shadow_stack,
+            self.gc_shadow_stack_top,
+            self.gc_region_base,
+            self.gc_region_fromspace,
+            self.gc_evacuate,
+        );
     }
 
     /// One incremental relocation quantum: rdi = byte budget. Linearly

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -38853,97 +38853,24 @@ impl NativeCodeGenerator {
     /// (<= REGION_SIZE). Flushes the previous evac region's watermark
     /// first. Never fails: the headroom invariant guarantees a region.
     fn emit_gc_acquire_evac_region_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_acquire_evac_region);
-        let no_flush = self.asm.create_text_label();
-        let from_tail = self.asm.create_text_label();
-        let install = self.asm.create_text_label();
-        // Flush the previous evac region's watermark, if any.
-        self.asm.mov_data_addr(Reg::R10, self.gc_evac_region_base);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        self.asm.jcc_label(Condition::Equal, no_flush);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_base);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-        self.asm.sub_reg_reg(Reg::Rax, Reg::R11);
-        self.asm.shr_reg_imm8(Reg::Rax, Self::GC_REGION_SHIFT);
-        self.asm.shl_reg_imm8(Reg::Rax, 3);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_top);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rax);
-        self.asm.mov_data_addr(Reg::R8, self.gc_evac_top);
-        self.asm.load_ptr_disp32(Reg::Rdx, Reg::R8, 0);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rdx);
-        self.asm.bind_text_label(no_flush);
-        // (1) Free-region pool.
-        self.asm.mov_data_addr(Reg::R10, self.gc_free_region_head);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        self.asm.jcc_label(Condition::Equal, from_tail);
-        self.asm.load_ptr_disp32(Reg::Rcx, Reg::Rax, 0);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rcx); // pop
-        // Zero the reused region.
-        let zero_loop = self.asm.create_text_label();
-        let zero_done = self.asm.create_text_label();
-        self.asm.mov_reg_reg(Reg::R8, Reg::Rax);
-        self.asm.mov_reg_reg(Reg::R11, Reg::Rax);
-        self.asm
-            .add_reg_imm32(Reg::R11, Self::GC_REGION_SIZE as i32);
-        self.asm.mov_imm64(Reg::R9, 0);
-        self.asm.bind_text_label(zero_loop);
-        self.asm.cmp_reg_reg(Reg::R8, Reg::R11);
-        self.asm.jcc_label(Condition::AboveOrEqual, zero_done);
-        self.asm.store_ptr_disp32(Reg::R8, 0, Reg::R9);
-        self.asm.add_reg_imm32(Reg::R8, 8);
-        self.asm.jmp_label(zero_loop);
-        self.asm.bind_text_label(zero_done);
-        self.asm.jmp_label(install);
-        // (2) Commit the next tail region. Hard safety net: never commit
-        // past the reservation. The headroom cap in gc_relocate_start
-        // makes this unreachable (selected live bytes fit in
-        // free_regions-2 even at ~50% packing), but an out-of-bounds
-        // to-space write would be silent memory corruption, so abort
-        // cleanly instead if the accounting is ever wrong.
-        self.asm.bind_text_label(from_tail);
-        self.asm.mov_data_addr(Reg::R10, self.gc_committed_count);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        let evac_ok = self.asm.create_text_label();
-        self.asm
-            .cmp_reg_imm32(Reg::Rax, Self::GC_RESERVE_REGIONS as i32);
-        self.asm.jcc_label(Condition::Below, evac_ok);
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper). The
+        // exhaustion-diagnostic label and stderr fd are host-side details
+        // resolved here and passed in.
+        let entry = self.gc_acquire_evac_region;
         let msg = b"klassic gc: evacuation exhausted the heap reservation\n";
         let txt = self.asm.data_label_with_bytes(msg);
-        self.emit_write_data(self.platform.stderr_fd(), txt, msg.len());
-        self.emit_exit_code(1);
-        self.asm.bind_text_label(evac_ok);
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-        self.asm.shl_reg_imm8(Reg::Rcx, Self::GC_REGION_SHIFT);
-        self.asm.mov_data_addr(Reg::R8, self.gc_region_base);
-        self.asm.load_ptr_disp32(Reg::R8, Reg::R8, 0);
-        self.asm.add_reg_reg(Reg::R8, Reg::Rcx);
-        self.asm.add_reg_imm32(Reg::Rax, 1);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.mov_reg_reg(Reg::Rax, Reg::R8); // rax = new base
-        // install: set the evac bump globals (NOT the mutator's).
-        self.asm.bind_text_label(install);
-        self.asm.mov_data_addr(Reg::R10, self.gc_evac_region_base);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.mov_data_addr(Reg::R10, self.gc_evac_top);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-        self.asm
-            .add_reg_imm32(Reg::Rcx, Self::GC_REGION_SIZE as i32);
-        self.asm.mov_data_addr(Reg::R10, self.gc_evac_end);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rcx);
-        // region_top[newidx] = base (empty until the watermark is flushed).
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_base);
-        self.asm.load_ptr_disp32(Reg::R10, Reg::R10, 0);
-        self.asm.sub_reg_reg(Reg::Rcx, Reg::R10);
-        self.asm.shr_reg_imm8(Reg::Rcx, Self::GC_REGION_SHIFT);
-        self.asm.shl_reg_imm8(Reg::Rcx, 3);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_top);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rcx);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.ret();
+        let stderr_fd = self.platform.stderr_fd();
+        let cells = portable_asm::EvacRegionCells {
+            evac_region_base: self.gc_evac_region_base,
+            evac_top: self.gc_evac_top,
+            evac_end: self.gc_evac_end,
+            region_base: self.gc_region_base,
+            region_top: self.gc_region_top,
+            committed_count: self.gc_committed_count,
+            free_region_head: self.gc_free_region_head,
+        };
+        portable_asm::emit_gc_acquire_evac_region(self, entry, cells, txt, msg.len(), stderr_fd);
     }
 
     /// Evacuate one object: rdi = user pointer. Returns rax = to-space

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -39201,94 +39201,25 @@ impl NativeCodeGenerator {
     /// caller-saved registers. First flushes the current region's
     /// watermark so a subsequent sweep can walk it.
     fn emit_gc_acquire_region_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_acquire_region);
-        let from_tail = self.asm.create_text_label();
-        let install = self.asm.create_text_label();
-        let fail = self.asm.create_text_label();
-
-        // region_top[cur] = gc_heap_top, where cur = (heap_base -
-        // region_base) >> REGION_SHIFT.
-        self.asm.mov_data_addr(Reg::R10, self.gc_heap_base);
-        self.asm.load_ptr_disp32(Reg::Rcx, Reg::R10, 0);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_base);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-        self.asm.sub_reg_reg(Reg::Rcx, Reg::R11);
-        self.asm.shr_reg_imm8(Reg::Rcx, Self::GC_REGION_SHIFT);
-        self.asm.shl_reg_imm8(Reg::Rcx, 3);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_top);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rcx);
-        self.asm.mov_data_addr(Reg::R8, self.gc_heap_top);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R8, 0);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-
-        // (1) Free-region pool: rax = free_region_head; if non-null pop it.
-        self.asm.mov_data_addr(Reg::R10, self.gc_free_region_head);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        self.asm.jcc_label(Condition::Equal, from_tail);
-        // free_region_head = [rax] (link stored at the region base).
-        self.asm.load_ptr_disp32(Reg::Rcx, Reg::Rax, 0);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rcx);
-        // Zero the reused region: unlike a fresh mmap'd tail region, a
-        // reclaimed region still holds its previous objects' bytes. The
-        // bump path does not clear an object's padding qwords (those
-        // within the 16-aligned block size that the constructor doesn't
-        // write), and the mark trace walks every payload qword of a
-        // pointer object -- so a stale non-null value there would be
-        // chased as a bogus pointer. Clearing the whole region once on
-        // reuse restores the "all bump memory reads as zero" invariant.
-        let zero_loop = self.asm.create_text_label();
-        let zero_done = self.asm.create_text_label();
-        self.asm.mov_reg_reg(Reg::R8, Reg::Rax); // cursor
-        self.asm.mov_reg_reg(Reg::R11, Reg::Rax);
-        self.asm
-            .add_reg_imm32(Reg::R11, Self::GC_REGION_SIZE as i32); // end
-        self.asm.mov_imm64(Reg::R9, 0);
-        self.asm.bind_text_label(zero_loop);
-        self.asm.cmp_reg_reg(Reg::R8, Reg::R11);
-        self.asm.jcc_label(Condition::AboveOrEqual, zero_done);
-        self.asm.store_ptr_disp32(Reg::R8, 0, Reg::R9);
-        self.asm.add_reg_imm32(Reg::R8, 8);
-        self.asm.jmp_label(zero_loop);
-        self.asm.bind_text_label(zero_done);
-        self.asm.jmp_label(install);
-
-        // (2) Commit the next tail region if within budget.
-        self.asm.bind_text_label(from_tail);
-        self.asm.mov_data_addr(Reg::R10, self.gc_committed_count);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.mov_data_addr(Reg::R8, self.gc_budget_regions);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R8, 0);
-        self.asm.cmp_reg_reg(Reg::Rax, Reg::R11);
-        self.asm.jcc_label(Condition::AboveOrEqual, fail);
-        // new_base = region_base + (committed << REGION_SHIFT).
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-        self.asm.shl_reg_imm8(Reg::Rcx, Self::GC_REGION_SHIFT);
-        self.asm.mov_data_addr(Reg::R8, self.gc_region_base);
-        self.asm.load_ptr_disp32(Reg::R8, Reg::R8, 0);
-        self.asm.add_reg_reg(Reg::R8, Reg::Rcx);
-        // committed_count = committed + 1.
-        self.asm.add_reg_imm32(Reg::Rax, 1);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.mov_reg_reg(Reg::Rax, Reg::R8);
-
-        // install: rax = new region base. Set the bump globals.
-        self.asm.bind_text_label(install);
-        self.asm.mov_data_addr(Reg::R10, self.gc_heap_base);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.mov_data_addr(Reg::R10, self.gc_heap_top);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-        self.asm
-            .add_reg_imm32(Reg::Rcx, Self::GC_REGION_SIZE as i32);
-        self.asm.mov_data_addr(Reg::R10, self.gc_heap_end);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rcx);
-        self.asm.mov_imm64(Reg::Rax, 1);
-        self.asm.ret();
-
-        self.asm.bind_text_label(fail);
-        self.asm.mov_imm64(Reg::Rax, 0);
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper).
+        let entry = self.gc_acquire_region;
+        let tables = portable_asm::RegionTables {
+            heap_base: self.gc_heap_base,
+            heap_top: self.gc_heap_top,
+            region_base: self.gc_region_base,
+            region_top: self.gc_region_top,
+            committed_count: self.gc_committed_count,
+            region_fromspace: self.gc_region_fromspace,
+        };
+        portable_asm::emit_gc_acquire_region(
+            self,
+            entry,
+            tables,
+            self.gc_free_region_head,
+            self.gc_budget_regions,
+            self.gc_heap_end,
+        );
     }
 
     // ===================== M7 evacuation machinery =====================

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -36754,7 +36754,8 @@ impl NativeCodeGenerator {
     const GC_RESERVE_BYTES: u64 = crate::gc_layout::GC_RESERVE_BYTES;
     const GC_INITIAL_BUDGET_REGIONS: u64 = crate::gc_layout::GC_INITIAL_BUDGET_REGIONS;
     const GC_TABLES_BYTES: u64 = crate::gc_layout::GC_TABLES_BYTES;
-    const GC_MARK_WORKLIST_LEN: usize = crate::gc_layout::GC_MARK_WORKLIST_LEN;
+    // GC_MARK_WORKLIST_LEN's last in-lib.rs user moved to the portable
+    // emitter; reference crate::gc_layout::GC_MARK_WORKLIST_LEN directly.
     const GC_SHADOW_STACK_LEN: usize = crate::gc_layout::GC_SHADOW_STACK_LEN;
     const GC_MAX_PAYLOAD_SIZE: u64 = crate::gc_layout::GC_MAX_PAYLOAD_SIZE;
     const GC_MAX_STRING_ALLOC_SIZE: u64 = crate::gc_layout::GC_MAX_STRING_ALLOC_SIZE;
@@ -38988,73 +38989,16 @@ impl NativeCodeGenerator {
     /// worklist. A no-op when addr is null or already marked. Aborts if
     /// the worklist is full.
     fn emit_gc_mark_visit_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_mark_visit);
-        self.asm.push_reg(Reg::Rbp);
-        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
-
-        let bail = self.asm.create_text_label();
-        let overflow = self.asm.create_text_label();
-
-        // Null check.
-        self.asm.test_reg_reg(Reg::Rdi, Reg::Rdi);
-        self.asm.jcc_label(Condition::Equal, bail);
-        // M7: follow forwarding first. If [rdi-16] is a forwarding word
-        // (FWD bit set), rdi points at a ghost -- redirect to the
-        // to-space copy so we mark (and later trace) the live object, not
-        // the ghost. ORing a mark into a ghost's forwarding word would
-        // corrupt the address. Inert while evac is off (FWD never set).
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::Rdi, -16);
-        let not_fwd = self.asm.create_text_label();
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-        self.asm.and_reg_imm32(Reg::Rcx, Self::GC_FWD as i32);
-        self.asm.test_reg_reg(Reg::Rcx, Reg::Rcx);
-        self.asm.jcc_label(Condition::Equal, not_fwd);
-        self.asm.and_reg_imm32(Reg::Rax, -16); // new user ptr
-        self.asm.mov_reg_reg(Reg::Rdi, Reg::Rax);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::Rdi, -16); // to-space header
-        self.asm.bind_text_label(not_fwd);
-        // Already marked this cycle? (current-parity mark bit set)
-        self.asm.mov_data_addr(Reg::R10, self.gc_header_mark);
-        self.asm.load_ptr_disp32(Reg::Rcx, Reg::R10, 0);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rcx);
-        self.asm.jcc_label(Condition::NotEqual, bail);
-        // Set the current mark bit.
-        self.asm.or_reg_reg(Reg::Rax, Reg::Rcx);
-        self.asm.store_ptr_disp32(Reg::Rdi, -16, Reg::Rax);
-        // Push onto worklist: worklist[top++] = rdi
-        self.asm.mov_data_addr(Reg::R10, self.gc_mark_worklist_top);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm
-            .cmp_reg_imm32(Reg::Rax, Self::GC_MARK_WORKLIST_LEN as i32);
-        self.asm.jcc_label(Condition::AboveOrEqual, overflow);
-        self.asm.mov_data_addr(Reg::R8, self.gc_mark_worklist);
-        self.asm.load_ptr_disp32(Reg::R8, Reg::R8, 0);
-        // r9 = base + rax*8
-        self.asm.mov_reg_reg(Reg::R9, Reg::Rax);
-        self.asm.shl_reg_imm8(Reg::R9, 3);
-        self.asm.add_reg_reg(Reg::R8, Reg::R9);
-        self.asm.store_ptr_disp32(Reg::R8, 0, Reg::Rdi);
-        self.asm.add_reg_imm32(Reg::Rax, 1);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-
-        self.asm.bind_text_label(bail);
-        self.asm.leave();
-        self.asm.ret();
-
-        self.asm.bind_text_label(overflow);
-        // Worklist full. The object's mark bit is already set (above), so
-        // it is not lost -- only its frontier (children-to-scan) entry is
-        // dropped. Raise the STW-fallback flag: the incremental driver
-        // (or gc_stw_mark_complete) will re-mark from scratch, which
-        // recovers the dropped frontier. On the from-scratch STW path
-        // that re-mark checks this flag after draining and aborts if it
-        // is still set (genuine over-capacity).
-        self.asm
-            .mov_data_addr(Reg::R10, self.gc_stw_fallback_pending);
-        self.asm.mov_imm64(Reg::Rax, 1);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.leave();
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper).
+        let entry = self.gc_mark_visit;
+        let worklist = portable_asm::MarkWorklist {
+            header_mark: self.gc_header_mark,
+            worklist: self.gc_mark_worklist,
+            worklist_top: self.gc_mark_worklist_top,
+            stw_fallback_pending: self.gc_stw_fallback_pending,
+        };
+        portable_asm::emit_gc_mark_visit(self, entry, worklist);
     }
 
     /// `gc_load_barrier_slow` (in: rax = bad-colored heap pointer,

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -38135,29 +38135,19 @@ impl NativeCodeGenerator {
     /// the clock syscall path panics on Windows, and no cell is written
     /// there, so a pause simply reads 0). Emitted at the start of each
     /// STW pause (MarkStart, MarkEnd, and the synchronous full collect).
+    ///
+    /// The STW pauses themselves are now emitted by the portable
+    /// `portable_asm::emit_gc_pause_start` / `emit_gc_pause_end` free
+    /// functions; every GC routine that brackets a pause has been migrated
+    /// onto the trait, so the former inherent wrappers are gone. Callers
+    /// build a `PauseCells` here and compute `timing = gc_log &&
+    /// !is_windows` at the call site.
     fn gc_pause_cells(&self) -> portable_asm::PauseCells<DataLabel> {
         portable_asm::PauseCells {
             start_ns: self.gc_pause_start_ns,
             total_ns: self.gc_pause_total_ns,
             max_ns: self.gc_pause_max_ns,
         }
-    }
-
-    fn emit_gc_pause_start(&mut self) {
-        // Delegated to the portable emitter; the `--gc-log`-and-not-Windows
-        // gate stays here (it is host-config state, not codegen), and the
-        // clock read is a `PortableAsm` platform primitive. Byte-identical.
-        let timing = self.gc_log && !self.is_windows;
-        let cells = self.gc_pause_cells();
-        portable_asm::emit_gc_pause_start(self, timing, cells);
-    }
-
-    /// Fold the elapsed pause (now - gc_pause_start_ns) into the max and
-    /// total pause accumulators. Emitted at the end of each STW pause.
-    fn emit_gc_pause_end(&mut self) {
-        let timing = self.gc_log && !self.is_windows;
-        let cells = self.gc_pause_cells();
-        portable_asm::emit_gc_pause_end(self, timing, cells);
     }
 
     fn emit_gc_alloc_runtime(&mut self) {
@@ -38398,53 +38388,20 @@ impl NativeCodeGenerator {
     }
 
     fn emit_gc_collect_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_collect);
-        self.asm.push_reg(Reg::Rbp);
-        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
-        // (The collection counter is bumped once per cycle inside
-        // gc_sweep.) M6: the synchronous collection entry (do_collect,
-        // --gc-stress). If a cycle is in progress (phase == Mark), finish
-        // it via gc_mark_end (which self-brackets its own pause);
-        // otherwise run a full from-scratch STW mark + sweep, bracketed
-        // as one pause here. Either way exactly one sweep runs.
-        let collect_mark = self.asm.create_text_label();
-        let collect_reloc = self.asm.create_text_label();
-        let collect_done = self.asm.create_text_label();
-        self.asm.mov_data_addr(Reg::R10, self.gc_phase);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.cmp_reg_imm8(Reg::Rax, Self::GC_PHASE_MARK as i8);
-        self.asm.jcc_label(Condition::Equal, collect_mark);
-        self.asm
-            .cmp_reg_imm8(Reg::Rax, Self::GC_PHASE_RELOCATE as i8);
-        self.asm.jcc_label(Condition::Equal, collect_reloc);
-        // Idle: a full from-scratch STW mark + sweep, bracketed as one
-        // pause. Free the previous cycle's ghosts first (no-op until
-        // evacuation runs).
-        self.emit_gc_pause_start();
-        self.asm.call_label(self.gc_stw_mark_complete);
-        self.asm.call_label(self.gc_free_ghost_regions);
-        self.asm.call_label(self.gc_sweep);
-        self.emit_gc_pause_end();
-        self.asm.jmp_label(collect_done);
-        // Relocate in progress: drain the remaining evacuation
-        // synchronously (unbounded quanta) until the phase returns to
-        // Idle. Unreachable until the activation step.
-        self.asm.bind_text_label(collect_reloc);
-        let reloc_loop = self.asm.create_text_label();
-        self.asm.bind_text_label(reloc_loop);
-        self.asm.mov_imm64(Reg::Rdi, i64::MAX as u64);
-        self.asm.call_label(self.gc_relocate_quantum);
-        self.asm.mov_data_addr(Reg::R10, self.gc_phase);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm
-            .cmp_reg_imm8(Reg::Rax, Self::GC_PHASE_RELOCATE as i8);
-        self.asm.jcc_label(Condition::Equal, reloc_loop);
-        self.asm.jmp_label(collect_done);
-        self.asm.bind_text_label(collect_mark);
-        self.asm.call_label(self.gc_mark_end);
-        self.asm.bind_text_label(collect_done);
-        self.asm.leave();
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper). The
+        // collection counter is bumped once per cycle inside gc_sweep.
+        let entry = self.gc_collect;
+        let timing = self.gc_log && !self.is_windows;
+        let pause = self.gc_pause_cells();
+        let targets = portable_asm::CollectTargets {
+            stw_mark_complete: self.gc_stw_mark_complete,
+            free_ghost_regions: self.gc_free_ghost_regions,
+            sweep: self.gc_sweep,
+            relocate_quantum: self.gc_relocate_quantum,
+            mark_end: self.gc_mark_end,
+        };
+        portable_asm::emit_gc_collect(self, entry, timing, pause, self.gc_phase, targets);
     }
 
     /// Mark roots: walk the GC shadow stack (the sole root source),

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -37895,7 +37895,8 @@ impl NativeCodeGenerator {
     // reference crate::gc_layout::GC_PHASE_IDLE directly if needed here.
     const GC_PHASE_MARK: u64 = crate::gc_layout::GC_PHASE_MARK;
     const GC_PHASE_RELOCATE: u64 = crate::gc_layout::GC_PHASE_RELOCATE;
-    const GC_FWD: u64 = crate::gc_layout::GC_FWD;
+    // GC_FWD's last lib.rs user moved to the portable emitter; reference
+    // crate::gc_layout::GC_FWD directly if needed here again.
     // GC_HMARK0 / GC_HMARK_BOTH have no direct `Self::` use left in this
     // file: HMARK0's only reference was inside HMARK_BOTH's definition
     // (now in gc_layout), and HMARK_BOTH's last user (gc_mark_start) moved
@@ -38648,146 +38649,11 @@ impl NativeCodeGenerator {
     /// distinct variants fall out at the first slot. The recursion depth
     /// tracks the nesting depth of the compared values, not the heap size.
     fn emit_gc_deep_equal_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_deep_equal);
-        self.asm.push_reg(Reg::Rbp);
-        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
-        // Locals: [rbp-8] = cursor_a, [rbp-16] = end_a, [rbp-24] = cursor_b.
-        self.asm.sub_reg_imm8(Reg::Rsp, 32);
-
-        let equal = self.asm.create_text_label();
-        let not_equal = self.asm.create_text_label();
-        let done = self.asm.create_text_label();
-        let raw_bytes = self.asm.create_text_label();
-        let raw_loop = self.asm.create_text_label();
-        let ptr_setup = self.asm.create_text_label();
-        let slot_loop = self.asm.create_text_label();
-        let raw_have_min = self.asm.create_text_label();
-        let ptr_have_min = self.asm.create_text_label();
-
-        // Identical pointers (including both null) are trivially equal.
-        self.asm.cmp_reg_reg(Reg::Rdi, Reg::Rsi);
-        self.asm.jcc_label(Condition::Equal, equal);
-        // A null on exactly one side has no header to dereference.
-        self.asm.test_reg_reg(Reg::Rdi, Reg::Rdi);
-        self.asm.jcc_label(Condition::Equal, not_equal);
-        self.asm.test_reg_reg(Reg::Rsi, Reg::Rsi);
-        self.asm.jcc_label(Condition::Equal, not_equal);
-        // M7: follow forwarding on each operand before dereferencing its
-        // header -- during a moving cycle a value may be a ghost whose
-        // word0 is a forwarding word (garbage as a size/type). Inert while
-        // evac is off (FWD never set). rax is scratch.
-        let deq_a_not_fwd = self.asm.create_text_label();
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::Rdi, -16);
-        self.asm.and_reg_imm32(Reg::Rax, Self::GC_FWD as i32);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        self.asm.jcc_label(Condition::Equal, deq_a_not_fwd);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::Rdi, -16);
-        self.asm.and_reg_imm32(Reg::Rax, -16);
-        self.asm.mov_reg_reg(Reg::Rdi, Reg::Rax);
-        self.asm.bind_text_label(deq_a_not_fwd);
-        let deq_b_not_fwd = self.asm.create_text_label();
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::Rsi, -16);
-        self.asm.and_reg_imm32(Reg::Rax, Self::GC_FWD as i32);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        self.asm.jcc_label(Condition::Equal, deq_b_not_fwd);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::Rsi, -16);
-        self.asm.and_reg_imm32(Reg::Rax, -16);
-        self.asm.mov_reg_reg(Reg::Rsi, Reg::Rax);
-        self.asm.bind_text_label(deq_b_not_fwd);
-        // Type tags must match: type_a = [rdi-8], type_b = [rsi-8].
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::Rdi, -8);
-        self.asm.load_ptr_disp32(Reg::Rcx, Reg::Rsi, -8);
-        self.asm.cmp_reg_reg(Reg::Rax, Reg::Rcx);
-        self.asm.jcc_label(Condition::NotEqual, not_equal);
-        // payload_a = ([rdi-16] & -16) - 16 in r8, payload_b in r9.
-        self.asm.load_ptr_disp32(Reg::R8, Reg::Rdi, -16);
-        self.asm.load_ptr_disp32(Reg::R9, Reg::Rsi, -16);
-        self.asm.and_reg_imm32(Reg::R8, -16);
-        self.asm.and_reg_imm32(Reg::R9, -16);
-        self.asm.sub_reg_imm8(Reg::R8, 16);
-        self.asm.sub_reg_imm8(Reg::R9, 16);
-        // rax still holds the shared type tag.
-        self.asm
-            .cmp_reg_imm8(Reg::Rax, Self::GC_TYPE_RAW_BYTES as i8);
-        self.asm.jcc_label(Condition::Equal, raw_bytes);
-        self.asm
-            .cmp_reg_imm8(Reg::Rax, Self::GC_TYPE_POINTER_RECORD as i8);
-        self.asm.jcc_label(Condition::Below, not_equal);
-        // Pointer record / array / list: a packed run of heap-pointer
-        // slots, optionally led by an integer length for the list tag.
-        self.asm
-            .cmp_reg_imm8(Reg::Rax, Self::GC_TYPE_POINTER_LIST as i8);
-        self.asm.jcc_label(Condition::NotEqual, ptr_setup);
-        // List: the two lengths must match, then skip past the length word.
-        self.asm.load_ptr_disp32(Reg::R10, Reg::Rdi, 0);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::Rsi, 0);
-        self.asm.cmp_reg_reg(Reg::R10, Reg::R11);
-        self.asm.jcc_label(Condition::NotEqual, not_equal);
-        self.asm.add_reg_imm32(Reg::Rdi, 8);
-        self.asm.add_reg_imm32(Reg::Rsi, 8);
-        self.asm.sub_reg_imm8(Reg::R8, 8);
-        self.asm.sub_reg_imm8(Reg::R9, 8);
-        self.asm.bind_text_label(ptr_setup);
-        // r8 = min(payload_a, payload_b): compare only the shared prefix.
-        self.asm.cmp_reg_reg(Reg::R8, Reg::R9);
-        self.asm.jcc_label(Condition::Below, ptr_have_min);
-        self.asm.mov_reg_reg(Reg::R8, Reg::R9);
-        self.asm.bind_text_label(ptr_have_min);
-        // cursor_a = rdi, end_a = rdi + min, cursor_b = rsi.
-        self.asm.mov_reg_reg(Reg::R10, Reg::Rdi);
-        self.asm.add_reg_reg(Reg::R10, Reg::R8);
-        self.asm.store_rbp_slot(8, Reg::Rdi);
-        self.asm.store_rbp_slot(16, Reg::R10);
-        self.asm.store_rbp_slot(24, Reg::Rsi);
-        self.asm.bind_text_label(slot_loop);
-        self.asm.load_rbp_slot(Reg::R10, 8);
-        self.asm.load_rbp_slot(Reg::R11, 16);
-        self.asm.cmp_reg_reg(Reg::R10, Reg::R11);
-        self.asm.jcc_label(Condition::AboveOrEqual, equal);
-        self.asm.load_rbp_slot(Reg::R11, 24);
-        // rdi = a_slot = [cursor_a], rsi = b_slot = [cursor_b], recurse.
-        // Both slots hold colored pointers; strip before the recursive
-        // deep-equal dereferences them. (No-op until color-on-store.)
-        self.asm.load_ptr_disp32(Reg::Rdi, Reg::R10, 0);
-        self.asm.and_reg_reg(Reg::Rdi, Reg::R13);
-        self.asm.load_ptr_disp32(Reg::Rsi, Reg::R11, 0);
-        self.asm.and_reg_reg(Reg::Rsi, Reg::R13);
-        self.asm.call_label(self.gc_deep_equal);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        self.asm.jcc_label(Condition::Equal, not_equal);
-        // Advance both cursors one slot and continue.
-        self.asm.load_rbp_slot(Reg::R10, 8);
-        self.asm.add_reg_imm32(Reg::R10, 8);
-        self.asm.store_rbp_slot(8, Reg::R10);
-        self.asm.load_rbp_slot(Reg::R10, 24);
-        self.asm.add_reg_imm32(Reg::R10, 8);
-        self.asm.store_rbp_slot(24, Reg::R10);
-        self.asm.jmp_label(slot_loop);
-        // Raw bytes: compare the shared-prefix payload qword by qword.
-        self.asm.bind_text_label(raw_bytes);
-        self.asm.cmp_reg_reg(Reg::R8, Reg::R9);
-        self.asm.jcc_label(Condition::Below, raw_have_min);
-        self.asm.mov_reg_reg(Reg::R8, Reg::R9);
-        self.asm.bind_text_label(raw_have_min);
-        self.asm.bind_text_label(raw_loop);
-        self.asm.test_reg_reg(Reg::R8, Reg::R8);
-        self.asm.jcc_label(Condition::Equal, equal);
-        self.asm.load_ptr_disp32(Reg::R10, Reg::Rdi, 0);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::Rsi, 0);
-        self.asm.cmp_reg_reg(Reg::R10, Reg::R11);
-        self.asm.jcc_label(Condition::NotEqual, not_equal);
-        self.asm.add_reg_imm32(Reg::Rdi, 8);
-        self.asm.add_reg_imm32(Reg::Rsi, 8);
-        self.asm.sub_reg_imm8(Reg::R8, 8);
-        self.asm.jmp_label(raw_loop);
-        self.asm.bind_text_label(equal);
-        self.asm.mov_imm64(Reg::Rax, 1);
-        self.asm.jmp_label(done);
-        self.asm.bind_text_label(not_equal);
-        self.asm.mov_imm64(Reg::Rax, 0);
-        self.asm.bind_text_label(done);
-        self.asm.leave();
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper). Recursive:
+        // the entry label is also the self-call target.
+        let entry = self.gc_deep_equal;
+        portable_asm::emit_gc_deep_equal(self, entry);
     }
 
     /// `gc_acquire_region` (no args): install a fresh empty region as the

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -40293,7 +40293,7 @@ impl NativeCodeGenerator {
         let entry = self.gc_grow_budget;
         let committed = self.gc_committed_count;
         let budget = self.gc_budget_regions;
-        portable_asm::emit_gc_grow_budget(&mut self.asm, entry, committed, budget);
+        portable_asm::emit_gc_grow_budget(self, entry, committed, budget);
     }
 
     /// `gc_bounds_error` is a non-returning subroutine that prints a
@@ -40301,13 +40301,15 @@ impl NativeCodeGenerator {
     /// builtins jump here directly when they detect an index outside
     /// the stored length range.
     fn emit_gc_bounds_error_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_bounds_error);
-        self.emit_write_data(
-            2,
-            self.gc_bounds_error_text,
-            b"klassic gc: index out of bounds\n".len(),
-        );
-        self.emit_exit_code(1);
+        // Migrated onto the portable `PortableAsm` emitter trait -- the
+        // first GC routine to use its platform primitives. The control
+        // flow (bind, write diagnostic, exit) is architecture-independent;
+        // the OS interface (Linux/macOS syscall vs Windows shim) lives in
+        // the impl. Byte-identical to the previous inline emission.
+        let entry = self.gc_bounds_error;
+        let text = self.gc_bounds_error_text;
+        let len = b"klassic gc: index out of bounds\n".len();
+        portable_asm::emit_gc_bounds_error(self, entry, text, len);
     }
 
     fn push_scope(&mut self) {

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -36749,7 +36749,7 @@ impl NativeCodeGenerator {
     // aliases keep the `Self::GC_*` call sites throughout this file
     // unchanged.
     const GC_REGION_SIZE: u64 = crate::gc_layout::GC_REGION_SIZE;
-    const GC_REGION_SHIFT: u8 = crate::gc_layout::GC_REGION_SHIFT;
+    // GC_REGION_SHIFT's last `Self::` user moved to the portable emitter.
     const GC_RESERVE_REGIONS: u64 = crate::gc_layout::GC_RESERVE_REGIONS;
     const GC_RESERVE_BYTES: u64 = crate::gc_layout::GC_RESERVE_BYTES;
     const GC_INITIAL_BUDGET_REGIONS: u64 = crate::gc_layout::GC_INITIAL_BUDGET_REGIONS;
@@ -37889,12 +37889,10 @@ impl NativeCodeGenerator {
     const GC_COLOR_MASK: u64 = crate::gc_layout::GC_COLOR_MASK;
     const GC_COLOR_STRIP: u64 = crate::gc_layout::GC_COLOR_STRIP;
     const GC_COLOR_BAD_MASK: u64 = crate::gc_layout::GC_COLOR_BAD_MASK;
-    const GC_QUANTUM_POPS: u64 = crate::gc_layout::GC_QUANTUM_POPS;
-    const GC_QUANTUM_BYTES: u64 = crate::gc_layout::GC_QUANTUM_BYTES;
-    // GC_PHASE_IDLE's last lib.rs user moved to the portable emitter;
-    // reference crate::gc_layout::GC_PHASE_IDLE directly if needed here.
-    const GC_PHASE_MARK: u64 = crate::gc_layout::GC_PHASE_MARK;
-    const GC_PHASE_RELOCATE: u64 = crate::gc_layout::GC_PHASE_RELOCATE;
+    // The GC phase tags and mark quantum sizes (GC_PHASE_IDLE/MARK/RELOCATE,
+    // GC_QUANTUM_POPS/BYTES) have no `Self::` users left in this file: every
+    // GC routine that referenced them moved to the portable emitter, which
+    // reads them from crate::gc_layout directly.
     // GC_FWD's last lib.rs user moved to the portable emitter; reference
     // crate::gc_layout::GC_FWD directly if needed here again.
     // GC_HMARK0 / GC_HMARK_BOTH have no direct `Self::` use left in this
@@ -38153,240 +38151,48 @@ impl NativeCodeGenerator {
     }
 
     fn emit_gc_alloc_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_alloc);
-        self.asm.push_reg(Reg::Rbp);
-        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
-        self.asm.push_reg(Reg::Rbx);
-        // Reserve two qwords for locals.
-        self.asm.sub_reg_imm8(Reg::Rsp, 16);
-        // total = align_up(rdi + 16, 16)
-        self.asm.add_reg_imm32(Reg::Rdi, 16 + 15);
-        self.asm.and_reg_imm32(Reg::Rdi, -16);
-        self.asm.store_rbp_slot(16, Reg::Rdi);
-        self.asm.store_rbp_slot(24, Reg::Rsi);
-
-        let success = self.asm.create_text_label();
-        let do_collect = self.asm.create_text_label();
-        let do_grow = self.asm.create_text_label();
-        let oom = self.asm.create_text_label();
-        let after_collect = self.asm.create_text_label();
-
-        // ---- M6 incremental-mark driver ----
-        // Runs BEFORE the attempt so it observes only the mutator's
-        // already-rooted state: the previous allocation's object is
-        // rooted by now, and THIS allocation has not happened yet, so
-        // starting a cycle here cannot strand an unrooted register-only
-        // object (which the following attempt then makes allocate-black).
-        // None of the routines called here allocate, so gc_alloc is not
-        // re-entered.
-        let driver_mark = self.asm.create_text_label();
-        let driver_reloc = self.asm.create_text_label();
-        let driver_done = self.asm.create_text_label();
-        self.asm.mov_data_addr(Reg::R10, self.gc_phase);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-        self.asm.cmp_reg_imm8(Reg::R11, Self::GC_PHASE_MARK as i8);
-        self.asm.jcc_label(Condition::Equal, driver_mark);
-        self.asm
-            .cmp_reg_imm8(Reg::R11, Self::GC_PHASE_RELOCATE as i8);
-        self.asm.jcc_label(Condition::Equal, driver_reloc);
-        // Idle: accumulate allocation pressure since the last cycle and,
-        // once it crosses half the soft budget, start a cycle
-        // proactively (so the incremental mark has slack to finish
-        // before exhaustion; the exhaustion path is the STW fallback).
-        self.asm.mov_data_addr(Reg::R10, self.gc_bytes_since_cycle);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.load_rbp_slot(Reg::R11, 16); // total block bytes
-        self.asm.add_reg_reg(Reg::Rax, Reg::R11);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        // threshold = budget_regions * REGION_SIZE / 2 = budget << 16.
-        self.asm.mov_data_addr(Reg::R10, self.gc_budget_regions);
-        self.asm.load_ptr_disp32(Reg::Rcx, Reg::R10, 0);
-        self.asm.shl_reg_imm8(Reg::Rcx, Self::GC_REGION_SHIFT - 1);
-        self.asm.cmp_reg_reg(Reg::Rax, Reg::Rcx);
-        self.asm.jcc_label(Condition::Below, driver_done);
-        self.asm.call_label(self.gc_mark_start);
-        self.asm.jmp_label(driver_done);
-        // Mark: run one bounded quantum per GC_QUANTUM_BYTES allocated;
-        // when the worklist empties, the mark has reached fixpoint, so
-        // finish the cycle (MarkEnd sweeps and returns to Idle).
-        self.asm.bind_text_label(driver_mark);
-        self.asm
-            .mov_data_addr(Reg::R10, self.gc_bytes_since_quantum);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.load_rbp_slot(Reg::R11, 16);
-        self.asm.add_reg_reg(Reg::Rax, Reg::R11);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm
-            .cmp_reg_imm32(Reg::Rax, Self::GC_QUANTUM_BYTES as i32);
-        self.asm.jcc_label(Condition::Below, driver_done);
-        // Reset to 0 (discards the remainder over the threshold, and the
-        // counter is not carried across cycles) -- a pacing detail, not
-        // correctness; the first quantum of a new cycle may fire a little
-        // early. A tuning knob for M8.
-        self.asm.mov_imm64(Reg::Rax, 0);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax); // reset counter
-        self.asm.mov_imm64(Reg::Rdi, Self::GC_QUANTUM_POPS);
-        self.asm.call_label(self.gc_trace);
-        self.asm.mov_data_addr(Reg::R10, self.gc_mark_worklist_top);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        self.asm.jcc_label(Condition::NotEqual, driver_done);
-        self.asm.call_label(self.gc_mark_end);
-        self.asm.jmp_label(driver_done);
-        // Relocate: run one bounded evacuation quantum per GC_QUANTUM_BYTES
-        // allocated (unreachable until the activation step enters the
-        // Relocate phase). gc_relocate_quantum returns to Idle when all
-        // from-space is drained.
-        self.asm.bind_text_label(driver_reloc);
-        self.asm
-            .mov_data_addr(Reg::R10, self.gc_bytes_since_quantum);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.load_rbp_slot(Reg::R11, 16);
-        self.asm.add_reg_reg(Reg::Rax, Reg::R11);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm
-            .cmp_reg_imm32(Reg::Rax, Self::GC_QUANTUM_BYTES as i32);
-        self.asm.jcc_label(Condition::Below, driver_done);
-        self.asm.mov_imm64(Reg::Rax, 0);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.mov_imm64(Reg::Rdi, Self::GC_QUANTUM_BYTES);
-        self.asm.call_label(self.gc_relocate_quantum);
-        self.asm.bind_text_label(driver_done);
-
-        // --gc-stress: collect before every allocation attempt. The
-        // request's own object is allocated by the attempt that
-        // follows, so collecting here only reclaims prior garbage --
-        // and turns any pointer left unrooted across an allocation into
-        // a deterministic crash. gc_collect makes its own frame and
-        // preserves this frame's rbp-relative slots.
-        if self.gc_stress {
-            self.asm.call_label(self.gc_collect);
-        }
-
-        self.emit_gc_alloc_attempt(do_collect, success);
-        // First attempt failed; run collector then retry.
-        self.asm.bind_text_label(do_collect);
-        self.asm.call_label(self.gc_collect);
-        self.asm.bind_text_label(after_collect);
-        self.emit_gc_alloc_attempt(do_grow, success);
-
-        // Collector freed no usable region — raise the soft budget and
-        // retry once more. gc_grow_budget returns rax = 1 on success and
-        // rax = 0 when even the full 64 MiB reservation cannot hold the
-        // request.
-        self.asm.bind_text_label(do_grow);
-        self.asm.load_rbp_slot(Reg::Rdi, 16);
-        self.asm.call_label(self.gc_grow_budget);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        self.asm.jcc_label(Condition::Equal, oom);
-        self.emit_gc_alloc_attempt(oom, success);
-
-        self.asm.bind_text_label(oom);
-        self.emit_write_data(
-            self.platform.stderr_fd(),
-            self.gc_oom_text,
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper). The
+        // gc_stress / gc_log codegen flags and the oom diagnostic are
+        // resolved here and passed in.
+        let entry = self.gc_alloc;
+        let cells = portable_asm::AllocCells {
+            phase: self.gc_phase,
+            bytes_since_cycle: self.gc_bytes_since_cycle,
+            budget_regions: self.gc_budget_regions,
+            bytes_since_quantum: self.gc_bytes_since_quantum,
+            mark_worklist_top: self.gc_mark_worklist_top,
+            header_mark: self.gc_header_mark,
+            alloc_count: self.gc_alloc_count,
+            bytes_allocated: self.gc_bytes_allocated,
+            heap_top: self.gc_heap_top,
+            heap_end: self.gc_heap_end,
+            oom_text: self.gc_oom_text,
+        };
+        let targets = portable_asm::AllocTargets {
+            mark_start: self.gc_mark_start,
+            trace: self.gc_trace,
+            mark_end: self.gc_mark_end,
+            relocate_quantum: self.gc_relocate_quantum,
+            collect: self.gc_collect,
+            grow_budget: self.gc_grow_budget,
+            acquire_region: self.gc_acquire_region,
+            alloc_large: self.gc_alloc_large,
+        };
+        let flags = portable_asm::AllocFlags {
+            stress: self.gc_stress,
+            log: self.gc_log,
+        };
+        let stderr_fd = self.platform.stderr_fd();
+        portable_asm::emit_gc_alloc(
+            self,
+            entry,
+            cells,
+            targets,
+            flags,
             b"klassic gc: out of memory\n".len(),
+            stderr_fd,
         );
-        self.emit_exit_code(1);
-
-        self.asm.bind_text_label(success);
-        // Allocate-black: an object allocated during the Mark phase is
-        // born live this cycle (its current-parity header mark bit is
-        // set), so the in-progress incremental mark -- which may already
-        // be past the point where this object would be discovered -- does
-        // not reclaim it at the coming sweep. rax = user pointer, header
-        // at [rax-16]; rax must survive, so this uses r10/r11 only. Only
-        // during Mark (not Relocate: new objects go into the mutator's
-        // current region, never a from-space region).
-        let skip_black = self.asm.create_text_label();
-        self.asm.mov_data_addr(Reg::R10, self.gc_phase);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-        self.asm.cmp_reg_imm8(Reg::R11, Self::GC_PHASE_MARK as i8);
-        self.asm.jcc_label(Condition::NotEqual, skip_black);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::Rax, -16);
-        self.asm.mov_data_addr(Reg::R10, self.gc_header_mark);
-        self.asm.load_ptr_disp32(Reg::R10, Reg::R10, 0);
-        self.asm.or_reg_reg(Reg::R11, Reg::R10);
-        self.asm.store_ptr_disp32(Reg::Rax, -16, Reg::R11);
-        self.asm.bind_text_label(skip_black);
-        // --gc-log: count this allocation and its byte size (total,
-        // header included, in slot 16). rax holds the user pointer and
-        // must survive, so the counter bumps use r10/r11 only.
-        if self.gc_log {
-            self.asm.mov_data_addr(Reg::R10, self.gc_alloc_count);
-            self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-            self.asm.add_reg_imm32(Reg::R11, 1);
-            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R11);
-            self.asm.load_rbp_slot(Reg::R11, 16); // total block bytes
-            self.asm.mov_data_addr(Reg::R10, self.gc_bytes_allocated);
-            self.asm.load_ptr_disp32(Reg::Rbx, Reg::R10, 0);
-            self.asm.add_reg_reg(Reg::Rbx, Reg::R11);
-            self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rbx);
-        }
-        // Tear down locals and return.
-        self.asm.add_reg_imm32(Reg::Rsp, 16);
-        self.asm.pop_reg(Reg::Rbx);
-        self.asm.leave();
-        self.asm.ret();
-    }
-
-    /// Inline body of an allocation attempt: bump within the current
-    /// region, acquiring a new region on boundary, or the large-object
-    /// path for requests bigger than one region. Jumps to `fail` when no
-    /// region can satisfy the request and to `success` (rax = user
-    /// pointer) on success. No per-object payload zeroing is emitted
-    /// here: a region is either fresh demand-paged (zero) memory, or a
-    /// reclaimed region that gc_acquire_region zeroed whole on reuse. So
-    /// an object's payload is always zero until its constructor writes
-    /// its fields (which the incremental collector relies on -- see
-    /// compile_gc_record).
-    fn emit_gc_alloc_attempt(&mut self, fail: TextLabel, success: TextLabel) {
-        let large = self.asm.create_text_label();
-        let need_region = self.asm.create_text_label();
-        let do_bump = self.asm.create_text_label();
-
-        // total = [rbp - 16]; requests larger than a region go the large
-        // path (a contiguous run of regions).
-        self.asm.load_rbp_slot(Reg::Rdi, 16);
-        self.asm.mov_imm64(Reg::Rcx, Self::GC_REGION_SIZE);
-        self.asm.cmp_reg_reg(Reg::Rdi, Reg::Rcx);
-        self.asm.jcc_label(Condition::Above, large);
-
-        // ---- Bump within the current region ----
-        self.asm.bind_text_label(do_bump);
-        self.asm.mov_data_addr(Reg::R10, self.gc_heap_top);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-        self.asm.load_rbp_slot(Reg::Rdi, 16);
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::R11);
-        self.asm.add_reg_reg(Reg::Rcx, Reg::Rdi);
-        self.asm.mov_data_addr(Reg::R8, self.gc_heap_end);
-        self.asm.load_ptr_disp32(Reg::R8, Reg::R8, 0);
-        self.asm.cmp_reg_reg(Reg::Rcx, Reg::R8);
-        self.asm.jcc_label(Condition::Above, need_region);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rcx);
-        self.asm.store_ptr_disp32(Reg::R11, 0, Reg::Rdi);
-        self.asm.load_rbp_slot(Reg::Rsi, 24);
-        self.asm.store_ptr_disp32(Reg::R11, 8, Reg::Rsi);
-        self.asm.mov_reg_reg(Reg::Rax, Reg::R11);
-        self.asm.add_reg_imm32(Reg::Rax, 16);
-        self.asm.jmp_label(success);
-
-        // Current region is full: acquire a fresh empty one and retry the
-        // bump (which is guaranteed to fit, since total <= region size).
-        self.asm.bind_text_label(need_region);
-        self.asm.call_label(self.gc_acquire_region);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        self.asm.jcc_label(Condition::Equal, fail);
-        self.asm.jmp_label(do_bump);
-
-        // ---- Large object (> one region): contiguous region run. ----
-        self.asm.bind_text_label(large);
-        self.asm.load_rbp_slot(Reg::Rdi, 16);
-        self.asm.load_rbp_slot(Reg::Rsi, 24);
-        self.asm.call_label(self.gc_alloc_large);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        self.asm.jcc_label(Condition::Equal, fail);
-        self.asm.jmp_label(success);
     }
 
     fn emit_gc_collect_runtime(&mut self) {

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -38580,195 +38580,26 @@ impl NativeCodeGenerator {
     /// Sweep: region-based reclamation -- clear mark bits and reclaim
     /// whole-dead regions onto the free-region pool.
     fn emit_gc_sweep_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_sweep);
-        self.asm.push_reg(Reg::Rbp);
-        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
-        self.asm.sub_reg_imm8(Reg::Rsp, 64);
-        // One completed collection cycle per sweep: bump the counter here
-        // so both the synchronous and incremental paths count once.
-        self.asm.mov_data_addr(Reg::R10, self.gc_collect_counter);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.add_reg_imm32(Reg::Rax, 1);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        // ---- Sweep phase (region-based) ----
-        // Walk every committed region. Within a region, walk its blocks
-        // from base to the region's watermark: clear the mark bit on live
-        // blocks, and note whether any block is live. A region with NO
-        // live block is reclaimed wholesale onto the free-region pool (a
-        // large object's contiguous run is reclaimed as a unit); a region
-        // with any live block is kept as-is, its dead space stranded until
-        // M7 compaction. r9 accumulates the free-region-list head across
-        // both loops (CALL-free, so it survives).
-        //
-        // First flush the current region's watermark (the bump path only
-        // updates the global gc_heap_top) so its objects are covered.
-        self.asm.mov_data_addr(Reg::R10, self.gc_heap_base);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R10, 0);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_base);
-        self.asm.load_ptr_disp32(Reg::R10, Reg::R10, 0);
-        self.asm.sub_reg_reg(Reg::R11, Reg::R10); // offset = heap_base - region_base
-        self.asm.shr_reg_imm8(Reg::R11, Self::GC_REGION_SHIFT); // cur region index
-        self.asm.shl_reg_imm8(Reg::R11, 3); // * 8
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_top);
-        self.asm.add_reg_reg(Reg::R10, Reg::R11);
-        self.asm.mov_data_addr(Reg::R8, self.gc_heap_top);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R8, 0);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax); // region_top[cur] = heap_top
-
-        // Cache committed bound, reset region index. Seed the free-region
-        // accumulator with the EXISTING pool head, not zero: regions that
-        // were already free at sweep entry are skipped by the walk (their
-        // watermark is base), so if we started from zero we would drop
-        // them from the list entirely -- leaking them (still committed,
-        // but unreachable to acquire, the tail-commit path, and
-        // gc_alloc_large). Seeding from the current head keeps the old
-        // chain intact (their [base] link qwords are untouched by the
-        // walk) and pushes this cycle's newly-dead regions on top.
-        self.asm.mov_data_addr(Reg::R10, self.gc_committed_count);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.store_rbp_slot(48, Reg::Rax);
-        self.asm.mov_imm64(Reg::Rax, 0);
-        self.asm.store_rbp_slot(40, Reg::Rax);
-        self.asm.mov_data_addr(Reg::R10, self.gc_free_region_head);
-        self.asm.load_ptr_disp32(Reg::R9, Reg::R10, 0);
-        // Cache the current-parity header mark bit in slot 8 (M7: the
-        // mark bit lives in header word0 bits 1-2, alternating per cycle,
-        // so a live block tests non-zero against this bit). Slot 16 holds
-        // the per-region live-byte accumulator (gc_region_live[idx]),
-        // which drives M7 sparsest-first evacuation selection.
-        self.asm.mov_data_addr(Reg::R10, self.gc_header_mark);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.store_rbp_slot(8, Reg::Rax);
-
-        let region_loop = self.asm.create_text_label();
-        let region_done = self.asm.create_text_label();
-        let inner_loop = self.asm.create_text_label();
-        let inner_done = self.asm.create_text_label();
-        let block_dead = self.asm.create_text_label();
-        let next_region = self.asm.create_text_label();
-        let reclaim_step = self.asm.create_text_label();
-
-        self.asm.bind_text_label(region_loop);
-        self.asm.load_rbp_slot(Reg::Rax, 40);
-        self.asm.load_rbp_slot(Reg::Rcx, 48);
-        self.asm.cmp_reg_reg(Reg::Rax, Reg::Rcx);
-        self.asm.jcc_label(Condition::AboveOrEqual, region_done);
-
-        // rsi = region_base + (i << REGION_SHIFT); save it.
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-        self.asm.shl_reg_imm8(Reg::Rcx, Self::GC_REGION_SHIFT);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_base);
-        self.asm.load_ptr_disp32(Reg::R10, Reg::R10, 0);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rcx);
-        self.asm.mov_reg_reg(Reg::Rsi, Reg::R10);
-        self.asm.store_rbp_slot(56, Reg::Rsi);
-        // r8 = region_top[i]
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-        self.asm.shl_reg_imm8(Reg::Rcx, 3);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_top);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rcx);
-        self.asm.load_ptr_disp32(Reg::R8, Reg::R10, 0);
-        // Empty region (top == base): skip; it is already free.
-        self.asm.cmp_reg_reg(Reg::R8, Reg::Rsi);
-        self.asm.jcc_label(Condition::Equal, next_region);
-        // M7: skip from-space (ghost) regions -- they are handled by the
-        // relocate/free-ghost machinery, not swept. Inert while evac is
-        // off (the array is all zero).
-        self.asm.load_rbp_slot(Reg::Rax, 40);
-        self.asm.shl_reg_imm8(Reg::Rax, 3);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_fromspace);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rax);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        self.asm.jcc_label(Condition::NotEqual, next_region);
-
-        // Inner block walk: r11 = cursor, rdx = any_live flag, slot 16 =
-        // live-byte accumulator for this region.
-        self.asm.mov_reg_reg(Reg::R11, Reg::Rsi);
-        self.asm.xor_reg_reg(Reg::Rdx, Reg::Rdx);
-        self.asm.mov_imm64(Reg::Rax, 0);
-        self.asm.store_rbp_slot(16, Reg::Rax);
-        self.asm.bind_text_label(inner_loop);
-        self.asm.cmp_reg_reg(Reg::R11, Reg::R8);
-        self.asm.jcc_label(Condition::AboveOrEqual, inner_done);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R11, 0); // header word0
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rax);
-        self.asm.and_reg_imm32(Reg::Rcx, -16); // size (clears FWD + mark bits)
-        // Live iff the current-parity mark bit is set (slot 8).
-        self.asm.load_rbp_slot(Reg::Rdi, 8);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rdi);
-        self.asm.jcc_label(Condition::Equal, block_dead);
-        // Live: rewrite the header as size | current mark -- this KEEPS
-        // the current mark (so the relocate walk can still read liveness
-        // after the sweep) and clears the stale (previous-cycle) mark and
-        // the FWD bit. any_live=1; accumulate the live bytes.
-        self.asm.mov_reg_reg(Reg::Rax, Reg::Rcx);
-        self.asm.or_reg_reg(Reg::Rax, Reg::Rdi);
-        self.asm.store_ptr_disp32(Reg::R11, 0, Reg::Rax);
-        self.asm.mov_imm64(Reg::Rdx, 1);
-        self.asm.load_rbp_slot(Reg::Rax, 16);
-        self.asm.add_reg_reg(Reg::Rax, Reg::Rcx);
-        self.asm.store_rbp_slot(16, Reg::Rax);
-        self.asm.add_reg_reg(Reg::R11, Reg::Rcx);
-        self.asm.jmp_label(inner_loop);
-        self.asm.bind_text_label(block_dead);
-        // Dead: skip; whole-region reclamation is decided after the walk.
-        self.asm.add_reg_reg(Reg::R11, Reg::Rcx);
-        self.asm.jmp_label(inner_loop);
-
-        self.asm.bind_text_label(inner_done);
-        // Record this region's live bytes for M7 sparsest-first selection.
-        self.asm.load_rbp_slot(Reg::Rax, 40);
-        self.asm.shl_reg_imm8(Reg::Rax, 3);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_live);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rax);
-        self.asm.load_rbp_slot(Reg::Rax, 16);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.test_reg_reg(Reg::Rdx, Reg::Rdx);
-        self.asm.jcc_label(Condition::NotEqual, next_region); // any live: keep
-        self.asm.load_rbp_slot(Reg::Rsi, 56);
-        // Never reclaim the current bump region.
-        self.asm.mov_data_addr(Reg::R10, self.gc_heap_base);
-        self.asm.load_ptr_disp32(Reg::R10, Reg::R10, 0);
-        self.asm.cmp_reg_reg(Reg::Rsi, Reg::R10);
-        self.asm.jcc_label(Condition::Equal, next_region);
-        // Fully dead: reclaim the run. rax = first block size (== the
-        // object size; for a large run it spans multiple regions, for a
-        // normal region it is <= REGION_SIZE so exactly one region).
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::Rsi, 0);
-        self.asm.and_reg_imm32(Reg::Rax, -16); // size (clears FWD + marks)
-        self.asm.mov_reg_reg(Reg::Rdi, Reg::Rsi); // rdi = m = run base
-        self.asm.bind_text_label(reclaim_step);
-        // Link this region into the free pool and mark it empty.
-        self.asm.store_ptr_disp32(Reg::Rdi, 0, Reg::R9);
-        self.asm.mov_reg_reg(Reg::R9, Reg::Rdi);
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rdi);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_base);
-        self.asm.load_ptr_disp32(Reg::R10, Reg::R10, 0);
-        self.asm.sub_reg_reg(Reg::Rcx, Reg::R10);
-        self.asm.shr_reg_imm8(Reg::Rcx, Self::GC_REGION_SHIFT);
-        self.asm.shl_reg_imm8(Reg::Rcx, 3);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_top);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rcx);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rdi); // region_top[idx] = base
-        self.asm
-            .sub_reg_imm32(Reg::Rax, Self::GC_REGION_SIZE as i32);
-        self.asm
-            .add_reg_imm32(Reg::Rdi, Self::GC_REGION_SIZE as i32);
-        self.asm.cmp_reg_imm8(Reg::Rax, 0);
-        self.asm.jcc_label(Condition::Greater, reclaim_step);
-
-        self.asm.bind_text_label(next_region);
-        self.asm.load_rbp_slot(Reg::Rax, 40);
-        self.asm.add_reg_imm32(Reg::Rax, 1);
-        self.asm.store_rbp_slot(40, Reg::Rax);
-        self.asm.jmp_label(region_loop);
-
-        self.asm.bind_text_label(region_done);
-        self.asm.mov_data_addr(Reg::R10, self.gc_free_region_head);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R9);
-        self.asm.leave();
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper).
+        let entry = self.gc_sweep;
+        let tables = portable_asm::RegionTables {
+            heap_base: self.gc_heap_base,
+            heap_top: self.gc_heap_top,
+            region_base: self.gc_region_base,
+            region_top: self.gc_region_top,
+            committed_count: self.gc_committed_count,
+            region_fromspace: self.gc_region_fromspace,
+        };
+        portable_asm::emit_gc_sweep(
+            self,
+            entry,
+            tables,
+            self.gc_collect_counter,
+            self.gc_free_region_head,
+            self.gc_header_mark,
+            self.gc_region_live,
+        );
     }
 
     /// Clear the mark bit on EVERY block of every committed region,

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -38826,40 +38826,23 @@ impl NativeCodeGenerator {
     /// fixpoint. Does NOT flip the mark color and does NOT sweep -- the
     /// caller sweeps.
     fn emit_gc_stw_mark_complete_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_stw_mark_complete);
-        self.asm.push_reg(Reg::Rbp);
-        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
-        // Clear the fallback flag: this from-scratch STW mark is the
-        // recovery. If the worklist overflows AGAIN during this drain,
-        // the live frontier genuinely exceeds capacity and we abort.
-        self.asm
-            .mov_data_addr(Reg::R10, self.gc_stw_fallback_pending);
-        self.asm.mov_imm64(Reg::Rax, 0);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.call_label(self.gc_clear_all_marks);
-        // Reset the worklist top.
-        self.asm.mov_data_addr(Reg::R10, self.gc_mark_worklist_top);
-        self.asm.mov_imm64(Reg::Rax, 0);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.call_label(self.gc_mark_roots);
-        self.asm.call_label(self.gc_drain);
-        // If the flag is set again, the worklist overflowed even on the
-        // from-scratch mark: genuine over-capacity, abort as before.
-        self.asm
-            .mov_data_addr(Reg::R10, self.gc_stw_fallback_pending);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        let ok = self.asm.create_text_label();
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        self.asm.jcc_label(Condition::Equal, ok);
-        self.emit_write_data(
-            2,
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper).
+        let entry = self.gc_stw_mark_complete;
+        let targets = portable_asm::StwMarkTargets {
+            clear_all_marks: self.gc_clear_all_marks,
+            mark_roots: self.gc_mark_roots,
+            drain: self.gc_drain,
+        };
+        portable_asm::emit_gc_stw_mark_complete(
+            self,
+            entry,
+            targets,
+            self.gc_stw_fallback_pending,
+            self.gc_mark_worklist_top,
             self.gc_worklist_overflow_text,
             b"klassic gc: mark worklist overflow\n".len(),
         );
-        self.emit_exit_code(1);
-        self.asm.bind_text_label(ok);
-        self.asm.leave();
-        self.asm.ret();
     }
 
     /// Drain the mark worklist to fixpoint by running quanta back to

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -39284,73 +39284,18 @@ impl NativeCodeGenerator {
     /// sweep reads exactly one block; member regions are left empty so
     /// the sweep skips them. Leaf routine.
     fn emit_gc_alloc_large_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_alloc_large);
-        let member_loop = self.asm.create_text_label();
-        let member_done = self.asm.create_text_label();
-        let fail = self.asm.create_text_label();
-
-        // rcx = N = ceil(total / REGION_SIZE) = (total + REGION_SIZE-1) >> SHIFT
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::Rdi);
-        self.asm
-            .add_reg_imm32(Reg::Rcx, (Self::GC_REGION_SIZE - 1) as i32);
-        self.asm.shr_reg_imm8(Reg::Rcx, Self::GC_REGION_SHIFT);
-        // r8 = committed, r9 = committed + N (new committed). Check budget.
-        self.asm.mov_data_addr(Reg::R10, self.gc_committed_count);
-        self.asm.load_ptr_disp32(Reg::R8, Reg::R10, 0);
-        self.asm.mov_reg_reg(Reg::R9, Reg::R8);
-        self.asm.add_reg_reg(Reg::R9, Reg::Rcx);
-        self.asm.mov_data_addr(Reg::R11, self.gc_budget_regions);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::R11, 0);
-        self.asm.cmp_reg_reg(Reg::R9, Reg::R11);
-        self.asm.jcc_label(Condition::Above, fail);
-        // base_f = region_base + (committed << REGION_SHIFT).
-        self.asm.mov_reg_reg(Reg::Rax, Reg::R8);
-        self.asm.shl_reg_imm8(Reg::Rax, Self::GC_REGION_SHIFT);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_base);
-        self.asm.load_ptr_disp32(Reg::R10, Reg::R10, 0);
-        self.asm.add_reg_reg(Reg::Rax, Reg::R10); // rax = base_f
-        // committed_count = committed + N.
-        self.asm.mov_data_addr(Reg::R10, self.gc_committed_count);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R9);
-        // Header at base_f: [base_f] = total, [base_f+8] = tag.
-        self.asm.store_ptr_disp32(Reg::Rax, 0, Reg::Rdi);
-        self.asm.store_ptr_disp32(Reg::Rax, 8, Reg::Rsi);
-        // region_top[f] = base_f + total (spans the whole run's object).
-        self.asm.mov_reg_reg(Reg::R11, Reg::R8);
-        self.asm.shl_reg_imm8(Reg::R11, 3);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_top);
-        self.asm.add_reg_reg(Reg::R10, Reg::R11);
-        self.asm.mov_reg_reg(Reg::R11, Reg::Rax);
-        self.asm.add_reg_reg(Reg::R11, Reg::Rdi);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R11);
-        // Member regions f+1 .. f+N-1: region_top[m] = its base (empty).
-        // r8 = m index (start f+1), r9 = f+N bound.
-        self.asm.add_reg_imm32(Reg::R8, 1);
-        self.asm.bind_text_label(member_loop);
-        self.asm.cmp_reg_reg(Reg::R8, Reg::R9);
-        self.asm.jcc_label(Condition::AboveOrEqual, member_done);
-        // addr = region_base + (m << REGION_SHIFT).
-        self.asm.mov_reg_reg(Reg::R11, Reg::R8);
-        self.asm.shl_reg_imm8(Reg::R11, Self::GC_REGION_SHIFT);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_base);
-        self.asm.load_ptr_disp32(Reg::R10, Reg::R10, 0);
-        self.asm.add_reg_reg(Reg::R11, Reg::R10); // r11 = member base
-        // region_top[m] = member base.
-        self.asm.mov_reg_reg(Reg::Rcx, Reg::R8);
-        self.asm.shl_reg_imm8(Reg::Rcx, 3);
-        self.asm.mov_data_addr(Reg::R10, self.gc_region_top);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rcx);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R11);
-        self.asm.add_reg_imm32(Reg::R8, 1);
-        self.asm.jmp_label(member_loop);
-        self.asm.bind_text_label(member_done);
-        // return rax = base_f + 16.
-        self.asm.add_reg_imm32(Reg::Rax, 16);
-        self.asm.ret();
-
-        self.asm.bind_text_label(fail);
-        self.asm.mov_imm64(Reg::Rax, 0);
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper).
+        let entry = self.gc_alloc_large;
+        let tables = portable_asm::RegionTables {
+            heap_base: self.gc_heap_base,
+            heap_top: self.gc_heap_top,
+            region_base: self.gc_region_base,
+            region_top: self.gc_region_top,
+            committed_count: self.gc_committed_count,
+            region_fromspace: self.gc_region_fromspace,
+        };
+        portable_asm::emit_gc_alloc_large(self, entry, tables, self.gc_budget_regions);
     }
 
     /// `gc_grow_budget(rdi = total)`: raise the soft region budget after

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -38451,42 +38451,16 @@ impl NativeCodeGenerator {
     /// pushing each non-null root target onto the mark worklist via
     /// gc_mark_visit. The caller resets the worklist top first.
     fn emit_gc_mark_roots_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_mark_roots);
-        self.asm.push_reg(Reg::Rbp);
-        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
-        self.asm.sub_reg_imm8(Reg::Rsp, 16);
-        self.asm.mov_data_addr(Reg::R10, self.gc_shadow_stack);
-        self.asm.load_ptr_disp32(Reg::R10, Reg::R10, 0);
-        self.asm.store_rbp_slot(8, Reg::R10);
-        // end = base + top * 8
-        self.asm.mov_data_addr(Reg::R8, self.gc_shadow_stack_top);
-        self.asm.load_ptr_disp32(Reg::Rcx, Reg::R8, 0);
-        self.asm.shl_reg_imm8(Reg::Rcx, 3);
-        self.asm.add_reg_reg(Reg::R10, Reg::Rcx);
-        self.asm.store_rbp_slot(16, Reg::R10);
-
-        let shadow_loop = self.asm.create_text_label();
-        let shadow_done = self.asm.create_text_label();
-        let shadow_skip = self.asm.create_text_label();
-        self.asm.bind_text_label(shadow_loop);
-        self.asm.load_rbp_slot(Reg::R10, 8);
-        self.asm.load_rbp_slot(Reg::R11, 16);
-        self.asm.cmp_reg_reg(Reg::R10, Reg::R11);
-        self.asm.jcc_label(Condition::AboveOrEqual, shadow_done);
-        // entry = [r10] is the address of a slot; deref to read the pointer.
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.load_ptr_disp32(Reg::Rdi, Reg::Rax, 0);
-        self.asm.test_reg_reg(Reg::Rdi, Reg::Rdi);
-        self.asm.jcc_label(Condition::Equal, shadow_skip);
-        self.asm.call_label(self.gc_mark_visit);
-        self.asm.bind_text_label(shadow_skip);
-        self.asm.load_rbp_slot(Reg::R10, 8);
-        self.asm.add_reg_imm32(Reg::R10, 8);
-        self.asm.store_rbp_slot(8, Reg::R10);
-        self.asm.jmp_label(shadow_loop);
-        self.asm.bind_text_label(shadow_done);
-        self.asm.leave();
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper).
+        let entry = self.gc_mark_roots;
+        portable_asm::emit_gc_mark_roots(
+            self,
+            entry,
+            self.gc_shadow_stack,
+            self.gc_shadow_stack_top,
+            self.gc_mark_visit,
+        );
     }
 
     /// Trace: drain the mark worklist, walking each pointer object's

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -38466,115 +38466,16 @@ impl NativeCodeGenerator {
     /// Trace: drain the mark worklist, walking each pointer object's
     /// payload and marking its children (the strong tricolor closure).
     fn emit_gc_trace_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_trace);
-        self.asm.push_reg(Reg::Rbp);
-        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
-        self.asm.sub_reg_imm8(Reg::Rsp, 32);
-        // rdi = pop budget for this quantum; [rbp-8] holds the remaining
-        // budget, [rbp-24] the field cursor, [rbp-32] the field end.
-        self.asm.store_rbp_slot(8, Reg::Rdi);
-        let trace_loop = self.asm.create_text_label();
-        let trace_done = self.asm.create_text_label();
-        let trace_field_loop = self.asm.create_text_label();
-        let trace_skip_field = self.asm.create_text_label();
-        self.asm.bind_text_label(trace_loop);
-        // Budget exhausted? (an incremental quantum stops here; the caller
-        // resumes next time. gc_drain passes a large budget per call and
-        // loops until the worklist empties, so it drains fully.)
-        self.asm.load_rbp_slot(Reg::Rax, 8);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        self.asm.jcc_label(Condition::Equal, trace_done);
-        self.asm.mov_data_addr(Reg::R10, self.gc_mark_worklist_top);
-        self.asm.load_ptr_disp32(Reg::Rcx, Reg::R10, 0);
-        self.asm.test_reg_reg(Reg::Rcx, Reg::Rcx);
-        self.asm.jcc_label(Condition::Equal, trace_done);
-        // We have work: spend one budget unit (rax still holds it).
-        self.asm.sub_reg_imm8(Reg::Rax, 1);
-        self.asm.store_rbp_slot(8, Reg::Rax);
-        // top--, fetch worklist[top]
-        self.asm.sub_reg_imm8(Reg::Rcx, 1);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rcx);
-        self.asm.mov_data_addr(Reg::R8, self.gc_mark_worklist);
-        self.asm.load_ptr_disp32(Reg::R8, Reg::R8, 0);
-        self.asm.mov_reg_reg(Reg::R9, Reg::Rcx);
-        self.asm.shl_reg_imm8(Reg::R9, 3);
-        self.asm.add_reg_reg(Reg::R8, Reg::R9);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R8, 0);
-        // type at [rax - 8]
-        self.asm.load_ptr_disp32(Reg::Rcx, Reg::Rax, -8);
-        // Save the type tag because the upcoming size load reuses rcx.
-        self.asm.mov_reg_reg(Reg::R8, Reg::Rcx);
-        // Tags below GC_TYPE_POINTER_RECORD (free / raw bytes) carry no
-        // pointer fields; tags >= GC_TYPE_POINTER_RECORD (record, array,
-        // pointer list) are walked as a packed array of heap pointers,
-        // optionally skipping a leading length qword for the list tag.
-        self.asm
-            .cmp_reg_imm8(Reg::Rcx, Self::GC_TYPE_POINTER_RECORD as i8);
-        self.asm.jcc_label(Condition::Below, trace_loop);
-        // Pointer record / array / list: walk payload. payload_size =
-        // (size & -16) - 16 (mask clears the FWD + mark low bits).
-        self.asm.load_ptr_disp32(Reg::Rcx, Reg::Rax, -16);
-        self.asm.and_reg_imm32(Reg::Rcx, -16);
-        self.asm.sub_reg_imm8(Reg::Rcx, 16);
-        // GC_TYPE_POINTER_LIST stores an integer length at offset 0 of
-        // the payload — skip it so the mark phase does not try to chase
-        // the length value as a heap pointer.
-        let after_list_skip = self.asm.create_text_label();
-        self.asm
-            .cmp_reg_imm8(Reg::R8, Self::GC_TYPE_POINTER_LIST as i8);
-        self.asm.jcc_label(Condition::NotEqual, after_list_skip);
-        self.asm.add_reg_imm32(Reg::Rax, 8);
-        self.asm.sub_reg_imm8(Reg::Rcx, 8);
-        self.asm.bind_text_label(after_list_skip);
-        // trace_end = rax + payload_size; trace_cursor = rax
-        self.asm.mov_reg_reg(Reg::R9, Reg::Rax);
-        self.asm.add_reg_reg(Reg::R9, Reg::Rcx);
-        self.asm.store_rbp_slot(32, Reg::R9);
-        self.asm.store_rbp_slot(24, Reg::Rax);
-        self.asm.bind_text_label(trace_field_loop);
-        self.asm.load_rbp_slot(Reg::R10, 24);
-        self.asm.load_rbp_slot(Reg::R11, 32);
-        self.asm.cmp_reg_reg(Reg::R10, Reg::R11);
-        self.asm.jcc_label(Condition::AboveOrEqual, trace_loop);
-        self.asm.load_ptr_disp32(Reg::Rdi, Reg::R10, 0);
-        // Heap slots hold colored pointers; strip the color before
-        // gc_mark_visit dereferences the block header at [rdi-16].
-        self.asm.and_reg_reg(Reg::Rdi, Reg::R13);
-        self.asm.test_reg_reg(Reg::Rdi, Reg::Rdi);
-        self.asm.jcc_label(Condition::Equal, trace_skip_field);
-        // M7: follow forwarding BEFORE recoloring/healing the slot. If the
-        // child was already evacuated, its header is a forwarding word;
-        // we must heal the slot to the TO-SPACE address, not write a
-        // good-colored ghost pointer (which a later fast-path load would
-        // dereference as a forwarding word -> use-after-free). Inert while
-        // evac is off (FWD never set). r11 is scratch here.
-        let trace_child_not_fwd = self.asm.create_text_label();
-        self.asm.load_ptr_disp32(Reg::R11, Reg::Rdi, -16);
-        self.asm.and_reg_imm32(Reg::R11, Self::GC_FWD as i32);
-        self.asm.test_reg_reg(Reg::R11, Reg::R11);
-        self.asm.jcc_label(Condition::Equal, trace_child_not_fwd);
-        self.asm.load_ptr_disp32(Reg::R11, Reg::Rdi, -16);
-        self.asm.and_reg_imm32(Reg::R11, -16); // to-space user ptr
-        self.asm.mov_reg_reg(Reg::Rdi, Reg::R11);
-        self.asm.bind_text_label(trace_child_not_fwd);
-        // Recolor-on-trace: write the good-colored (to-space) child back
-        // into this field slot (r10 = slot address) BEFORE marking, so a
-        // later barriered load of the same field takes the fast path
-        // instead of re-entering the slow path. Must precede the call,
-        // which clobbers r10; the cursor is reloaded afterward. Inert
-        // until the mark color flips (recoloring good->good is a no-op).
-        self.asm.mov_reg_reg(Reg::R11, Reg::Rdi);
-        self.asm.or_reg_reg(Reg::R11, Reg::R14);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R11);
-        self.asm.call_label(self.gc_mark_visit);
-        self.asm.bind_text_label(trace_skip_field);
-        self.asm.load_rbp_slot(Reg::R10, 24);
-        self.asm.add_reg_imm32(Reg::R10, 8);
-        self.asm.store_rbp_slot(24, Reg::R10);
-        self.asm.jmp_label(trace_field_loop);
-        self.asm.bind_text_label(trace_done);
-        self.asm.leave();
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper).
+        let entry = self.gc_trace;
+        portable_asm::emit_gc_trace(
+            self,
+            entry,
+            self.gc_mark_worklist_top,
+            self.gc_mark_worklist,
+            self.gc_mark_visit,
+        );
     }
 
     /// Sweep: region-based reclamation -- clear mark bits and reclaim

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -489,6 +489,7 @@ pub fn compile_source_to_elf(
 
 #[allow(clippy::result_large_err)]
 mod cbackend;
+mod gc_layout;
 mod llvm;
 
 #[allow(clippy::result_large_err)]
@@ -36741,55 +36742,26 @@ impl NativeCodeGenerator {
         self.asm.ret();
     }
 
-    /// Region granularity for the region-based heap. Objects bump-allocate
-    /// within a region; whole dead regions are the unit of reclamation.
-    const GC_REGION_SIZE: u64 = 1 << 17; // 128 KiB
-    const GC_REGION_SHIFT: u8 = 17;
-    /// The heap is one up-front virtual reservation of this many regions
-    /// (64 MiB, matching the old segment cap). Linux demand-pages it, so
-    /// only touched regions cost physical memory; the soft budget below
-    /// bounds how many the mutator may touch before a collection.
-    const GC_RESERVE_REGIONS: u64 = 512;
-    const GC_RESERVE_BYTES: u64 = Self::GC_REGION_SIZE * Self::GC_RESERVE_REGIONS;
-    /// Initial soft budget: 8 regions = 1 MiB, preserving the collection
-    /// cadence of the old 1 MiB initial heap. Doubles on allocation stall,
-    /// capped at GC_RESERVE_REGIONS.
-    const GC_INITIAL_BUDGET_REGIONS: u64 = 8;
-    /// Total bytes for the single mmap backing the GC's runtime tables:
-    /// the shadow stack (the sole root source) and the mark worklist.
-    const GC_TABLES_BYTES: u64 =
-        ((Self::GC_SHADOW_STACK_LEN + Self::GC_MARK_WORKLIST_LEN) * 8) as u64;
-    // The mark worklist must hold the breadth-first frontier of the
-    // live object graph; deep recursion with per-frame heap values
-    // makes the live set proportional to recursion depth.
-    const GC_MARK_WORKLIST_LEN: usize = 262144;
-    /// Maximum number of stack-frame heap-pointer slots tracked at any
-    /// one time. Allocating a 33rd nested heap-pointer var beyond this
-    /// limit aborts with an explicit shadow-stack overflow message.
-    // Sized for deep recursion: every live frame of a function with
-    // heap-pointer parameters holds roots here. The GC tables are
-    // lazily-backed mmap (see the GC-table init), so a large cap
-    // reserves address space without committing pages until used;
-    // sized to comfortably exceed the frame count the C call stack can
-    // hold, so a deep recursion trips the stack-overflow probe (a
-    // clean diagnostic) before this cap, matching the evaluator.
-    const GC_SHADOW_STACK_LEN: usize = 262144;
-    const GC_MAX_PAYLOAD_SIZE: u64 = i64::MAX as u64 - 31 - 4095;
-    const GC_MAX_STRING_ALLOC_SIZE: u64 = Self::GC_MAX_PAYLOAD_SIZE - 15;
-    const GC_MAX_POINTER_SLOT_COUNT: u64 = Self::GC_MAX_PAYLOAD_SIZE / 8;
-    const GC_MAX_LIST_LENGTH: u64 = (Self::GC_MAX_PAYLOAD_SIZE - 8) / 8;
-    /// Type tag stored in the second header word. 0 marks a free block,
-    /// 1 marks a raw-bytes payload (no pointer fields), 2 marks a
-    /// "pointer record" whose payload is interpreted as a packed array
-    /// of heap pointers that the mark phase recurses into, and 3 marks a
-    /// variable-length pointer array (same tracing as a record).
-    const GC_TYPE_RAW_BYTES: u64 = 1;
-    const GC_TYPE_POINTER_RECORD: u64 = 2;
-    /// Heap-backed pointer list: payload is `[len: i64, ptr_0, ptr_1,
-    /// ...]`. The first qword is an integer length and must be skipped
-    /// by the mark phase; the remaining payload is a packed pointer
-    /// table identical to `GC_TYPE_POINTER_ARRAY` for tracing purposes.
-    const GC_TYPE_POINTER_LIST: u64 = 4;
+    // Region-heap GC design constants. The definitions and their prose
+    // live in the architecture-independent `gc_layout` module (the
+    // single non-x86-64 home for the collector's ABI); these associated
+    // aliases keep the `Self::GC_*` call sites throughout this file
+    // unchanged.
+    const GC_REGION_SIZE: u64 = crate::gc_layout::GC_REGION_SIZE;
+    const GC_REGION_SHIFT: u8 = crate::gc_layout::GC_REGION_SHIFT;
+    const GC_RESERVE_REGIONS: u64 = crate::gc_layout::GC_RESERVE_REGIONS;
+    const GC_RESERVE_BYTES: u64 = crate::gc_layout::GC_RESERVE_BYTES;
+    const GC_INITIAL_BUDGET_REGIONS: u64 = crate::gc_layout::GC_INITIAL_BUDGET_REGIONS;
+    const GC_TABLES_BYTES: u64 = crate::gc_layout::GC_TABLES_BYTES;
+    const GC_MARK_WORKLIST_LEN: usize = crate::gc_layout::GC_MARK_WORKLIST_LEN;
+    const GC_SHADOW_STACK_LEN: usize = crate::gc_layout::GC_SHADOW_STACK_LEN;
+    const GC_MAX_PAYLOAD_SIZE: u64 = crate::gc_layout::GC_MAX_PAYLOAD_SIZE;
+    const GC_MAX_STRING_ALLOC_SIZE: u64 = crate::gc_layout::GC_MAX_STRING_ALLOC_SIZE;
+    const GC_MAX_POINTER_SLOT_COUNT: u64 = crate::gc_layout::GC_MAX_POINTER_SLOT_COUNT;
+    const GC_MAX_LIST_LENGTH: u64 = crate::gc_layout::GC_MAX_LIST_LENGTH;
+    const GC_TYPE_RAW_BYTES: u64 = crate::gc_layout::GC_TYPE_RAW_BYTES;
+    const GC_TYPE_POINTER_RECORD: u64 = crate::gc_layout::GC_TYPE_POINTER_RECORD;
+    const GC_TYPE_POINTER_LIST: u64 = crate::gc_layout::GC_TYPE_POINTER_LIST;
 
     /// Initialize the GC heap: mmap a private anonymous region and seed the
     /// heap_base / heap_top / heap_end globals.
@@ -37907,41 +37879,25 @@ impl NativeCodeGenerator {
         self.emit_exit_code(1);
     }
 
-    /// ZGC colored-pointer bits (in bits 60-62; mmap addresses are <= 47
-    /// bits, so these are free, and any pointer with one set is
-    /// non-canonical -- dereferencing a colored pointer without stripping
-    /// faults, which is the barrier-coverage guarantee).
-    const GC_COLOR_M0: u64 = 1 << 60;
-    const GC_COLOR_M1: u64 = 1 << 61;
-    const GC_COLOR_R: u64 = 1 << 62;
-    const GC_COLOR_MASK: u64 = 7 << 60;
-    /// Strip mask: clears the color bits, leaving the raw address.
-    const GC_COLOR_STRIP: u64 = !Self::GC_COLOR_MASK;
-    /// Bad-color test mask: a good (M0) pointer ANDs to zero; a poisoned
-    /// (M1) or relocation-flagged (R) pointer ANDs non-zero and takes the
-    /// load-barrier slow path.
-    const GC_COLOR_BAD_MASK: u64 = Self::GC_COLOR_M1 | Self::GC_COLOR_R;
-    /// M6 incremental-marking tuning. A mark quantum traces up to
-    /// GC_QUANTUM_POPS worklist objects; the driver runs one quantum per
-    /// GC_QUANTUM_BYTES allocated during the Mark phase. A cycle starts
-    /// proactively when live regions exceed 5/8 of the soft budget.
-    const GC_QUANTUM_POPS: u64 = 512;
-    const GC_QUANTUM_BYTES: u64 = 8192;
-    const GC_PHASE_IDLE: u64 = 0;
-    const GC_PHASE_MARK: u64 = 1;
-    /// M7 relocation phase: live objects are evacuated out of the sparsest
-    /// regions so those regions can be freed (heap compaction).
-    const GC_PHASE_RELOCATE: u64 = 2;
-    /// M7 object-header low bits (the size is 16-aligned, so bits 0-3 of
-    /// header word0 are free). bit0 = forwarded (word0 then holds the new
-    /// user pointer | GC_FWD); bits 1-2 = the two alternating mark bits
-    /// (which parity is "current" this cycle lives in the gc_header_mark
-    /// cell). The mark bit moved off bit 63 so word0 can hold a
-    /// forwarding pointer. Size is recovered with `and reg, -16`.
-    const GC_FWD: u64 = 1;
-    const GC_HMARK0: u64 = 1 << 1;
-    const GC_HMARK1: u64 = 1 << 2;
-    const GC_HMARK_BOTH: u64 = Self::GC_HMARK0 | Self::GC_HMARK1;
+    // Colored-pointer + phase/header GC design constants. Definitions and
+    // prose live in `gc_layout`; these are `Self::GC_*` aliases.
+    const GC_COLOR_M0: u64 = crate::gc_layout::GC_COLOR_M0;
+    const GC_COLOR_M1: u64 = crate::gc_layout::GC_COLOR_M1;
+    const GC_COLOR_R: u64 = crate::gc_layout::GC_COLOR_R;
+    const GC_COLOR_MASK: u64 = crate::gc_layout::GC_COLOR_MASK;
+    const GC_COLOR_STRIP: u64 = crate::gc_layout::GC_COLOR_STRIP;
+    const GC_COLOR_BAD_MASK: u64 = crate::gc_layout::GC_COLOR_BAD_MASK;
+    const GC_QUANTUM_POPS: u64 = crate::gc_layout::GC_QUANTUM_POPS;
+    const GC_QUANTUM_BYTES: u64 = crate::gc_layout::GC_QUANTUM_BYTES;
+    const GC_PHASE_IDLE: u64 = crate::gc_layout::GC_PHASE_IDLE;
+    const GC_PHASE_MARK: u64 = crate::gc_layout::GC_PHASE_MARK;
+    const GC_PHASE_RELOCATE: u64 = crate::gc_layout::GC_PHASE_RELOCATE;
+    const GC_FWD: u64 = crate::gc_layout::GC_FWD;
+    // GC_HMARK0 has no direct `Self::` use in this file (its only prior
+    // reference was inside GC_HMARK_BOTH's definition, now in gc_layout);
+    // reference it via `crate::gc_layout::GC_HMARK0` if ever needed.
+    const GC_HMARK1: u64 = crate::gc_layout::GC_HMARK1;
+    const GC_HMARK_BOTH: u64 = crate::gc_layout::GC_HMARK_BOTH;
 
     /// Initialize the reserved color registers once, before any user
     /// code or collector routine runs. r13 = strip mask, r14 = good

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -38134,23 +38134,29 @@ impl NativeCodeGenerator {
     /// the clock syscall path panics on Windows, and no cell is written
     /// there, so a pause simply reads 0). Emitted at the start of each
     /// STW pause (MarkStart, MarkEnd, and the synchronous full collect).
+    fn gc_pause_cells(&self) -> portable_asm::PauseCells<DataLabel> {
+        portable_asm::PauseCells {
+            start_ns: self.gc_pause_start_ns,
+            total_ns: self.gc_pause_total_ns,
+            max_ns: self.gc_pause_max_ns,
+        }
+    }
+
     fn emit_gc_pause_start(&mut self) {
         // Delegated to the portable emitter; the `--gc-log`-and-not-Windows
         // gate stays here (it is host-config state, not codegen), and the
         // clock read is a `PortableAsm` platform primitive. Byte-identical.
         let timing = self.gc_log && !self.is_windows;
-        let start = self.gc_pause_start_ns;
-        portable_asm::emit_gc_pause_start(self, timing, start);
+        let cells = self.gc_pause_cells();
+        portable_asm::emit_gc_pause_start(self, timing, cells);
     }
 
     /// Fold the elapsed pause (now - gc_pause_start_ns) into the max and
     /// total pause accumulators. Emitted at the end of each STW pause.
     fn emit_gc_pause_end(&mut self) {
         let timing = self.gc_log && !self.is_windows;
-        let start = self.gc_pause_start_ns;
-        let total = self.gc_pause_total_ns;
-        let max = self.gc_pause_max_ns;
-        portable_asm::emit_gc_pause_end(self, timing, start, total, max);
+        let cells = self.gc_pause_cells();
+        portable_asm::emit_gc_pause_end(self, timing, cells);
     }
 
     fn emit_gc_alloc_runtime(&mut self) {
@@ -38934,43 +38940,27 @@ impl NativeCodeGenerator {
     /// to fixpoint (a straggler may have been added by the barrier), and
     /// if THAT overflows, degrade. Then sweep and return to Idle.
     fn emit_gc_mark_end_runtime(&mut self) {
-        self.asm.bind_text_label(self.gc_mark_end);
-        self.asm.push_reg(Reg::Rbp);
-        self.asm.mov_reg_reg(Reg::Rbp, Reg::Rsp);
-        self.emit_gc_pause_start(); // MarkEnd STW pause (final drain + sweep).
-        let do_degrade = self.asm.create_text_label();
-        let after_mark = self.asm.create_text_label();
-        self.asm
-            .mov_data_addr(Reg::R10, self.gc_stw_fallback_pending);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        self.asm.jcc_label(Condition::NotEqual, do_degrade);
-        self.asm.call_label(self.gc_drain);
-        self.asm
-            .mov_data_addr(Reg::R10, self.gc_stw_fallback_pending);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-        self.asm.jcc_label(Condition::Equal, after_mark);
-        self.asm.bind_text_label(do_degrade);
-        self.asm.mov_data_addr(Reg::R10, self.gc_stw_fallbacks);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.add_reg_imm32(Reg::Rax, 1);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.call_label(self.gc_stw_mark_complete);
-        self.asm.bind_text_label(after_mark);
-        // Free the previous cycle's ghost (from-space) regions: the mark
-        // just reached fixpoint, so no live slot references them
-        // (soundness invariant III). A no-op until evacuation runs.
-        self.asm.call_label(self.gc_free_ghost_regions);
-        self.asm.call_label(self.gc_sweep);
-        // Close the cycle. gc_relocate_start selects from-space regions,
-        // fixes roots, and enters the Relocate phase when evacuation is
-        // active; until the activation step it just returns to Idle and
-        // resets the proactive-trigger counter.
-        self.asm.call_label(self.gc_relocate_start);
-        self.emit_gc_pause_end();
-        self.asm.leave();
-        self.asm.ret();
+        // Migrated onto the portable `PortableAsm` emitter trait; behavior
+        // is byte-identical (the x86-64 impl is a 1:1 wrapper).
+        let entry = self.gc_mark_end;
+        let timing = self.gc_log && !self.is_windows;
+        let pause = self.gc_pause_cells();
+        let targets = portable_asm::MarkEndTargets {
+            drain: self.gc_drain,
+            stw_mark_complete: self.gc_stw_mark_complete,
+            free_ghost_regions: self.gc_free_ghost_regions,
+            sweep: self.gc_sweep,
+            relocate_start: self.gc_relocate_start,
+        };
+        portable_asm::emit_gc_mark_end(
+            self,
+            entry,
+            timing,
+            pause,
+            targets,
+            self.gc_stw_fallback_pending,
+            self.gc_stw_fallbacks,
+        );
     }
 
     /// `gc_mark_visit(addr)` (rdi = addr): if addr points to an unmarked

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -131,6 +131,12 @@ pub trait PortableAsm {
     fn plat_write_data(&mut self, fd: u64, data: Self::DataLabel, len: usize);
     /// Terminate the process with status `code` (does not return).
     fn plat_exit(&mut self, code: u64);
+    /// Read the monotonic clock in nanoseconds into `V0`. The clock
+    /// source and its timespec ABI are platform-specific (a Linux/macOS
+    /// `clock_gettime` syscall here), so the whole read is one primitive
+    /// rather than a syscall op plus portable arithmetic. Clobbers scratch
+    /// registers (V0/V1/V8 on x86-64) like any subroutine-free helper.
+    fn plat_read_monotonic_ns(&mut self);
 }
 
 impl From<Reg> for crate::Reg {
@@ -270,6 +276,55 @@ impl PortableAsm for crate::NativeCodeGenerator {
     }
     fn plat_exit(&mut self, code: u64) {
         self.emit_exit_code(code);
+    }
+    fn plat_read_monotonic_ns(&mut self) {
+        self.emit_read_monotonic_ns_to_rax();
+    }
+}
+
+/// Portable version of the `gc_pause_start` STW-pause helper: when
+/// `timing` is set (the `--gc-log` build on a platform whose clock the
+/// backend supports), capture the monotonic clock into `pause_start_ns`;
+/// otherwise emit nothing. Inlined at the start of every STW pause.
+pub fn emit_gc_pause_start<E: PortableAsm>(
+    out: &mut E,
+    timing: bool,
+    pause_start_ns: E::DataLabel,
+) {
+    if timing {
+        out.plat_read_monotonic_ns();
+        out.mov_data_addr(Reg::V10, pause_start_ns);
+        out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    }
+}
+
+/// Portable version of the `gc_pause_end` STW-pause helper: when `timing`
+/// is set, fold the elapsed pause (`now - pause_start_ns`) into the total
+/// and max accumulators; otherwise emit nothing. Inlined at the end of
+/// every STW pause.
+pub fn emit_gc_pause_end<E: PortableAsm>(
+    out: &mut E,
+    timing: bool,
+    pause_start_ns: E::DataLabel,
+    pause_total_ns: E::DataLabel,
+    pause_max_ns: E::DataLabel,
+) {
+    if timing {
+        out.plat_read_monotonic_ns();
+        out.mov_data_addr(Reg::V10, pause_start_ns);
+        out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+        out.sub_reg_reg(Reg::V0, Reg::V11); // rax = delta ns
+        out.mov_data_addr(Reg::V10, pause_total_ns);
+        out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+        out.add_reg_reg(Reg::V11, Reg::V0);
+        out.store_ptr_disp32(Reg::V10, 0, Reg::V11);
+        out.mov_data_addr(Reg::V10, pause_max_ns);
+        out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+        out.cmp_reg_reg(Reg::V0, Reg::V11);
+        let keep_max = out.create_text_label();
+        out.jcc_label(Condition::LessEqual, keep_max);
+        out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+        out.bind_text_label(keep_max);
     }
 }
 

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -529,3 +529,82 @@ pub fn emit_gc_stw_mark_complete<E: PortableAsm>(
     out.leave();
     out.ret();
 }
+
+/// Portable version of `gc_free_ghost_regions`: walk every committed
+/// region and, for each from-space (ghost) region, push its backing
+/// store onto the free-region pool and reset the region's metadata
+/// (top = base, fromspace = 0, live = 0). Runs at MarkEnd once the mark
+/// has reached fixpoint, so no live slot still references a ghost. Uses
+/// two frame slots (`[rbp-8]` = index, `[rbp-16]` = committed bound).
+/// Reuses `RegionTables` (committed_count / region_fromspace /
+/// region_base / region_top); `free_region_head` and `region_live` are
+/// the two labels beyond that set.
+pub fn emit_gc_free_ghost_regions<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    t: RegionTables<E::DataLabel>,
+    free_region_head: E::DataLabel,
+    region_live: E::DataLabel,
+) {
+    use crate::gc_layout::GC_REGION_SHIFT;
+
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V5); // rbp
+    out.mov_reg_reg(Reg::V5, Reg::V4); // rbp = rsp
+    out.sub_reg_imm8(Reg::V4, 16);
+    out.mov_data_addr(Reg::V10, t.committed_count);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.store_rbp_slot(16, Reg::V0); // bound
+    out.mov_imm64(Reg::V0, 0);
+    out.store_rbp_slot(8, Reg::V0); // idx
+    let loop_l = out.create_text_label();
+    let done_l = out.create_text_label();
+    let next_l = out.create_text_label();
+    out.bind_text_label(loop_l);
+    out.load_rbp_slot(Reg::V0, 8);
+    out.load_rbp_slot(Reg::V1, 16);
+    out.cmp_reg_reg(Reg::V0, Reg::V1);
+    out.jcc_label(Condition::AboveOrEqual, done_l);
+    // fromspace[idx]?
+    out.mov_reg_reg(Reg::V1, Reg::V0);
+    out.shl_reg_imm8(Reg::V1, 3);
+    out.mov_data_addr(Reg::V10, t.region_fromspace);
+    out.add_reg_reg(Reg::V10, Reg::V1);
+    out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+    out.test_reg_reg(Reg::V11, Reg::V11);
+    out.jcc_label(Condition::Equal, next_l);
+    // base = region_base + (idx << SHIFT)
+    out.load_rbp_slot(Reg::V0, 8);
+    out.shl_reg_imm8(Reg::V0, GC_REGION_SHIFT);
+    out.mov_data_addr(Reg::V10, t.region_base);
+    out.load_ptr_disp32(Reg::V10, Reg::V10, 0);
+    out.add_reg_reg(Reg::V0, Reg::V10); // rax = base
+    // push onto free pool: [base] = free_head; free_head = base
+    out.mov_data_addr(Reg::V10, free_region_head);
+    out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+    out.store_ptr_disp32(Reg::V0, 0, Reg::V11);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    // idx*8 in rcx for the three arrays.
+    out.load_rbp_slot(Reg::V1, 8);
+    out.shl_reg_imm8(Reg::V1, 3);
+    // region_top[idx] = base (empty)
+    out.mov_data_addr(Reg::V10, t.region_top);
+    out.add_reg_reg(Reg::V10, Reg::V1);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    // fromspace[idx] = 0 ; live[idx] = 0
+    out.mov_imm64(Reg::V11, 0);
+    out.mov_data_addr(Reg::V10, t.region_fromspace);
+    out.add_reg_reg(Reg::V10, Reg::V1);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V11);
+    out.mov_data_addr(Reg::V10, region_live);
+    out.add_reg_reg(Reg::V10, Reg::V1);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V11);
+    out.bind_text_label(next_l);
+    out.load_rbp_slot(Reg::V0, 8);
+    out.add_reg_imm32(Reg::V0, 1);
+    out.store_rbp_slot(8, Reg::V0);
+    out.jmp_label(loop_l);
+    out.bind_text_label(done_l);
+    out.leave();
+    out.ret();
+}

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -1621,6 +1621,160 @@ pub fn emit_gc_acquire_region<E: PortableAsm>(
     out.ret();
 }
 
+/// The resumable-cursor and mark cells the relocate quantum reads.
+#[derive(Clone, Copy)]
+pub struct RelocQuantumCells<D: Copy> {
+    pub reloc_scan_idx: D,
+    pub reloc_block: D,
+    pub header_mark: D,
+}
+
+/// Portable version of `gc_relocate_quantum` (V7/rdi = byte budget):
+/// linearly walk the from-space regions (resumable cursor in
+/// reloc_scan_idx / reloc_block), evacuating each live block until the
+/// budget is spent or all from-space is drained. On drain, call
+/// relocate_finish; otherwise save the block cursor for the next quantum.
+/// Frame: 8 = budget, 16 = cur, 24 = top. Reuses `RegionTables` for
+/// committed_count / region_base / region_top / region_fromspace.
+pub fn emit_gc_relocate_quantum<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    t: RegionTables<E::DataLabel>,
+    c: RelocQuantumCells<E::DataLabel>,
+    evacuate: E::TextLabel,
+    relocate_finish: E::TextLabel,
+) {
+    use crate::gc_layout::{GC_FWD, GC_REGION_SHIFT};
+
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V5); // rbp
+    out.mov_reg_reg(Reg::V5, Reg::V4); // rbp = rsp
+    out.sub_reg_imm8(Reg::V4, 32); // 8=budget,16=cur,24=top
+    out.store_rbp_slot(8, Reg::V7);
+    let region_scan = out.create_text_label();
+    let block_loop = out.create_text_label();
+    let advance_region = out.create_text_label();
+    let not_fwd = out.create_text_label();
+    let after_block = out.create_text_label();
+    let saved_cur = out.create_text_label();
+    out.bind_text_label(region_scan);
+    // idx = gc_reloc_scan_idx; if idx >= committed -> finish.
+    out.mov_data_addr(Reg::V10, c.reloc_scan_idx);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.mov_data_addr(Reg::V10, t.committed_count);
+    out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+    out.cmp_reg_reg(Reg::V0, Reg::V11);
+    out.jcc_label(Condition::AboveOrEqual, saved_cur);
+    // fromspace[idx]? if not, advance to next region.
+    out.mov_reg_reg(Reg::V1, Reg::V0);
+    out.shl_reg_imm8(Reg::V1, 3);
+    out.mov_data_addr(Reg::V10, t.region_fromspace);
+    out.add_reg_reg(Reg::V10, Reg::V1);
+    out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+    out.test_reg_reg(Reg::V11, Reg::V11);
+    out.jcc_label(Condition::Equal, advance_region);
+    // base = region_base + (idx << SHIFT) ; top = region_top[idx].
+    out.mov_reg_reg(Reg::V1, Reg::V0);
+    out.shl_reg_imm8(Reg::V1, GC_REGION_SHIFT);
+    out.mov_data_addr(Reg::V10, t.region_base);
+    out.load_ptr_disp32(Reg::V10, Reg::V10, 0);
+    out.add_reg_reg(Reg::V1, Reg::V10); // base
+    out.mov_reg_reg(Reg::V8, Reg::V0);
+    out.shl_reg_imm8(Reg::V8, 3);
+    out.mov_data_addr(Reg::V10, t.region_top);
+    out.add_reg_reg(Reg::V10, Reg::V8);
+    out.load_ptr_disp32(Reg::V8, Reg::V10, 0); // top
+    out.store_rbp_slot(24, Reg::V8);
+    // cur = gc_reloc_block; if 0 use base.
+    out.mov_data_addr(Reg::V10, c.reloc_block);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    let have_cur = out.create_text_label();
+    out.jcc_label(Condition::NotEqual, have_cur);
+    out.mov_reg_reg(Reg::V0, Reg::V1); // cur = base
+    out.bind_text_label(have_cur);
+    out.store_rbp_slot(16, Reg::V0);
+    out.bind_text_label(block_loop);
+    out.load_rbp_slot(Reg::V0, 16); // cur
+    out.load_rbp_slot(Reg::V8, 24); // top
+    out.cmp_reg_reg(Reg::V0, Reg::V8);
+    out.jcc_label(Condition::AboveOrEqual, advance_region);
+    // budget <= 0 ? save cur and return.
+    out.load_rbp_slot(Reg::V1, 8);
+    out.test_reg_reg(Reg::V1, Reg::V1);
+    out.jcc_label(Condition::Equal, saved_cur);
+    out.cmp_reg_imm8(Reg::V1, 0);
+    out.jcc_label(Condition::Less, saved_cur);
+    // word0 = [cur].
+    out.load_ptr_disp32(Reg::V11, Reg::V0, 0);
+    out.mov_reg_reg(Reg::V1, Reg::V11);
+    out.and_reg_imm32(Reg::V1, GC_FWD as i32);
+    out.test_reg_reg(Reg::V1, Reg::V1);
+    out.jcc_label(Condition::Equal, not_fwd);
+    // Forwarded: size from word1 = [cur+8].
+    out.load_ptr_disp32(Reg::V1, Reg::V0, 8);
+    out.jmp_label(after_block);
+    out.bind_text_label(not_fwd);
+    // size = word0 & -16.
+    out.mov_reg_reg(Reg::V1, Reg::V11);
+    out.and_reg_imm32(Reg::V1, -16);
+    // live? (word0 & current mark bit)
+    out.mov_data_addr(Reg::V10, c.header_mark);
+    out.load_ptr_disp32(Reg::V8, Reg::V10, 0);
+    out.test_reg_reg(Reg::V11, Reg::V8);
+    out.jcc_label(Condition::Equal, after_block);
+    // Live: evacuate(cur+16). Preserve cur/size in slots; the call
+    // clobbers rax/rcx/etc. budget -= size.
+    out.store_rbp_slot(16, Reg::V0); // (cur unchanged, keep)
+    out.mov_reg_reg(Reg::V7, Reg::V0);
+    out.add_reg_imm32(Reg::V7, 16); // user ptr
+    // stash size in a callee-preserved-ish slot before the call.
+    out.push_reg(Reg::V1); // size (one push, then call — realign)
+    out.push_reg(Reg::V1); // pad to keep rsp 16-aligned
+    out.call_label(evacuate);
+    out.pop_reg(Reg::V1);
+    out.pop_reg(Reg::V1); // rcx = size
+    // budget -= size
+    out.load_rbp_slot(Reg::V0, 8);
+    out.sub_reg_reg(Reg::V0, Reg::V1);
+    out.store_rbp_slot(8, Reg::V0);
+    out.bind_text_label(after_block);
+    // cur += size (rcx). Reload cur, advance, store.
+    out.load_rbp_slot(Reg::V0, 16);
+    out.add_reg_reg(Reg::V0, Reg::V1);
+    out.store_rbp_slot(16, Reg::V0);
+    out.jmp_label(block_loop);
+    out.bind_text_label(advance_region);
+    // gc_reloc_scan_idx++ ; gc_reloc_block = 0 ; rescan.
+    out.mov_data_addr(Reg::V10, c.reloc_scan_idx);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.add_reg_imm32(Reg::V0, 1);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.mov_data_addr(Reg::V10, c.reloc_block);
+    out.mov_imm64(Reg::V0, 0);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.jmp_label(region_scan);
+    out.bind_text_label(saved_cur);
+    // Save the block cursor for resumption. gc_relocate_finish is called
+    // only when idx >= committed.
+    out.mov_data_addr(Reg::V10, c.reloc_scan_idx);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.mov_data_addr(Reg::V10, t.committed_count);
+    out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+    out.cmp_reg_reg(Reg::V0, Reg::V11);
+    let just_save = out.create_text_label();
+    out.jcc_label(Condition::Below, just_save);
+    out.call_label(relocate_finish);
+    out.leave();
+    out.ret();
+    out.bind_text_label(just_save);
+    out.load_rbp_slot(Reg::V0, 16);
+    out.mov_data_addr(Reg::V10, c.reloc_block);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.leave();
+    out.ret();
+}
+
 /// The evacuation bump cursor cells plus the relocated-object counter.
 #[derive(Clone, Copy)]
 pub struct EvacBumpCells<D: Copy> {

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -110,6 +110,7 @@ pub trait PortableAsm {
 
     fn add_reg_reg(&mut self, dst: Reg, src: Reg);
     fn sub_reg_reg(&mut self, dst: Reg, src: Reg);
+    fn or_reg_reg(&mut self, dst: Reg, src: Reg);
     fn cmp_reg_reg(&mut self, a: Reg, b: Reg);
     /// Compare `a & b` against zero, setting flags (x86-64 `test`).
     fn test_reg_reg(&mut self, a: Reg, b: Reg);
@@ -235,6 +236,9 @@ impl PortableAsm for crate::NativeCodeGenerator {
     }
     fn sub_reg_reg(&mut self, dst: Reg, src: Reg) {
         self.asm.sub_reg_reg(dst.into(), src.into());
+    }
+    fn or_reg_reg(&mut self, dst: Reg, src: Reg) {
+        self.asm.or_reg_reg(dst.into(), src.into());
     }
     fn cmp_reg_reg(&mut self, a: Reg, b: Reg) {
         self.asm.cmp_reg_reg(a.into(), b.into());
@@ -605,6 +609,98 @@ pub fn emit_gc_free_ghost_regions<E: PortableAsm>(
     out.store_rbp_slot(8, Reg::V0);
     out.jmp_label(loop_l);
     out.bind_text_label(done_l);
+    out.leave();
+    out.ret();
+}
+
+/// Data-section labels the incremental-mark worklist routines address.
+#[derive(Clone, Copy)]
+pub struct MarkWorklist<D: Copy> {
+    pub header_mark: D,
+    pub worklist: D,
+    pub worklist_top: D,
+    pub stw_fallback_pending: D,
+}
+
+/// Portable version of `gc_mark_visit(addr)` (V7/rdi = addr): if `addr`
+/// points at an unmarked heap block, set its current-parity mark bit and
+/// push it onto the trace worklist; a no-op when null or already marked.
+/// Follows an M7 forwarding word first (a ghost redirects to its
+/// to-space copy). On worklist overflow the mark bit is already set (so
+/// the object is not lost, only its frontier entry), so it raises the
+/// STW-fallback flag for a from-scratch re-mark. Note the routine emits
+/// its fall-through `leave; ret` at the `bail` label, THEN the overflow
+/// handler after it -- the emission order is preserved exactly.
+pub fn emit_gc_mark_visit<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    w: MarkWorklist<E::DataLabel>,
+) {
+    use crate::gc_layout::{GC_FWD, GC_MARK_WORKLIST_LEN};
+
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V5); // rbp
+    out.mov_reg_reg(Reg::V5, Reg::V4); // rbp = rsp
+
+    let bail = out.create_text_label();
+    let overflow = out.create_text_label();
+
+    // Null check.
+    out.test_reg_reg(Reg::V7, Reg::V7);
+    out.jcc_label(Condition::Equal, bail);
+    // M7: follow forwarding first. If [rdi-16] is a forwarding word (FWD
+    // bit set), rdi points at a ghost -- redirect to the to-space copy so
+    // we mark (and later trace) the live object, not the ghost. ORing a
+    // mark into a ghost's forwarding word would corrupt the address.
+    // Inert while evac is off (FWD never set).
+    out.load_ptr_disp32(Reg::V0, Reg::V7, -16);
+    let not_fwd = out.create_text_label();
+    out.mov_reg_reg(Reg::V1, Reg::V0);
+    out.and_reg_imm32(Reg::V1, GC_FWD as i32);
+    out.test_reg_reg(Reg::V1, Reg::V1);
+    out.jcc_label(Condition::Equal, not_fwd);
+    out.and_reg_imm32(Reg::V0, -16); // new user ptr
+    out.mov_reg_reg(Reg::V7, Reg::V0);
+    out.load_ptr_disp32(Reg::V0, Reg::V7, -16); // to-space header
+    out.bind_text_label(not_fwd);
+    // Already marked this cycle? (current-parity mark bit set)
+    out.mov_data_addr(Reg::V10, w.header_mark);
+    out.load_ptr_disp32(Reg::V1, Reg::V10, 0);
+    out.test_reg_reg(Reg::V0, Reg::V1);
+    out.jcc_label(Condition::NotEqual, bail);
+    // Set the current mark bit.
+    out.or_reg_reg(Reg::V0, Reg::V1);
+    out.store_ptr_disp32(Reg::V7, -16, Reg::V0);
+    // Push onto worklist: worklist[top++] = rdi
+    out.mov_data_addr(Reg::V10, w.worklist_top);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.cmp_reg_imm32(Reg::V0, GC_MARK_WORKLIST_LEN as i32);
+    out.jcc_label(Condition::AboveOrEqual, overflow);
+    out.mov_data_addr(Reg::V8, w.worklist);
+    out.load_ptr_disp32(Reg::V8, Reg::V8, 0);
+    // r9 = base + rax*8
+    out.mov_reg_reg(Reg::V9, Reg::V0);
+    out.shl_reg_imm8(Reg::V9, 3);
+    out.add_reg_reg(Reg::V8, Reg::V9);
+    out.store_ptr_disp32(Reg::V8, 0, Reg::V7);
+    out.add_reg_imm32(Reg::V0, 1);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+
+    out.bind_text_label(bail);
+    out.leave();
+    out.ret();
+
+    out.bind_text_label(overflow);
+    // Worklist full. The object's mark bit is already set (above), so it
+    // is not lost -- only its frontier (children-to-scan) entry is
+    // dropped. Raise the STW-fallback flag: the incremental driver (or
+    // gc_stw_mark_complete) will re-mark from scratch, which recovers the
+    // dropped frontier. On the from-scratch STW path that re-mark checks
+    // this flag after draining and aborts if it is still set (genuine
+    // over-capacity).
+    out.mov_data_addr(Reg::V10, w.stw_fallback_pending);
+    out.mov_imm64(Reg::V0, 1);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
     out.leave();
     out.ret();
 }

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -1,0 +1,259 @@
+//! Portable codegen abstraction: a trait-based instruction-emission
+//! interface that migrated GC codegen functions are generic over,
+//! instead of being hardcoded to the concrete x86-64 `Assembler`. This
+//! is the first, incremental step toward making the hand-written ZGC
+//! collector architecture-independent so a future AArch64 backend can
+//! share the collector's design.
+//!
+//! Design (see `docs/superpowers/specs/2026-07-24-portable-codegen-ir-
+//! design.md` for the full rationale): a *trait*, not a virtual-register
+//! IR with a register allocator, and not a `Vec<Instruction>` value type
+//! lowered in a separate pass. The existing backend emits instructions
+//! as it walks the AST with every physical register manually assigned;
+//! migration is then "change which concrete type a function's emitter
+//! parameter is," not "restructure how compilation works" -- the
+//! lowest-risk path for a ~40k-line retrofit.
+//!
+//! This module starts intentionally incomplete: it covers exactly what
+//! the currently-migrated GC functions need, and grows one migration
+//! slice at a time. In particular the platform primitives (mmap /
+//! write / exit / clock) that some GC functions need -- which on this
+//! codebase must handle three emission models (Linux syscall, macOS
+//! syscall, Windows shim `call`) -- are deliberately NOT here yet; they
+//! arrive with the first GC function that needs them, on a context type
+//! that can carry `is_windows`/`platform` state the bare `Assembler`
+//! lacks.
+
+/// Portable general-purpose register slots. `V0..V11` match the x86-64
+/// backend's 12 freely-assignable registers (mapped 1:1 onto
+/// `Rax, Rcx, Rdx, Rbx, Rsp, Rbp, Rsi, Rdi, R8-R11` in declaration
+/// order). The three GC-reserved color registers are named by their
+/// semantic role rather than a neutral slot number: their meaning is
+/// constant across the whole collector, and a future backend maps them
+/// to any three of its own callee-saved registers -- the name survives
+/// the remap where a bare `V13` would not.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum Reg {
+    V0,
+    V1,
+    V2,
+    V3,
+    V4,
+    V5,
+    V6,
+    V7,
+    V8,
+    V9,
+    V10,
+    V11,
+    /// GC load-barrier strip mask (x86-64: r13).
+    ColorStrip,
+    /// GC current good color (x86-64: r14).
+    GoodColor,
+    /// GC bad-color test mask (x86-64: r15).
+    BadMask,
+}
+
+/// Semantic comparison outcomes for conditional jumps -- these describe
+/// *what was compared*, not any architecture's condition-code
+/// mnemonics, so they carry over unchanged from the x86-64 `Condition`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum Condition {
+    Equal,
+    NotEqual,
+    Below,
+    Above,
+    AboveOrEqual,
+    Less,
+    LessEqual,
+    Greater,
+    GreaterEqual,
+    NoOverflow,
+    /// Parity flag set (x86-64 NaN-aware `ucomisd` follow-ups).
+    Parity,
+}
+
+/// A portable instruction-emission interface. Covers exactly the
+/// operations the currently-migrated GC functions need; extended one
+/// migration slice at a time.
+pub trait PortableAsm {
+    /// Opaque handle to a not-yet-placed code-section label.
+    type TextLabel: Copy;
+    /// Opaque handle to a data-section label.
+    type DataLabel: Copy;
+
+    fn create_text_label(&mut self) -> Self::TextLabel;
+    fn bind_text_label(&mut self, label: Self::TextLabel);
+    fn jmp_label(&mut self, label: Self::TextLabel);
+    fn jcc_label(&mut self, cond: Condition, label: Self::TextLabel);
+    fn ret(&mut self);
+
+    fn mov_reg_reg(&mut self, dst: Reg, src: Reg);
+    fn mov_imm64(&mut self, dst: Reg, imm: u64);
+    fn mov_data_addr(&mut self, dst: Reg, label: Self::DataLabel);
+
+    /// `dst = [base + disp]` (64-bit load).
+    fn load_ptr_disp32(&mut self, dst: Reg, base: Reg, disp: i32);
+    /// `[base + disp] = src` (64-bit store).
+    fn store_ptr_disp32(&mut self, base: Reg, disp: i32, src: Reg);
+
+    fn add_reg_reg(&mut self, dst: Reg, src: Reg);
+    fn cmp_reg_reg(&mut self, a: Reg, b: Reg);
+    fn add_reg_imm32(&mut self, dst: Reg, imm: i32);
+    fn cmp_reg_imm32(&mut self, r: Reg, imm: i32);
+    fn shl_reg_imm8(&mut self, r: Reg, imm: u8);
+    fn shr_reg_imm8(&mut self, r: Reg, imm: u8);
+}
+
+impl From<Reg> for crate::Reg {
+    fn from(r: Reg) -> crate::Reg {
+        match r {
+            Reg::V0 => crate::Reg::Rax,
+            Reg::V1 => crate::Reg::Rcx,
+            Reg::V2 => crate::Reg::Rdx,
+            Reg::V3 => crate::Reg::Rbx,
+            Reg::V4 => crate::Reg::Rsp,
+            Reg::V5 => crate::Reg::Rbp,
+            Reg::V6 => crate::Reg::Rsi,
+            Reg::V7 => crate::Reg::Rdi,
+            Reg::V8 => crate::Reg::R8,
+            Reg::V9 => crate::Reg::R9,
+            Reg::V10 => crate::Reg::R10,
+            Reg::V11 => crate::Reg::R11,
+            Reg::ColorStrip => crate::Reg::R13,
+            Reg::GoodColor => crate::Reg::R14,
+            Reg::BadMask => crate::Reg::R15,
+        }
+    }
+}
+
+impl From<Condition> for crate::Condition {
+    fn from(c: Condition) -> crate::Condition {
+        match c {
+            Condition::Equal => crate::Condition::Equal,
+            Condition::NotEqual => crate::Condition::NotEqual,
+            Condition::Below => crate::Condition::Below,
+            Condition::Above => crate::Condition::Above,
+            Condition::AboveOrEqual => crate::Condition::AboveOrEqual,
+            Condition::Less => crate::Condition::Less,
+            Condition::LessEqual => crate::Condition::LessEqual,
+            Condition::Greater => crate::Condition::Greater,
+            Condition::GreaterEqual => crate::Condition::GreaterEqual,
+            Condition::NoOverflow => crate::Condition::NoOverflow,
+            Condition::Parity => crate::Condition::Parity,
+        }
+    }
+}
+
+impl PortableAsm for crate::Assembler {
+    type TextLabel = crate::TextLabel;
+    type DataLabel = crate::DataLabel;
+
+    fn create_text_label(&mut self) -> Self::TextLabel {
+        crate::Assembler::create_text_label(self)
+    }
+    fn bind_text_label(&mut self, label: Self::TextLabel) {
+        crate::Assembler::bind_text_label(self, label);
+    }
+    fn jmp_label(&mut self, label: Self::TextLabel) {
+        crate::Assembler::jmp_label(self, label);
+    }
+    fn jcc_label(&mut self, cond: Condition, label: Self::TextLabel) {
+        crate::Assembler::jcc_label(self, cond.into(), label);
+    }
+    fn ret(&mut self) {
+        crate::Assembler::ret(self);
+    }
+    fn mov_reg_reg(&mut self, dst: Reg, src: Reg) {
+        crate::Assembler::mov_reg_reg(self, dst.into(), src.into());
+    }
+    fn mov_imm64(&mut self, dst: Reg, imm: u64) {
+        crate::Assembler::mov_imm64(self, dst.into(), imm);
+    }
+    fn mov_data_addr(&mut self, dst: Reg, label: Self::DataLabel) {
+        crate::Assembler::mov_data_addr(self, dst.into(), label);
+    }
+    fn load_ptr_disp32(&mut self, dst: Reg, base: Reg, disp: i32) {
+        crate::Assembler::load_ptr_disp32(self, dst.into(), base.into(), disp);
+    }
+    fn store_ptr_disp32(&mut self, base: Reg, disp: i32, src: Reg) {
+        crate::Assembler::store_ptr_disp32(self, base.into(), disp, src.into());
+    }
+    fn add_reg_reg(&mut self, dst: Reg, src: Reg) {
+        crate::Assembler::add_reg_reg(self, dst.into(), src.into());
+    }
+    fn cmp_reg_reg(&mut self, a: Reg, b: Reg) {
+        crate::Assembler::cmp_reg_reg(self, a.into(), b.into());
+    }
+    fn add_reg_imm32(&mut self, dst: Reg, imm: i32) {
+        crate::Assembler::add_reg_imm32(self, dst.into(), imm);
+    }
+    fn cmp_reg_imm32(&mut self, r: Reg, imm: i32) {
+        crate::Assembler::cmp_reg_imm32(self, r.into(), imm);
+    }
+    fn shl_reg_imm8(&mut self, r: Reg, imm: u8) {
+        crate::Assembler::shl_reg_imm8(self, r.into(), imm);
+    }
+    fn shr_reg_imm8(&mut self, r: Reg, imm: u8) {
+        crate::Assembler::shr_reg_imm8(self, r.into(), imm);
+    }
+}
+
+/// Portable version of `gc_grow_budget` (raises the soft region budget
+/// after an allocation stall). Entry: `V7` (rdi) = pending request's
+/// total bytes. Grows the budget to `max(2*budget, committed + N)`
+/// capped at `GC_RESERVE_REGIONS`, where `N = ceil(total / region)`.
+/// Returns `V0` (rax) = 1 if the budget could grow enough, 0 if even the
+/// whole reservation cannot hold the request. Leaf routine.
+pub fn emit_gc_grow_budget<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    committed_count: E::DataLabel,
+    budget_regions: E::DataLabel,
+) {
+    use crate::gc_layout::{GC_REGION_SHIFT, GC_REGION_SIZE, GC_RESERVE_REGIONS};
+
+    out.bind_text_label(entry);
+    let have = out.create_text_label();
+    let set = out.create_text_label();
+    let fail = out.create_text_label();
+
+    // rcx = N = ceil(total / REGION_SIZE).
+    out.mov_reg_reg(Reg::V1, Reg::V7);
+    out.add_reg_imm32(Reg::V1, (GC_REGION_SIZE - 1) as i32);
+    out.shr_reg_imm8(Reg::V1, GC_REGION_SHIFT);
+    // r8 = committed + N (the minimum budget the request needs).
+    out.mov_data_addr(Reg::V10, committed_count);
+    out.load_ptr_disp32(Reg::V8, Reg::V10, 0);
+    out.add_reg_reg(Reg::V8, Reg::V1);
+    // rax = budget * 2.
+    out.mov_data_addr(Reg::V10, budget_regions);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.shl_reg_imm8(Reg::V0, 1);
+    // rax = max(2*budget, committed+N).
+    out.cmp_reg_reg(Reg::V0, Reg::V8);
+    out.jcc_label(Condition::AboveOrEqual, have);
+    out.mov_reg_reg(Reg::V0, Reg::V8);
+    out.bind_text_label(have);
+    // Cap at GC_RESERVE_REGIONS (unsigned region counts).
+    let over_cap = out.create_text_label();
+    out.cmp_reg_imm32(Reg::V0, GC_RESERVE_REGIONS as i32);
+    out.jcc_label(Condition::Above, over_cap);
+    out.jmp_label(set); // rax <= reserve: use it as-is
+    out.bind_text_label(over_cap);
+    // Over the cap: the request fits only if committed+N <= reserve.
+    out.cmp_reg_imm32(Reg::V8, GC_RESERVE_REGIONS as i32);
+    out.jcc_label(Condition::Above, fail);
+    out.mov_imm64(Reg::V0, GC_RESERVE_REGIONS);
+    out.bind_text_label(set);
+    out.mov_data_addr(Reg::V10, budget_regions);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.mov_imm64(Reg::V0, 1);
+    out.ret();
+
+    out.bind_text_label(fail);
+    out.mov_imm64(Reg::V0, 0);
+    out.ret();
+}

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -95,6 +95,7 @@ pub trait PortableAsm {
     fn leave(&mut self);
 
     fn push_reg(&mut self, r: Reg);
+    fn pop_reg(&mut self, r: Reg);
     fn mov_reg_reg(&mut self, dst: Reg, src: Reg);
     fn mov_imm64(&mut self, dst: Reg, imm: u64);
     fn mov_data_addr(&mut self, dst: Reg, label: Self::DataLabel);
@@ -124,6 +125,10 @@ pub trait PortableAsm {
     fn cmp_reg_imm32(&mut self, r: Reg, imm: i32);
     fn shl_reg_imm8(&mut self, r: Reg, imm: u8);
     fn shr_reg_imm8(&mut self, r: Reg, imm: u8);
+    /// Bit-test: copy bit `bit` of `r` into the carry flag (x86-64 `bt`),
+    /// so a following Below/AboveOrEqual jump branches on it without a
+    /// scratch register.
+    fn bt_reg_imm8(&mut self, r: Reg, bit: u8);
 
     // Platform primitives. These are the genuinely platform-DEPENDENT
     // operations the collector needs -- the OS interface, not an
@@ -220,6 +225,9 @@ impl PortableAsm for crate::NativeCodeGenerator {
     fn push_reg(&mut self, r: Reg) {
         self.asm.push_reg(r.into());
     }
+    fn pop_reg(&mut self, r: Reg) {
+        self.asm.pop_reg(r.into());
+    }
     fn mov_reg_reg(&mut self, dst: Reg, src: Reg) {
         self.asm.mov_reg_reg(dst.into(), src.into());
     }
@@ -285,6 +293,9 @@ impl PortableAsm for crate::NativeCodeGenerator {
     }
     fn shr_reg_imm8(&mut self, r: Reg, imm: u8) {
         self.asm.shr_reg_imm8(r.into(), imm);
+    }
+    fn bt_reg_imm8(&mut self, r: Reg, bit: u8) {
+        self.asm.bt_reg_imm8(r.into(), bit);
     }
 
     fn plat_write_data(&mut self, fd: u64, data: Self::DataLabel, len: usize) {
@@ -865,6 +876,99 @@ pub fn emit_gc_sweep<E: PortableAsm>(
     out.mov_data_addr(Reg::V10, free_region_head);
     out.store_ptr_disp32(Reg::V10, 0, Reg::V9);
     out.leave();
+    out.ret();
+}
+
+/// Portable version of `gc_load_barrier_slow` (V0/rax = bad-colored heap
+/// pointer, V10/r10 = the field address it was loaded from; out: V0 = raw
+/// remapped pointer). Strips the color, follows an M7 forwarding word
+/// (via `bt` so no scratch register is needed), evacuates on demand
+/// during Relocate, self-heals the slot to the good-colored pointer, and
+/// marks the result during Mark. Preserves the caller-saved registers a
+/// pointer-typed barriered read must keep live across the evacuate/mark
+/// calls. Not a framed routine -- bind ... ret. Uses ColorStrip (R13) and
+/// GoodColor (R14).
+pub fn emit_gc_load_barrier_slow<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    phase: E::DataLabel,
+    region_base: E::DataLabel,
+    region_fromspace: E::DataLabel,
+    evacuate: E::TextLabel,
+    mark_visit: E::TextLabel,
+) {
+    use crate::gc_layout::{GC_PHASE_MARK, GC_PHASE_RELOCATE, GC_REGION_SHIFT};
+
+    out.bind_text_label(entry);
+    out.and_reg_reg(Reg::V0, Reg::ColorStrip); // strip -> raw P
+    let healed = out.create_text_label();
+    let not_fwd = out.create_text_label();
+    let done = out.create_text_label();
+    // Follow forwarding: if P's header is a forwarding word, P is a ghost
+    // -- redirect rax to the to-space copy. Inert while evac is off. Uses
+    // `bt` so the FWD test needs no scratch register -- the slow path must
+    // preserve every caller-saved register in the Idle path (its M5/M6
+    // clobber set was rax/r10/r11 only).
+    out.load_ptr_disp32(Reg::V11, Reg::V0, -16);
+    out.bt_reg_imm8(Reg::V11, 0); // CF = FWD bit
+    out.jcc_label(Condition::AboveOrEqual, not_fwd); // CF clear
+    out.and_reg_imm32(Reg::V11, -16); // to-space user ptr
+    out.mov_reg_reg(Reg::V0, Reg::V11);
+    out.jmp_label(healed);
+    out.bind_text_label(not_fwd);
+    // Relocate: evacuate-on-demand. r10 (the field address) must be
+    // preserved through the self-heal, so the phase is read via r11.
+    out.mov_data_addr(Reg::V11, phase);
+    out.load_ptr_disp32(Reg::V11, Reg::V11, 0);
+    out.cmp_reg_imm8(Reg::V11, GC_PHASE_RELOCATE as i8);
+    out.jcc_label(Condition::NotEqual, healed);
+    // idx = (P - region_base) >> SHIFT ; from-space?
+    out.mov_reg_reg(Reg::V1, Reg::V0);
+    out.mov_data_addr(Reg::V11, region_base);
+    out.load_ptr_disp32(Reg::V11, Reg::V11, 0);
+    out.sub_reg_reg(Reg::V1, Reg::V11);
+    out.shr_reg_imm8(Reg::V1, GC_REGION_SHIFT);
+    out.shl_reg_imm8(Reg::V1, 3);
+    out.mov_data_addr(Reg::V11, region_fromspace);
+    out.add_reg_reg(Reg::V11, Reg::V1);
+    out.load_ptr_disp32(Reg::V11, Reg::V11, 0);
+    out.test_reg_reg(Reg::V11, Reg::V11);
+    out.jcc_label(Condition::Equal, healed);
+    // Preserve across the evacuation call the registers the Idle/Mark slow
+    // path leaves untouched but gc_evacuate clobbers: r10 (field address),
+    // and rdx/rsi (a pointer-typed barriered read preserves them in every
+    // other phase). Four pushes keep rsp 16-aligned; r11 is a throwaway
+    // pad (recomputed at the self-heal).
+    out.push_reg(Reg::V10);
+    out.push_reg(Reg::V2);
+    out.push_reg(Reg::V6);
+    out.push_reg(Reg::V11);
+    out.mov_reg_reg(Reg::V7, Reg::V0);
+    out.call_label(evacuate); // rax = to-space
+    out.pop_reg(Reg::V11);
+    out.pop_reg(Reg::V6);
+    out.pop_reg(Reg::V2);
+    out.pop_reg(Reg::V10);
+    out.bind_text_label(healed);
+    // Self-heal: write the good-colored (remapped) pointer back to the
+    // slot. r10 = the field address, carried from the barrier fast path
+    // (and preserved across gc_evacuate above).
+    out.mov_reg_reg(Reg::V11, Reg::V0);
+    out.or_reg_reg(Reg::V11, Reg::GoodColor); // recolor to good
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V11); // self-heal
+    // During Mark, the mutator has just loaded a raw pointer into a
+    // register, so it must be marked to keep the strong tricolor invariant
+    // (load-barrier-driven incremental update). rax (the raw result) is
+    // preserved across the mark call.
+    out.mov_data_addr(Reg::V10, phase);
+    out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+    out.cmp_reg_imm8(Reg::V11, GC_PHASE_MARK as i8);
+    out.jcc_label(Condition::NotEqual, done);
+    out.push_reg(Reg::V0);
+    out.mov_reg_reg(Reg::V7, Reg::V0);
+    out.call_label(mark_visit);
+    out.pop_reg(Reg::V0);
+    out.bind_text_label(done);
     out.ret();
 }
 

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -129,6 +129,10 @@ pub trait PortableAsm {
     /// so a following Below/AboveOrEqual jump branches on it without a
     /// scratch register.
     fn bt_reg_imm8(&mut self, r: Reg, bit: u8);
+    /// Block copy of V1 (rcx) bytes from [V6/rsi] to [V7/rdi] (x86-64
+    /// `rep movsb`); clobbers V1/V6/V7. A byte memcpy primitive; a future
+    /// backend lowers it to its own copy loop/instruction.
+    fn rep_movsb(&mut self);
 
     // Platform primitives. These are the genuinely platform-DEPENDENT
     // operations the collector needs -- the OS interface, not an
@@ -296,6 +300,9 @@ impl PortableAsm for crate::NativeCodeGenerator {
     }
     fn bt_reg_imm8(&mut self, r: Reg, bit: u8) {
         self.asm.bt_reg_imm8(r.into(), bit);
+    }
+    fn rep_movsb(&mut self) {
+        self.asm.rep_movsb();
     }
 
     fn plat_write_data(&mut self, fd: u64, data: Self::DataLabel, len: usize) {
@@ -1528,6 +1535,113 @@ pub fn emit_gc_acquire_region<E: PortableAsm>(
 
     out.bind_text_label(fail);
     out.mov_imm64(Reg::V0, 0);
+    out.ret();
+}
+
+/// The evacuation bump cursor cells plus the relocated-object counter.
+#[derive(Clone, Copy)]
+pub struct EvacBumpCells<D: Copy> {
+    pub evac_top: D,
+    pub evac_end: D,
+    pub relocated_count: D,
+}
+
+/// Portable version of `gc_evacuate` (V7/rdi = user pointer -> V0/rax =
+/// to-space user pointer). Idempotent: follows an existing forwarding
+/// word. Otherwise copies the whole block into the evacuation bump
+/// (refilling the to-space region as needed, aborting on an oversized
+/// object that selection should have excluded), installs a forwarding
+/// word `new_user | FWD` in the old header, stashes the size in the old
+/// word1 for the relocate walk, and bumps the --gc-log relocated counter.
+/// Non-recursive (only copies). Frame: [rbp-8] = oldP, [rbp-16] = size.
+pub fn emit_gc_evacuate<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    c: EvacBumpCells<E::DataLabel>,
+    acquire_evac_region: E::TextLabel,
+    oversized_msg: E::DataLabel,
+    oversized_len: usize,
+    stderr_fd: u64,
+) {
+    use crate::gc_layout::{GC_FWD, GC_REGION_SIZE};
+
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V5); // rbp
+    out.mov_reg_reg(Reg::V5, Reg::V4); // rbp = rsp
+    out.sub_reg_imm8(Reg::V4, 16); // [rbp-8]=oldP, [rbp-16]=size
+    let copy = out.create_text_label();
+    let epilogue = out.create_text_label();
+    let retry = out.create_text_label();
+    let fits = out.create_text_label();
+    out.load_ptr_disp32(Reg::V0, Reg::V7, -16);
+    // Already forwarded? rax & FWD.
+    out.mov_reg_reg(Reg::V1, Reg::V0);
+    out.and_reg_imm32(Reg::V1, GC_FWD as i32);
+    out.test_reg_reg(Reg::V1, Reg::V1);
+    out.jcc_label(Condition::Equal, copy);
+    out.and_reg_imm32(Reg::V0, -16); // to-space user ptr
+    out.jmp_label(epilogue);
+    out.bind_text_label(copy);
+    out.store_rbp_slot(8, Reg::V7); // oldP
+    out.and_reg_imm32(Reg::V0, -16); // size S
+    out.store_rbp_slot(16, Reg::V0);
+    // An object that does not fit one to-space region can never be
+    // evacuated (the refill loop would spin forever). Selection guarantees
+    // this never happens; treat it as an invariant violation and abort.
+    let evac_size_ok = out.create_text_label();
+    let evac_oversized = out.create_text_label();
+    out.cmp_reg_imm32(Reg::V0, GC_REGION_SIZE as i32);
+    out.jcc_label(Condition::Above, evac_oversized);
+    out.jmp_label(evac_size_ok);
+    out.bind_text_label(evac_oversized);
+    out.plat_write_data(stderr_fd, oversized_msg, oversized_len);
+    out.plat_exit(1);
+    out.bind_text_label(evac_size_ok);
+    let need_refill = out.create_text_label();
+    out.bind_text_label(retry);
+    out.mov_data_addr(Reg::V10, c.evac_top);
+    out.load_ptr_disp32(Reg::V8, Reg::V10, 0); // dst = evac_top
+    out.load_rbp_slot(Reg::V2, 16); // S
+    out.mov_reg_reg(Reg::V9, Reg::V8);
+    out.add_reg_reg(Reg::V9, Reg::V2); // new_top = dst + S
+    out.mov_data_addr(Reg::V10, c.evac_end);
+    out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+    out.cmp_reg_reg(Reg::V9, Reg::V11);
+    out.jcc_label(Condition::Above, need_refill); // new_top > end
+    out.jmp_label(fits);
+    // Refill to-space (never fails: headroom invariant).
+    out.bind_text_label(need_refill);
+    out.load_rbp_slot(Reg::V7, 16); // size
+    out.call_label(acquire_evac_region);
+    out.jmp_label(retry);
+    out.bind_text_label(fits);
+    out.mov_data_addr(Reg::V10, c.evac_top);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V9); // bump
+    // memcpy S bytes: rsi = oldP-16, rdi = dst (r8), rcx = S.
+    out.load_rbp_slot(Reg::V6, 8);
+    out.sub_reg_imm8(Reg::V6, 16);
+    out.mov_reg_reg(Reg::V7, Reg::V8);
+    out.mov_reg_reg(Reg::V1, Reg::V2);
+    out.rep_movsb(); // clobbers rsi/rdi/rcx; r8 survives
+    // n_user = dst + 16.
+    out.mov_reg_reg(Reg::V0, Reg::V8);
+    out.add_reg_imm32(Reg::V0, 16);
+    // Install forwarding in the OLD header: [oldP-16] = n_user | FWD.
+    out.load_rbp_slot(Reg::V11, 8); // oldP
+    out.mov_reg_reg(Reg::V1, Reg::V0);
+    out.mov_imm64(Reg::V2, GC_FWD);
+    out.or_reg_reg(Reg::V1, Reg::V2);
+    out.store_ptr_disp32(Reg::V11, -16, Reg::V1);
+    // [oldP-8] = S (word1, size for the relocate walk).
+    out.load_rbp_slot(Reg::V1, 16);
+    out.store_ptr_disp32(Reg::V11, -8, Reg::V1);
+    // Count this evacuation (--gc-log). rax = n_user must survive.
+    out.mov_data_addr(Reg::V10, c.relocated_count);
+    out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+    out.add_reg_imm32(Reg::V11, 1);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V11);
+    out.bind_text_label(epilogue);
+    out.leave();
     out.ret();
 }
 

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -1621,6 +1621,228 @@ pub fn emit_gc_acquire_region<E: PortableAsm>(
     out.ret();
 }
 
+/// All the data cells `gc_relocate_start` reads/writes across its color
+/// setup, sparsest-first selection, and Relocate/Idle entry. Grouped into
+/// one parameter because the routine touches ~18 globals.
+#[derive(Clone, Copy)]
+pub struct RelocateStartCells<D: Copy> {
+    pub good_color: D,
+    pub bad_mask: D,
+    pub free_region_head: D,
+    pub budget_regions: D,
+    pub committed_count: D,
+    pub heap_base: D,
+    pub region_base: D,
+    pub region_top: D,
+    pub region_live: D,
+    pub region_fromspace: D,
+    pub evac_region_base: D,
+    pub evac_top: D,
+    pub evac_end: D,
+    pub reloc_scan_idx: D,
+    pub reloc_block: D,
+    pub bytes_since_quantum: D,
+    pub phase: D,
+    pub bytes_since_cycle: D,
+}
+
+/// Portable version of `gc_relocate_start` (fused into the MarkEnd pause).
+/// When evacuation is active, switch to the Idle/Relocate color config
+/// (good = R), compute the evacuation byte cap from the free-region count,
+/// select the sparsest non-current, non-large from-space regions within
+/// the headroom cap, fix up the roots to their to-space copies, reset the
+/// relocate cursor + quantum pacer, and enter the Relocate phase. If
+/// evacuation is compiled off (`evac_off`), or nothing worth evacuating is
+/// selected, close the cycle straight to Idle. `poison` forces
+/// `bad = COLOR_MASK` (the barrier-coverage canary). Both flags gate
+/// codegen and are passed in.
+pub fn emit_gc_relocate_start<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    c: RelocateStartCells<E::DataLabel>,
+    fix_roots: E::TextLabel,
+    evac_off: bool,
+    poison: bool,
+) {
+    use crate::gc_layout::{
+        GC_COLOR_M0, GC_COLOR_M1, GC_COLOR_MASK, GC_COLOR_R, GC_PHASE_IDLE, GC_PHASE_RELOCATE,
+        GC_REGION_SHIFT, GC_REGION_SIZE,
+    };
+
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V5); // rbp
+    out.mov_reg_reg(Reg::V5, Reg::V4); // rbp = rsp
+    let mark_only = out.create_text_label();
+    if !evac_off {
+        // slots: 8=idx, 16=committed, 24=cap_bytes, 32=selected_live,
+        // 40=cur_bump_idx.
+        out.sub_reg_imm8(Reg::V4, 48);
+        // Idle/Relocate color config: good = R, bad = M0|M1 (or COLOR_MASK
+        // under poison). Applies to both the Relocate entry and the
+        // mark-only fallback (both end at good = R).
+        out.mov_imm64(Reg::V0, GC_COLOR_R);
+        out.mov_data_addr(Reg::V10, c.good_color);
+        out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+        if poison {
+            out.mov_imm64(Reg::V0, GC_COLOR_MASK);
+        } else {
+            out.mov_imm64(Reg::V0, GC_COLOR_M0 | GC_COLOR_M1);
+        }
+        out.mov_data_addr(Reg::V10, c.bad_mask);
+        out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+        out.mov_data_addr(Reg::GoodColor, c.good_color);
+        out.load_ptr_disp32(Reg::GoodColor, Reg::GoodColor, 0);
+        out.mov_data_addr(Reg::BadMask, c.bad_mask);
+        out.load_ptr_disp32(Reg::BadMask, Reg::BadMask, 0);
+        // free_regions = (budget - committed) + free-pool count.
+        out.mov_imm64(Reg::V1, 0);
+        out.mov_data_addr(Reg::V10, c.free_region_head);
+        out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+        let fp_loop = out.create_text_label();
+        let fp_done = out.create_text_label();
+        out.bind_text_label(fp_loop);
+        out.test_reg_reg(Reg::V0, Reg::V0);
+        out.jcc_label(Condition::Equal, fp_done);
+        out.add_reg_imm32(Reg::V1, 1);
+        out.load_ptr_disp32(Reg::V0, Reg::V0, 0);
+        out.jmp_label(fp_loop);
+        out.bind_text_label(fp_done);
+        out.mov_data_addr(Reg::V10, c.budget_regions);
+        out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+        out.mov_data_addr(Reg::V10, c.committed_count);
+        out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+        out.sub_reg_reg(Reg::V0, Reg::V11);
+        out.add_reg_reg(Reg::V0, Reg::V1); // rax = free_regions
+        // cap_bytes = (free_regions >= 2) ? (free_regions-2)<<(SHIFT-1) : 0.
+        // Half the free bytes keeps the region count within free_regions-2
+        // even at ~50% packing, so acquire_evac_region never runs past the
+        // reservation.
+        let have_cap = out.create_text_label();
+        let store_cap = out.create_text_label();
+        out.cmp_reg_imm8(Reg::V0, 2);
+        out.jcc_label(Condition::AboveOrEqual, have_cap);
+        out.mov_imm64(Reg::V0, 0);
+        out.jmp_label(store_cap);
+        out.bind_text_label(have_cap);
+        out.sub_reg_imm8(Reg::V0, 2);
+        out.shl_reg_imm8(Reg::V0, GC_REGION_SHIFT - 1);
+        out.bind_text_label(store_cap);
+        out.store_rbp_slot(24, Reg::V0); // cap_bytes
+        // cur_bump_idx = (heap_base - region_base) >> SHIFT.
+        out.mov_data_addr(Reg::V10, c.heap_base);
+        out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+        out.mov_data_addr(Reg::V10, c.region_base);
+        out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+        out.sub_reg_reg(Reg::V0, Reg::V11);
+        out.shr_reg_imm8(Reg::V0, GC_REGION_SHIFT);
+        out.store_rbp_slot(40, Reg::V0);
+        out.mov_data_addr(Reg::V10, c.committed_count);
+        out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+        out.store_rbp_slot(16, Reg::V0); // committed bound
+        out.mov_imm64(Reg::V0, 0);
+        out.store_rbp_slot(8, Reg::V0); // idx
+        out.store_rbp_slot(32, Reg::V0); // selected_live
+        let sel_loop = out.create_text_label();
+        let sel_next = out.create_text_label();
+        let sel_done = out.create_text_label();
+        out.bind_text_label(sel_loop);
+        out.load_rbp_slot(Reg::V0, 8);
+        out.load_rbp_slot(Reg::V1, 16);
+        out.cmp_reg_reg(Reg::V0, Reg::V1);
+        out.jcc_label(Condition::AboveOrEqual, sel_done);
+        // skip the current bump region.
+        out.load_rbp_slot(Reg::V1, 40);
+        out.cmp_reg_reg(Reg::V0, Reg::V1);
+        out.jcc_label(Condition::Equal, sel_next);
+        // base = region_base + idx<<SHIFT ; top = region_top[idx].
+        out.mov_reg_reg(Reg::V1, Reg::V0);
+        out.shl_reg_imm8(Reg::V1, GC_REGION_SHIFT);
+        out.mov_data_addr(Reg::V10, c.region_base);
+        out.load_ptr_disp32(Reg::V10, Reg::V10, 0);
+        out.add_reg_reg(Reg::V1, Reg::V10); // base (rcx)
+        out.load_rbp_slot(Reg::V8, 8);
+        out.shl_reg_imm8(Reg::V8, 3);
+        out.mov_data_addr(Reg::V10, c.region_top);
+        out.add_reg_reg(Reg::V10, Reg::V8);
+        out.load_ptr_disp32(Reg::V8, Reg::V10, 0); // top (r8)
+        // empty (top == base)?
+        out.cmp_reg_reg(Reg::V8, Reg::V1);
+        out.jcc_label(Condition::Equal, sel_next);
+        // large (top - base > REGION_SIZE)?
+        out.sub_reg_reg(Reg::V8, Reg::V1); // used bytes
+        out.cmp_reg_imm32(Reg::V8, GC_REGION_SIZE as i32);
+        out.jcc_label(Condition::Above, sel_next);
+        // live = gc_region_live[idx].
+        out.load_rbp_slot(Reg::V8, 8);
+        out.shl_reg_imm8(Reg::V8, 3);
+        out.mov_data_addr(Reg::V10, c.region_live);
+        out.add_reg_reg(Reg::V10, Reg::V8);
+        out.load_ptr_disp32(Reg::V11, Reg::V10, 0); // live (r11)
+        // not sparse (live >= REGION_SIZE/2)?
+        out.cmp_reg_imm32(Reg::V11, (GC_REGION_SIZE / 2) as i32);
+        out.jcc_label(Condition::AboveOrEqual, sel_next);
+        // headroom (selected_live + live > cap)?
+        out.load_rbp_slot(Reg::V0, 32);
+        out.add_reg_reg(Reg::V0, Reg::V11);
+        out.load_rbp_slot(Reg::V1, 24);
+        out.cmp_reg_reg(Reg::V0, Reg::V1);
+        out.jcc_label(Condition::Above, sel_next);
+        // select: fromspace[idx] = 1 ; selected_live += live.
+        out.store_rbp_slot(32, Reg::V0); // selected_live += live
+        out.load_rbp_slot(Reg::V8, 8);
+        out.shl_reg_imm8(Reg::V8, 3);
+        out.mov_data_addr(Reg::V10, c.region_fromspace);
+        out.add_reg_reg(Reg::V10, Reg::V8);
+        out.mov_imm64(Reg::V0, 1);
+        out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+        out.bind_text_label(sel_next);
+        out.load_rbp_slot(Reg::V0, 8);
+        out.add_reg_imm32(Reg::V0, 1);
+        out.store_rbp_slot(8, Reg::V0);
+        out.jmp_label(sel_loop);
+        out.bind_text_label(sel_done);
+        // Nothing selected -> mark-only close.
+        out.load_rbp_slot(Reg::V0, 32);
+        out.test_reg_reg(Reg::V0, Reg::V0);
+        out.jcc_label(Condition::Equal, mark_only);
+        // Reset the evacuation bump so the first copy acquires a fresh
+        // to-space region (relocate_finish only clears evac_region_base).
+        out.mov_imm64(Reg::V0, 0);
+        out.mov_data_addr(Reg::V10, c.evac_region_base);
+        out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+        out.mov_data_addr(Reg::V10, c.evac_top);
+        out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+        out.mov_data_addr(Reg::V10, c.evac_end);
+        out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+        // Fix roots, reset the relocate cursor + quantum pacer, enter the
+        // Relocate phase.
+        out.call_label(fix_roots);
+        out.mov_imm64(Reg::V0, 0);
+        out.mov_data_addr(Reg::V10, c.reloc_scan_idx);
+        out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+        out.mov_data_addr(Reg::V10, c.reloc_block);
+        out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+        out.mov_data_addr(Reg::V10, c.bytes_since_quantum);
+        out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+        out.mov_data_addr(Reg::V10, c.phase);
+        out.mov_imm64(Reg::V0, GC_PHASE_RELOCATE);
+        out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+        out.leave();
+        out.ret();
+    }
+    // Mark-only close (evac off, or nothing selected): back to Idle, reset
+    // the proactive counter.
+    out.bind_text_label(mark_only);
+    out.mov_data_addr(Reg::V10, c.phase);
+    out.mov_imm64(Reg::V0, GC_PHASE_IDLE);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.mov_data_addr(Reg::V10, c.bytes_since_cycle);
+    out.mov_imm64(Reg::V0, 0);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.leave();
+    out.ret();
+}
+
 /// The resumable-cursor and mark cells the relocate quantum reads.
 #[derive(Clone, Copy)]
 pub struct RelocQuantumCells<D: Copy> {

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -105,6 +105,17 @@ pub trait PortableAsm {
     fn cmp_reg_imm32(&mut self, r: Reg, imm: i32);
     fn shl_reg_imm8(&mut self, r: Reg, imm: u8);
     fn shr_reg_imm8(&mut self, r: Reg, imm: u8);
+
+    // Platform primitives. These are the genuinely platform-DEPENDENT
+    // operations the collector needs -- the OS interface, not an
+    // instruction encoding. Each backend implements them however its
+    // platform requires (Linux/macOS `syscall`, a Windows shim `call`, a
+    // future ARM-Linux `svc`), so that per-OS emission stays inside the
+    // impl and never leaks into the portable GC code that calls them.
+    /// Write `len` bytes at data label `data` to file descriptor `fd`.
+    fn plat_write_data(&mut self, fd: u64, data: Self::DataLabel, len: usize);
+    /// Terminate the process with status `code` (does not return).
+    fn plat_exit(&mut self, code: u64);
 }
 
 impl From<Reg> for crate::Reg {
@@ -147,57 +158,73 @@ impl From<Condition> for crate::Condition {
     }
 }
 
-impl PortableAsm for crate::Assembler {
+// The x86-64 backend implements `PortableAsm` on `NativeCodeGenerator`
+// (not the bare `Assembler`) because the platform primitives need the
+// generator's `is_windows`/`platform`/`windows` state: `plat_write_data`
+// / `plat_exit` reuse the generator's existing, tested `emit_write_data`
+// / `emit_exit_code` helpers, which already choose a Linux/macOS syscall
+// vs a Windows shim `call`. The instruction methods are 1:1 thin
+// wrappers over the inherent `Assembler` methods, so a migrated GC
+// function emits byte-identical code. A future AArch64 backend would
+// impl this same trait on its own generator type.
+impl PortableAsm for crate::NativeCodeGenerator {
     type TextLabel = crate::TextLabel;
     type DataLabel = crate::DataLabel;
 
     fn create_text_label(&mut self) -> Self::TextLabel {
-        crate::Assembler::create_text_label(self)
+        self.asm.create_text_label()
     }
     fn bind_text_label(&mut self, label: Self::TextLabel) {
-        crate::Assembler::bind_text_label(self, label);
+        self.asm.bind_text_label(label);
     }
     fn jmp_label(&mut self, label: Self::TextLabel) {
-        crate::Assembler::jmp_label(self, label);
+        self.asm.jmp_label(label);
     }
     fn jcc_label(&mut self, cond: Condition, label: Self::TextLabel) {
-        crate::Assembler::jcc_label(self, cond.into(), label);
+        self.asm.jcc_label(cond.into(), label);
     }
     fn ret(&mut self) {
-        crate::Assembler::ret(self);
+        self.asm.ret();
     }
     fn mov_reg_reg(&mut self, dst: Reg, src: Reg) {
-        crate::Assembler::mov_reg_reg(self, dst.into(), src.into());
+        self.asm.mov_reg_reg(dst.into(), src.into());
     }
     fn mov_imm64(&mut self, dst: Reg, imm: u64) {
-        crate::Assembler::mov_imm64(self, dst.into(), imm);
+        self.asm.mov_imm64(dst.into(), imm);
     }
     fn mov_data_addr(&mut self, dst: Reg, label: Self::DataLabel) {
-        crate::Assembler::mov_data_addr(self, dst.into(), label);
+        self.asm.mov_data_addr(dst.into(), label);
     }
     fn load_ptr_disp32(&mut self, dst: Reg, base: Reg, disp: i32) {
-        crate::Assembler::load_ptr_disp32(self, dst.into(), base.into(), disp);
+        self.asm.load_ptr_disp32(dst.into(), base.into(), disp);
     }
     fn store_ptr_disp32(&mut self, base: Reg, disp: i32, src: Reg) {
-        crate::Assembler::store_ptr_disp32(self, base.into(), disp, src.into());
+        self.asm.store_ptr_disp32(base.into(), disp, src.into());
     }
     fn add_reg_reg(&mut self, dst: Reg, src: Reg) {
-        crate::Assembler::add_reg_reg(self, dst.into(), src.into());
+        self.asm.add_reg_reg(dst.into(), src.into());
     }
     fn cmp_reg_reg(&mut self, a: Reg, b: Reg) {
-        crate::Assembler::cmp_reg_reg(self, a.into(), b.into());
+        self.asm.cmp_reg_reg(a.into(), b.into());
     }
     fn add_reg_imm32(&mut self, dst: Reg, imm: i32) {
-        crate::Assembler::add_reg_imm32(self, dst.into(), imm);
+        self.asm.add_reg_imm32(dst.into(), imm);
     }
     fn cmp_reg_imm32(&mut self, r: Reg, imm: i32) {
-        crate::Assembler::cmp_reg_imm32(self, r.into(), imm);
+        self.asm.cmp_reg_imm32(r.into(), imm);
     }
     fn shl_reg_imm8(&mut self, r: Reg, imm: u8) {
-        crate::Assembler::shl_reg_imm8(self, r.into(), imm);
+        self.asm.shl_reg_imm8(r.into(), imm);
     }
     fn shr_reg_imm8(&mut self, r: Reg, imm: u8) {
-        crate::Assembler::shr_reg_imm8(self, r.into(), imm);
+        self.asm.shr_reg_imm8(r.into(), imm);
+    }
+
+    fn plat_write_data(&mut self, fd: u64, data: Self::DataLabel, len: usize) {
+        self.emit_write_data(fd, data, len);
+    }
+    fn plat_exit(&mut self, code: u64) {
+        self.emit_exit_code(code);
     }
 }
 
@@ -256,4 +283,22 @@ pub fn emit_gc_grow_budget<E: PortableAsm>(
     out.bind_text_label(fail);
     out.mov_imm64(Reg::V0, 0);
     out.ret();
+}
+
+/// Portable version of `gc_bounds_error`: a non-returning subroutine that
+/// prints a fixed diagnostic to stderr and exits with status 1. The list
+/// / string builtins jump here directly on a detected out-of-range index.
+/// This is the first migration to exercise the platform primitives
+/// (`plat_write_data` / `plat_exit`): the routine's control flow is
+/// architecture-independent, while each backend's impl chooses the actual
+/// OS interface (Linux/macOS `syscall` vs Windows shim `call`).
+pub fn emit_gc_bounds_error<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    text: E::DataLabel,
+    text_len: usize,
+) {
+    out.bind_text_label(entry);
+    out.plat_write_data(2, text, text_len);
+    out.plat_exit(1);
 }

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -979,6 +979,155 @@ pub fn emit_gc_load_barrier_slow<E: PortableAsm>(
     out.ret();
 }
 
+/// Portable version of `gc_deep_equal(V7/rdi = a, V6/rsi = b -> V0/rax =
+/// 1 if structurally equal, else 0)`. Follows an M7 forwarding word on
+/// each operand, checks the type tags match, then compares only the
+/// shared-prefix payload: raw-bytes qword by qword, pointer records/lists
+/// slot by slot by recursing (the list tag first checking the two leading
+/// lengths). Recursive -- calls itself via `entry`. Frame slots: 8 =
+/// cursor_a, 16 = end_a, 24 = cursor_b. Uses ColorStrip (R13).
+pub fn emit_gc_deep_equal<E: PortableAsm>(out: &mut E, entry: E::TextLabel) {
+    use crate::gc_layout::{
+        GC_FWD, GC_TYPE_POINTER_LIST, GC_TYPE_POINTER_RECORD, GC_TYPE_RAW_BYTES,
+    };
+
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V5); // rbp
+    out.mov_reg_reg(Reg::V5, Reg::V4); // rbp = rsp
+    // Locals: [rbp-8] = cursor_a, [rbp-16] = end_a, [rbp-24] = cursor_b.
+    out.sub_reg_imm8(Reg::V4, 32);
+
+    let equal = out.create_text_label();
+    let not_equal = out.create_text_label();
+    let done = out.create_text_label();
+    let raw_bytes = out.create_text_label();
+    let raw_loop = out.create_text_label();
+    let ptr_setup = out.create_text_label();
+    let slot_loop = out.create_text_label();
+    let raw_have_min = out.create_text_label();
+    let ptr_have_min = out.create_text_label();
+
+    // Identical pointers (including both null) are trivially equal.
+    out.cmp_reg_reg(Reg::V7, Reg::V6);
+    out.jcc_label(Condition::Equal, equal);
+    // A null on exactly one side has no header to dereference.
+    out.test_reg_reg(Reg::V7, Reg::V7);
+    out.jcc_label(Condition::Equal, not_equal);
+    out.test_reg_reg(Reg::V6, Reg::V6);
+    out.jcc_label(Condition::Equal, not_equal);
+    // M7: follow forwarding on each operand before dereferencing its
+    // header. Inert while evac is off. rax is scratch.
+    let deq_a_not_fwd = out.create_text_label();
+    out.load_ptr_disp32(Reg::V0, Reg::V7, -16);
+    out.and_reg_imm32(Reg::V0, GC_FWD as i32);
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    out.jcc_label(Condition::Equal, deq_a_not_fwd);
+    out.load_ptr_disp32(Reg::V0, Reg::V7, -16);
+    out.and_reg_imm32(Reg::V0, -16);
+    out.mov_reg_reg(Reg::V7, Reg::V0);
+    out.bind_text_label(deq_a_not_fwd);
+    let deq_b_not_fwd = out.create_text_label();
+    out.load_ptr_disp32(Reg::V0, Reg::V6, -16);
+    out.and_reg_imm32(Reg::V0, GC_FWD as i32);
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    out.jcc_label(Condition::Equal, deq_b_not_fwd);
+    out.load_ptr_disp32(Reg::V0, Reg::V6, -16);
+    out.and_reg_imm32(Reg::V0, -16);
+    out.mov_reg_reg(Reg::V6, Reg::V0);
+    out.bind_text_label(deq_b_not_fwd);
+    // Type tags must match: type_a = [rdi-8], type_b = [rsi-8].
+    out.load_ptr_disp32(Reg::V0, Reg::V7, -8);
+    out.load_ptr_disp32(Reg::V1, Reg::V6, -8);
+    out.cmp_reg_reg(Reg::V0, Reg::V1);
+    out.jcc_label(Condition::NotEqual, not_equal);
+    // payload_a = ([rdi-16] & -16) - 16 in r8, payload_b in r9.
+    out.load_ptr_disp32(Reg::V8, Reg::V7, -16);
+    out.load_ptr_disp32(Reg::V9, Reg::V6, -16);
+    out.and_reg_imm32(Reg::V8, -16);
+    out.and_reg_imm32(Reg::V9, -16);
+    out.sub_reg_imm8(Reg::V8, 16);
+    out.sub_reg_imm8(Reg::V9, 16);
+    // rax still holds the shared type tag.
+    out.cmp_reg_imm8(Reg::V0, GC_TYPE_RAW_BYTES as i8);
+    out.jcc_label(Condition::Equal, raw_bytes);
+    out.cmp_reg_imm8(Reg::V0, GC_TYPE_POINTER_RECORD as i8);
+    out.jcc_label(Condition::Below, not_equal);
+    // Pointer record / array / list: a packed run of heap-pointer slots,
+    // optionally led by an integer length for the list tag.
+    out.cmp_reg_imm8(Reg::V0, GC_TYPE_POINTER_LIST as i8);
+    out.jcc_label(Condition::NotEqual, ptr_setup);
+    // List: the two lengths must match, then skip past the length word.
+    out.load_ptr_disp32(Reg::V10, Reg::V7, 0);
+    out.load_ptr_disp32(Reg::V11, Reg::V6, 0);
+    out.cmp_reg_reg(Reg::V10, Reg::V11);
+    out.jcc_label(Condition::NotEqual, not_equal);
+    out.add_reg_imm32(Reg::V7, 8);
+    out.add_reg_imm32(Reg::V6, 8);
+    out.sub_reg_imm8(Reg::V8, 8);
+    out.sub_reg_imm8(Reg::V9, 8);
+    out.bind_text_label(ptr_setup);
+    // r8 = min(payload_a, payload_b): compare only the shared prefix.
+    out.cmp_reg_reg(Reg::V8, Reg::V9);
+    out.jcc_label(Condition::Below, ptr_have_min);
+    out.mov_reg_reg(Reg::V8, Reg::V9);
+    out.bind_text_label(ptr_have_min);
+    // cursor_a = rdi, end_a = rdi + min, cursor_b = rsi.
+    out.mov_reg_reg(Reg::V10, Reg::V7);
+    out.add_reg_reg(Reg::V10, Reg::V8);
+    out.store_rbp_slot(8, Reg::V7);
+    out.store_rbp_slot(16, Reg::V10);
+    out.store_rbp_slot(24, Reg::V6);
+    out.bind_text_label(slot_loop);
+    out.load_rbp_slot(Reg::V10, 8);
+    out.load_rbp_slot(Reg::V11, 16);
+    out.cmp_reg_reg(Reg::V10, Reg::V11);
+    out.jcc_label(Condition::AboveOrEqual, equal);
+    out.load_rbp_slot(Reg::V11, 24);
+    // rdi = a_slot = [cursor_a], rsi = b_slot = [cursor_b], recurse. Both
+    // slots hold colored pointers; strip before the recursive deep-equal
+    // dereferences them.
+    out.load_ptr_disp32(Reg::V7, Reg::V10, 0);
+    out.and_reg_reg(Reg::V7, Reg::ColorStrip);
+    out.load_ptr_disp32(Reg::V6, Reg::V11, 0);
+    out.and_reg_reg(Reg::V6, Reg::ColorStrip);
+    out.call_label(entry);
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    out.jcc_label(Condition::Equal, not_equal);
+    // Advance both cursors one slot and continue.
+    out.load_rbp_slot(Reg::V10, 8);
+    out.add_reg_imm32(Reg::V10, 8);
+    out.store_rbp_slot(8, Reg::V10);
+    out.load_rbp_slot(Reg::V10, 24);
+    out.add_reg_imm32(Reg::V10, 8);
+    out.store_rbp_slot(24, Reg::V10);
+    out.jmp_label(slot_loop);
+    // Raw bytes: compare the shared-prefix payload qword by qword.
+    out.bind_text_label(raw_bytes);
+    out.cmp_reg_reg(Reg::V8, Reg::V9);
+    out.jcc_label(Condition::Below, raw_have_min);
+    out.mov_reg_reg(Reg::V8, Reg::V9);
+    out.bind_text_label(raw_have_min);
+    out.bind_text_label(raw_loop);
+    out.test_reg_reg(Reg::V8, Reg::V8);
+    out.jcc_label(Condition::Equal, equal);
+    out.load_ptr_disp32(Reg::V10, Reg::V7, 0);
+    out.load_ptr_disp32(Reg::V11, Reg::V6, 0);
+    out.cmp_reg_reg(Reg::V10, Reg::V11);
+    out.jcc_label(Condition::NotEqual, not_equal);
+    out.add_reg_imm32(Reg::V7, 8);
+    out.add_reg_imm32(Reg::V6, 8);
+    out.sub_reg_imm8(Reg::V8, 8);
+    out.jmp_label(raw_loop);
+    out.bind_text_label(equal);
+    out.mov_imm64(Reg::V0, 1);
+    out.jmp_label(done);
+    out.bind_text_label(not_equal);
+    out.mov_imm64(Reg::V0, 0);
+    out.bind_text_label(done);
+    out.leave();
+    out.ret();
+}
+
 /// Portable version of `gc_mark_roots`: walk every shadow-stack root
 /// slot and, for each non-null pointer, call `gc_mark_visit` to mark it
 /// and push it onto the trace worklist. The sole root source for the

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -476,3 +476,56 @@ pub fn emit_gc_clear_all_marks<E: PortableAsm>(
     out.leave();
     out.ret();
 }
+
+/// Text labels for the subroutines `gc_stw_mark_complete` calls.
+#[derive(Clone, Copy)]
+pub struct StwMarkTargets<T: Copy> {
+    pub clear_all_marks: T,
+    pub mark_roots: T,
+    pub drain: T,
+}
+
+/// Portable version of `gc_stw_mark_complete`: the from-scratch STW
+/// re-mark used to recover from a worklist overflow. Clears the fallback
+/// flag, clears all marks, rescans roots, and drains to fixpoint; if the
+/// flag is set AGAIN the live frontier genuinely exceeds capacity, so it
+/// prints the overflow diagnostic and exits. The diagnostic uses the
+/// platform primitives (`plat_write_data` / `plat_exit`).
+pub fn emit_gc_stw_mark_complete<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    targets: StwMarkTargets<E::TextLabel>,
+    stw_fallback_pending: E::DataLabel,
+    mark_worklist_top: E::DataLabel,
+    worklist_overflow_text: E::DataLabel,
+    worklist_overflow_len: usize,
+) {
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V5); // rbp
+    out.mov_reg_reg(Reg::V5, Reg::V4); // rbp = rsp
+    // Clear the fallback flag: this from-scratch STW mark is the
+    // recovery. If the worklist overflows AGAIN during this drain, the
+    // live frontier genuinely exceeds capacity and we abort.
+    out.mov_data_addr(Reg::V10, stw_fallback_pending);
+    out.mov_imm64(Reg::V0, 0);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.call_label(targets.clear_all_marks);
+    // Reset the worklist top.
+    out.mov_data_addr(Reg::V10, mark_worklist_top);
+    out.mov_imm64(Reg::V0, 0);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.call_label(targets.mark_roots);
+    out.call_label(targets.drain);
+    // If the flag is set again, the worklist overflowed even on the
+    // from-scratch mark: genuine over-capacity, abort as before.
+    out.mov_data_addr(Reg::V10, stw_fallback_pending);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    let ok = out.create_text_label();
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    out.jcc_label(Condition::Equal, ok);
+    out.plat_write_data(2, worklist_overflow_text, worklist_overflow_len);
+    out.plat_exit(1);
+    out.bind_text_label(ok);
+    out.leave();
+    out.ret();
+}

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -1431,6 +1431,89 @@ pub fn emit_gc_relocate_finish<E: PortableAsm>(
     out.ret();
 }
 
+/// Portable version of `gc_alloc_large` (V7/rdi = total size, V6/rsi =
+/// type tag -> V0/rax = user pointer, or 0 on budget exhaustion). Commits
+/// a contiguous run of `N = ceil(total / REGION_SIZE)` tail regions, lays
+/// the object's header into the first, sets the first region's watermark
+/// to span the whole object, marks the member regions empty, and returns
+/// `base + 16`. Leaf (no frame). Reuses `RegionTables` for committed_count
+/// / region_base / region_top; budget_regions is the extra label.
+pub fn emit_gc_alloc_large<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    t: RegionTables<E::DataLabel>,
+    budget_regions: E::DataLabel,
+) {
+    use crate::gc_layout::{GC_REGION_SHIFT, GC_REGION_SIZE};
+
+    out.bind_text_label(entry);
+    let member_loop = out.create_text_label();
+    let member_done = out.create_text_label();
+    let fail = out.create_text_label();
+
+    // rcx = N = ceil(total / REGION_SIZE) = (total + REGION_SIZE-1) >> SHIFT
+    out.mov_reg_reg(Reg::V1, Reg::V7);
+    out.add_reg_imm32(Reg::V1, (GC_REGION_SIZE - 1) as i32);
+    out.shr_reg_imm8(Reg::V1, GC_REGION_SHIFT);
+    // r8 = committed, r9 = committed + N (new committed). Check budget.
+    out.mov_data_addr(Reg::V10, t.committed_count);
+    out.load_ptr_disp32(Reg::V8, Reg::V10, 0);
+    out.mov_reg_reg(Reg::V9, Reg::V8);
+    out.add_reg_reg(Reg::V9, Reg::V1);
+    out.mov_data_addr(Reg::V11, budget_regions);
+    out.load_ptr_disp32(Reg::V11, Reg::V11, 0);
+    out.cmp_reg_reg(Reg::V9, Reg::V11);
+    out.jcc_label(Condition::Above, fail);
+    // base_f = region_base + (committed << REGION_SHIFT).
+    out.mov_reg_reg(Reg::V0, Reg::V8);
+    out.shl_reg_imm8(Reg::V0, GC_REGION_SHIFT);
+    out.mov_data_addr(Reg::V10, t.region_base);
+    out.load_ptr_disp32(Reg::V10, Reg::V10, 0);
+    out.add_reg_reg(Reg::V0, Reg::V10); // rax = base_f
+    // committed_count = committed + N.
+    out.mov_data_addr(Reg::V10, t.committed_count);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V9);
+    // Header at base_f: [base_f] = total, [base_f+8] = tag.
+    out.store_ptr_disp32(Reg::V0, 0, Reg::V7);
+    out.store_ptr_disp32(Reg::V0, 8, Reg::V6);
+    // region_top[f] = base_f + total (spans the whole run's object).
+    out.mov_reg_reg(Reg::V11, Reg::V8);
+    out.shl_reg_imm8(Reg::V11, 3);
+    out.mov_data_addr(Reg::V10, t.region_top);
+    out.add_reg_reg(Reg::V10, Reg::V11);
+    out.mov_reg_reg(Reg::V11, Reg::V0);
+    out.add_reg_reg(Reg::V11, Reg::V7);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V11);
+    // Member regions f+1 .. f+N-1: region_top[m] = its base (empty).
+    // r8 = m index (start f+1), r9 = f+N bound.
+    out.add_reg_imm32(Reg::V8, 1);
+    out.bind_text_label(member_loop);
+    out.cmp_reg_reg(Reg::V8, Reg::V9);
+    out.jcc_label(Condition::AboveOrEqual, member_done);
+    // addr = region_base + (m << REGION_SHIFT).
+    out.mov_reg_reg(Reg::V11, Reg::V8);
+    out.shl_reg_imm8(Reg::V11, GC_REGION_SHIFT);
+    out.mov_data_addr(Reg::V10, t.region_base);
+    out.load_ptr_disp32(Reg::V10, Reg::V10, 0);
+    out.add_reg_reg(Reg::V11, Reg::V10); // r11 = member base
+    // region_top[m] = member base.
+    out.mov_reg_reg(Reg::V1, Reg::V8);
+    out.shl_reg_imm8(Reg::V1, 3);
+    out.mov_data_addr(Reg::V10, t.region_top);
+    out.add_reg_reg(Reg::V10, Reg::V1);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V11);
+    out.add_reg_imm32(Reg::V8, 1);
+    out.jmp_label(member_loop);
+    out.bind_text_label(member_done);
+    // return rax = base_f + 16.
+    out.add_reg_imm32(Reg::V0, 16);
+    out.ret();
+
+    out.bind_text_label(fail);
+    out.mov_imm64(Reg::V0, 0);
+    out.ret();
+}
+
 /// Portable version of `gc_acquire_region`: obtain a fresh mutator
 /// region -- first flushing the current region's watermark, then popping
 /// the free-region pool (zeroing the reused region so stale bytes never

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -111,6 +111,7 @@ pub trait PortableAsm {
     fn add_reg_reg(&mut self, dst: Reg, src: Reg);
     fn sub_reg_reg(&mut self, dst: Reg, src: Reg);
     fn or_reg_reg(&mut self, dst: Reg, src: Reg);
+    fn xor_reg_reg(&mut self, dst: Reg, src: Reg);
     fn cmp_reg_reg(&mut self, a: Reg, b: Reg);
     /// Compare `a & b` against zero, setting flags (x86-64 `test`).
     fn test_reg_reg(&mut self, a: Reg, b: Reg);
@@ -245,6 +246,9 @@ impl PortableAsm for crate::NativeCodeGenerator {
     }
     fn or_reg_reg(&mut self, dst: Reg, src: Reg) {
         self.asm.or_reg_reg(dst.into(), src.into());
+    }
+    fn xor_reg_reg(&mut self, dst: Reg, src: Reg) {
+        self.asm.xor_reg_reg(dst.into(), src.into());
     }
     fn cmp_reg_reg(&mut self, a: Reg, b: Reg) {
         self.asm.cmp_reg_reg(a.into(), b.into());
@@ -828,6 +832,127 @@ pub fn emit_gc_mark_end<E: PortableAsm>(
     // until the activation step it just returns to Idle and resets the
     // proactive-trigger counter.
     out.call_label(targets.relocate_start);
+    emit_gc_pause_end(out, timing, pause);
+    out.leave();
+    out.ret();
+}
+
+/// Data cells the MarkStart color/phase setup writes and reloads.
+#[derive(Clone, Copy)]
+pub struct MarkStartCells<D: Copy> {
+    pub header_mark: D,
+    pub good_color: D,
+    pub bad_mask: D,
+    pub mark_color: D,
+    pub worklist_top: D,
+    pub phase: D,
+}
+
+/// Host-config flags that select which MarkStart color scheme is emitted.
+/// Both are compile-time constants for a given build, so they pick a code
+/// path exactly as the original inline `if`s did.
+#[derive(Clone, Copy)]
+pub struct MarkColorMode {
+    /// M6 scheme (good flips M0<->M1 directly) instead of the R scheme.
+    pub evac_off: bool,
+    /// `--gc-poison`: force `bad = COLOR_MASK` so every non-good pointer
+    /// slow-paths (the barrier-coverage canary).
+    pub poison: bool,
+}
+
+/// Portable version of `gc_mark_start` (short STW pause): flip the header
+/// mark parity and the collector's color config to the new cycle, reload
+/// the reserved color-register caches (GoodColor / BadMask), reset the
+/// worklist, scan roots, and enter the Mark phase. O(roots).
+///
+/// `evac_off` selects the M6 scheme (good flips M0<->M1 directly) vs the
+/// R scheme (a persistent mark color toggles and good/bad derive from
+/// it). `poison` forces `bad = COLOR_MASK` so every non-good pointer
+/// slow-paths (the `--gc-poison` barrier-coverage canary). Both are host
+/// config, passed in as flags so the emitted code is chosen the same way
+/// the original inline `if` did.
+pub fn emit_gc_mark_start<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    timing: bool,
+    pause: PauseCells<E::DataLabel>,
+    cells: MarkStartCells<E::DataLabel>,
+    mark_roots: E::TextLabel,
+    mode: MarkColorMode,
+) {
+    use crate::gc_layout::{
+        GC_COLOR_M0, GC_COLOR_M1, GC_COLOR_MASK, GC_COLOR_R, GC_HMARK_BOTH, GC_PHASE_MARK,
+    };
+    let MarkColorMode { evac_off, poison } = mode;
+
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V5); // rbp
+    out.mov_reg_reg(Reg::V5, Reg::V4); // rbp = rsp
+    emit_gc_pause_start(out, timing, pause); // MarkStart is a short STW pause (O(roots)).
+    // M7: toggle the header mark parity (bits 1-2) so this cycle marks
+    // with the OTHER bit than the last cycle -- a live object surviving
+    // multiple cycles is thus re-marked each cycle, and the sweep clears
+    // the now-stale parity. Must precede gc_mark_roots (which sets the
+    // current mark bit on roots).
+    out.mov_data_addr(Reg::V10, cells.header_mark);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.mov_imm64(Reg::V11, GC_HMARK_BOTH);
+    out.xor_reg_reg(Reg::V0, Reg::V11);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    // Enter the Mark phase's color config. The mark color toggles M0<->M1
+    // each cycle. Good becomes the new mark color; bad catches the other
+    // two colors so any pointer NOT at the new mark color (an R-colored
+    // Idle pointer, or a stale old-mark-color pointer) slow-paths and is
+    // remapped + marked (incremental update).
+    if evac_off {
+        // M6 scheme: good flips M0<->M1 directly via gc_good_color.
+        out.mov_data_addr(Reg::V10, cells.good_color);
+        out.load_ptr_disp32(Reg::V0, Reg::V10, 0); // old good
+        if poison {
+            out.mov_imm64(Reg::V1, GC_COLOR_MASK);
+        } else {
+            out.mov_reg_reg(Reg::V1, Reg::V0);
+            out.mov_imm64(Reg::V11, GC_COLOR_R);
+            out.or_reg_reg(Reg::V1, Reg::V11); // old_good | R
+        }
+        out.mov_data_addr(Reg::V11, cells.bad_mask);
+        out.store_ptr_disp32(Reg::V11, 0, Reg::V1);
+        out.mov_imm64(Reg::V1, GC_COLOR_M0 | GC_COLOR_M1);
+        out.xor_reg_reg(Reg::V0, Reg::V1);
+        out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    } else {
+        // R scheme: toggle the persistent mark color, then good = mark
+        // color, bad = (M0|M1|R) ^ mark color.
+        out.mov_data_addr(Reg::V10, cells.mark_color);
+        out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+        out.mov_imm64(Reg::V1, GC_COLOR_M0 | GC_COLOR_M1);
+        out.xor_reg_reg(Reg::V0, Reg::V1); // new mark color
+        out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+        out.mov_data_addr(Reg::V10, cells.good_color);
+        out.store_ptr_disp32(Reg::V10, 0, Reg::V0); // good = mark color
+        if poison {
+            out.mov_imm64(Reg::V1, GC_COLOR_MASK);
+        } else {
+            out.mov_imm64(Reg::V1, GC_COLOR_M0 | GC_COLOR_M1 | GC_COLOR_R);
+            out.xor_reg_reg(Reg::V1, Reg::V0); // (M0|M1|R) ^ mark
+        }
+        out.mov_data_addr(Reg::V11, cells.bad_mask);
+        out.store_ptr_disp32(Reg::V11, 0, Reg::V1);
+    }
+    // Reload the caches from the cells.
+    out.mov_data_addr(Reg::GoodColor, cells.good_color);
+    out.load_ptr_disp32(Reg::GoodColor, Reg::GoodColor, 0);
+    out.mov_data_addr(Reg::BadMask, cells.bad_mask);
+    out.load_ptr_disp32(Reg::BadMask, Reg::BadMask, 0);
+    // Reset the worklist and scan roots into it (marked new-color).
+    out.mov_data_addr(Reg::V10, cells.worklist_top);
+    out.mov_imm64(Reg::V0, 0);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.call_label(mark_roots);
+    // Enter the Mark phase.
+    out.mov_data_addr(Reg::V10, cells.phase);
+    out.mov_imm64(Reg::V0, GC_PHASE_MARK);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
     emit_gc_pause_end(out, timing, pause);
     out.leave();
     out.ret();

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -886,6 +886,113 @@ pub fn emit_gc_relocate_finish<E: PortableAsm>(
     out.ret();
 }
 
+/// Portable version of `gc_acquire_region`: obtain a fresh mutator
+/// region -- first flushing the current region's watermark, then popping
+/// the free-region pool (zeroing the reused region so stale bytes never
+/// read as bogus pointers), else committing the next tail region if
+/// within budget. Installs the region into the bump globals and returns
+/// `V0` = 1 on success, 0 if the budget is exhausted. Leaf (no frame).
+/// Reuses `RegionTables` for heap_base / heap_top / region_base /
+/// region_top / committed_count; free_region_head / budget_regions /
+/// heap_end are the labels beyond that set.
+pub fn emit_gc_acquire_region<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    t: RegionTables<E::DataLabel>,
+    free_region_head: E::DataLabel,
+    budget_regions: E::DataLabel,
+    heap_end: E::DataLabel,
+) {
+    use crate::gc_layout::{GC_REGION_SHIFT, GC_REGION_SIZE};
+
+    out.bind_text_label(entry);
+    let from_tail = out.create_text_label();
+    let install = out.create_text_label();
+    let fail = out.create_text_label();
+
+    // region_top[cur] = gc_heap_top, where cur = (heap_base -
+    // region_base) >> REGION_SHIFT.
+    out.mov_data_addr(Reg::V10, t.heap_base);
+    out.load_ptr_disp32(Reg::V1, Reg::V10, 0);
+    out.mov_data_addr(Reg::V10, t.region_base);
+    out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+    out.sub_reg_reg(Reg::V1, Reg::V11);
+    out.shr_reg_imm8(Reg::V1, GC_REGION_SHIFT);
+    out.shl_reg_imm8(Reg::V1, 3);
+    out.mov_data_addr(Reg::V10, t.region_top);
+    out.add_reg_reg(Reg::V10, Reg::V1);
+    out.mov_data_addr(Reg::V8, t.heap_top);
+    out.load_ptr_disp32(Reg::V0, Reg::V8, 0);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+
+    // (1) Free-region pool: rax = free_region_head; if non-null pop it.
+    out.mov_data_addr(Reg::V10, free_region_head);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    out.jcc_label(Condition::Equal, from_tail);
+    // free_region_head = [rax] (link stored at the region base).
+    out.load_ptr_disp32(Reg::V1, Reg::V0, 0);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V1);
+    // Zero the reused region: unlike a fresh mmap'd tail region, a
+    // reclaimed region still holds its previous objects' bytes. The bump
+    // path does not clear an object's padding qwords (those within the
+    // 16-aligned block size that the constructor doesn't write), and the
+    // mark trace walks every payload qword of a pointer object -- so a
+    // stale non-null value there would be chased as a bogus pointer.
+    // Clearing the whole region once on reuse restores the "all bump
+    // memory reads as zero" invariant.
+    let zero_loop = out.create_text_label();
+    let zero_done = out.create_text_label();
+    out.mov_reg_reg(Reg::V8, Reg::V0); // cursor
+    out.mov_reg_reg(Reg::V11, Reg::V0);
+    out.add_reg_imm32(Reg::V11, GC_REGION_SIZE as i32); // end
+    out.mov_imm64(Reg::V9, 0);
+    out.bind_text_label(zero_loop);
+    out.cmp_reg_reg(Reg::V8, Reg::V11);
+    out.jcc_label(Condition::AboveOrEqual, zero_done);
+    out.store_ptr_disp32(Reg::V8, 0, Reg::V9);
+    out.add_reg_imm32(Reg::V8, 8);
+    out.jmp_label(zero_loop);
+    out.bind_text_label(zero_done);
+    out.jmp_label(install);
+
+    // (2) Commit the next tail region if within budget.
+    out.bind_text_label(from_tail);
+    out.mov_data_addr(Reg::V10, t.committed_count);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.mov_data_addr(Reg::V8, budget_regions);
+    out.load_ptr_disp32(Reg::V11, Reg::V8, 0);
+    out.cmp_reg_reg(Reg::V0, Reg::V11);
+    out.jcc_label(Condition::AboveOrEqual, fail);
+    // new_base = region_base + (committed << REGION_SHIFT).
+    out.mov_reg_reg(Reg::V1, Reg::V0);
+    out.shl_reg_imm8(Reg::V1, GC_REGION_SHIFT);
+    out.mov_data_addr(Reg::V8, t.region_base);
+    out.load_ptr_disp32(Reg::V8, Reg::V8, 0);
+    out.add_reg_reg(Reg::V8, Reg::V1);
+    // committed_count = committed + 1.
+    out.add_reg_imm32(Reg::V0, 1);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.mov_reg_reg(Reg::V0, Reg::V8);
+
+    // install: rax = new region base. Set the bump globals.
+    out.bind_text_label(install);
+    out.mov_data_addr(Reg::V10, t.heap_base);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.mov_data_addr(Reg::V10, t.heap_top);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.mov_reg_reg(Reg::V1, Reg::V0);
+    out.add_reg_imm32(Reg::V1, GC_REGION_SIZE as i32);
+    out.mov_data_addr(Reg::V10, heap_end);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V1);
+    out.mov_imm64(Reg::V0, 1);
+    out.ret();
+
+    out.bind_text_label(fail);
+    out.mov_imm64(Reg::V0, 0);
+    out.ret();
+}
+
 /// Portable version of `gc_relocate_fix_roots`: at RelocateStart, walk
 /// every shadow-stack root slot and, for each root pointing into a
 /// from-space region, redirect it to the object's to-space copy --

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -550,6 +550,55 @@ pub fn emit_gc_clear_all_marks<E: PortableAsm>(
     out.ret();
 }
 
+/// Portable version of `gc_mark_roots`: walk every shadow-stack root
+/// slot and, for each non-null pointer, call `gc_mark_visit` to mark it
+/// and push it onto the trace worklist. The sole root source for the
+/// mark. Uses two frame slots (`[rbp-8]` = cursor, `[rbp-16]` = end).
+pub fn emit_gc_mark_roots<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    shadow_stack: E::DataLabel,
+    shadow_stack_top: E::DataLabel,
+    mark_visit: E::TextLabel,
+) {
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V5); // rbp
+    out.mov_reg_reg(Reg::V5, Reg::V4); // rbp = rsp
+    out.sub_reg_imm8(Reg::V4, 16);
+    out.mov_data_addr(Reg::V10, shadow_stack);
+    out.load_ptr_disp32(Reg::V10, Reg::V10, 0);
+    out.store_rbp_slot(8, Reg::V10);
+    // end = base + top * 8
+    out.mov_data_addr(Reg::V8, shadow_stack_top);
+    out.load_ptr_disp32(Reg::V1, Reg::V8, 0);
+    out.shl_reg_imm8(Reg::V1, 3);
+    out.add_reg_reg(Reg::V10, Reg::V1);
+    out.store_rbp_slot(16, Reg::V10);
+
+    let shadow_loop = out.create_text_label();
+    let shadow_done = out.create_text_label();
+    let shadow_skip = out.create_text_label();
+    out.bind_text_label(shadow_loop);
+    out.load_rbp_slot(Reg::V10, 8);
+    out.load_rbp_slot(Reg::V11, 16);
+    out.cmp_reg_reg(Reg::V10, Reg::V11);
+    out.jcc_label(Condition::AboveOrEqual, shadow_done);
+    // entry = [r10] is the address of a slot; deref to read the pointer.
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.load_ptr_disp32(Reg::V7, Reg::V0, 0);
+    out.test_reg_reg(Reg::V7, Reg::V7);
+    out.jcc_label(Condition::Equal, shadow_skip);
+    out.call_label(mark_visit);
+    out.bind_text_label(shadow_skip);
+    out.load_rbp_slot(Reg::V10, 8);
+    out.add_reg_imm32(Reg::V10, 8);
+    out.store_rbp_slot(8, Reg::V10);
+    out.jmp_label(shadow_loop);
+    out.bind_text_label(shadow_done);
+    out.leave();
+    out.ret();
+}
+
 /// Text labels for the subroutines `gc_stw_mark_complete` calls.
 #[derive(Clone, Copy)]
 pub struct StwMarkTargets<T: Copy> {

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -117,7 +117,9 @@ pub trait PortableAsm {
     fn test_reg_reg(&mut self, a: Reg, b: Reg);
     fn add_reg_imm32(&mut self, dst: Reg, imm: i32);
     fn sub_reg_imm8(&mut self, r: Reg, imm: i8);
+    fn sub_reg_imm32(&mut self, r: Reg, imm: i32);
     fn and_reg_imm32(&mut self, r: Reg, imm: i32);
+    fn cmp_reg_imm8(&mut self, r: Reg, imm: i8);
     fn cmp_reg_imm32(&mut self, r: Reg, imm: i32);
     fn shl_reg_imm8(&mut self, r: Reg, imm: u8);
     fn shr_reg_imm8(&mut self, r: Reg, imm: u8);
@@ -262,8 +264,14 @@ impl PortableAsm for crate::NativeCodeGenerator {
     fn sub_reg_imm8(&mut self, r: Reg, imm: i8) {
         self.asm.sub_reg_imm8(r.into(), imm);
     }
+    fn sub_reg_imm32(&mut self, r: Reg, imm: i32) {
+        self.asm.sub_reg_imm32(r.into(), imm);
+    }
     fn and_reg_imm32(&mut self, r: Reg, imm: i32) {
         self.asm.and_reg_imm32(r.into(), imm);
+    }
+    fn cmp_reg_imm8(&mut self, r: Reg, imm: i8) {
+        self.asm.cmp_reg_imm8(r.into(), imm);
     }
     fn cmp_reg_imm32(&mut self, r: Reg, imm: i32) {
         self.asm.cmp_reg_imm32(r.into(), imm);
@@ -546,6 +554,191 @@ pub fn emit_gc_clear_all_marks<E: PortableAsm>(
     out.store_rbp_slot(8, Reg::V0);
     out.jmp_label(region_loop);
     out.bind_text_label(region_done);
+    out.leave();
+    out.ret();
+}
+
+/// Portable version of `gc_sweep`: the region-based sweep. Bumps the
+/// collection counter, flushes the current region's watermark, then walks
+/// every committed region clearing the current-parity mark on live blocks
+/// (rewriting each live header as `size | mark`), recording per-region
+/// live bytes for M7 sparsest-first selection, and reclaiming any
+/// wholly-dead region's run onto the free-region pool (never the current
+/// bump region, never a from-space ghost). Frame slots: 8 = mark bit, 16
+/// = per-region live bytes, 40 = region index, 48 = committed bound, 56 =
+/// region base. Reuses `RegionTables`; collect_counter / free_region_head
+/// / header_mark / region_live are the labels beyond that set.
+pub fn emit_gc_sweep<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    t: RegionTables<E::DataLabel>,
+    collect_counter: E::DataLabel,
+    free_region_head: E::DataLabel,
+    header_mark: E::DataLabel,
+    region_live: E::DataLabel,
+) {
+    use crate::gc_layout::{GC_REGION_SHIFT, GC_REGION_SIZE};
+
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V5); // rbp
+    out.mov_reg_reg(Reg::V5, Reg::V4); // rbp = rsp
+    out.sub_reg_imm8(Reg::V4, 64);
+    // One completed collection cycle per sweep: bump the counter here so
+    // both the synchronous and incremental paths count once.
+    out.mov_data_addr(Reg::V10, collect_counter);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.add_reg_imm32(Reg::V0, 1);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    // Flush the current region's watermark (the bump path only updates the
+    // global gc_heap_top) so its objects are covered.
+    out.mov_data_addr(Reg::V10, t.heap_base);
+    out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+    out.mov_data_addr(Reg::V10, t.region_base);
+    out.load_ptr_disp32(Reg::V10, Reg::V10, 0);
+    out.sub_reg_reg(Reg::V11, Reg::V10); // offset = heap_base - region_base
+    out.shr_reg_imm8(Reg::V11, GC_REGION_SHIFT); // cur region index
+    out.shl_reg_imm8(Reg::V11, 3); // * 8
+    out.mov_data_addr(Reg::V10, t.region_top);
+    out.add_reg_reg(Reg::V10, Reg::V11);
+    out.mov_data_addr(Reg::V8, t.heap_top);
+    out.load_ptr_disp32(Reg::V0, Reg::V8, 0);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0); // region_top[cur] = heap_top
+    // Cache committed bound (48), reset region index (40), seed the
+    // free-region accumulator (r9) with the EXISTING pool head, not zero,
+    // so already-free regions stay linked.
+    out.mov_data_addr(Reg::V10, t.committed_count);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.store_rbp_slot(48, Reg::V0);
+    out.mov_imm64(Reg::V0, 0);
+    out.store_rbp_slot(40, Reg::V0);
+    out.mov_data_addr(Reg::V10, free_region_head);
+    out.load_ptr_disp32(Reg::V9, Reg::V10, 0);
+    // Cache the current-parity header mark bit in slot 8.
+    out.mov_data_addr(Reg::V10, header_mark);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.store_rbp_slot(8, Reg::V0);
+
+    let region_loop = out.create_text_label();
+    let region_done = out.create_text_label();
+    let inner_loop = out.create_text_label();
+    let inner_done = out.create_text_label();
+    let block_dead = out.create_text_label();
+    let next_region = out.create_text_label();
+    let reclaim_step = out.create_text_label();
+
+    out.bind_text_label(region_loop);
+    out.load_rbp_slot(Reg::V0, 40);
+    out.load_rbp_slot(Reg::V1, 48);
+    out.cmp_reg_reg(Reg::V0, Reg::V1);
+    out.jcc_label(Condition::AboveOrEqual, region_done);
+
+    // rsi = region_base + (i << REGION_SHIFT); save it.
+    out.mov_reg_reg(Reg::V1, Reg::V0);
+    out.shl_reg_imm8(Reg::V1, GC_REGION_SHIFT);
+    out.mov_data_addr(Reg::V10, t.region_base);
+    out.load_ptr_disp32(Reg::V10, Reg::V10, 0);
+    out.add_reg_reg(Reg::V10, Reg::V1);
+    out.mov_reg_reg(Reg::V6, Reg::V10);
+    out.store_rbp_slot(56, Reg::V6);
+    // r8 = region_top[i]
+    out.mov_reg_reg(Reg::V1, Reg::V0);
+    out.shl_reg_imm8(Reg::V1, 3);
+    out.mov_data_addr(Reg::V10, t.region_top);
+    out.add_reg_reg(Reg::V10, Reg::V1);
+    out.load_ptr_disp32(Reg::V8, Reg::V10, 0);
+    // Empty region (top == base): skip; it is already free.
+    out.cmp_reg_reg(Reg::V8, Reg::V6);
+    out.jcc_label(Condition::Equal, next_region);
+    // M7: skip from-space (ghost) regions. Inert while evac is off.
+    out.load_rbp_slot(Reg::V0, 40);
+    out.shl_reg_imm8(Reg::V0, 3);
+    out.mov_data_addr(Reg::V10, t.region_fromspace);
+    out.add_reg_reg(Reg::V10, Reg::V0);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    out.jcc_label(Condition::NotEqual, next_region);
+
+    // Inner block walk: r11 = cursor, rdx = any_live flag, slot 16 =
+    // live-byte accumulator for this region.
+    out.mov_reg_reg(Reg::V11, Reg::V6);
+    out.xor_reg_reg(Reg::V2, Reg::V2);
+    out.mov_imm64(Reg::V0, 0);
+    out.store_rbp_slot(16, Reg::V0);
+    out.bind_text_label(inner_loop);
+    out.cmp_reg_reg(Reg::V11, Reg::V8);
+    out.jcc_label(Condition::AboveOrEqual, inner_done);
+    out.load_ptr_disp32(Reg::V0, Reg::V11, 0); // header word0
+    out.mov_reg_reg(Reg::V1, Reg::V0);
+    out.and_reg_imm32(Reg::V1, -16); // size (clears FWD + mark bits)
+    // Live iff the current-parity mark bit is set (slot 8).
+    out.load_rbp_slot(Reg::V7, 8);
+    out.test_reg_reg(Reg::V0, Reg::V7);
+    out.jcc_label(Condition::Equal, block_dead);
+    // Live: rewrite the header as size | current mark -- KEEPS the current
+    // mark (so the relocate walk can still read liveness after the sweep)
+    // and clears the stale (previous-cycle) mark and the FWD bit.
+    out.mov_reg_reg(Reg::V0, Reg::V1);
+    out.or_reg_reg(Reg::V0, Reg::V7);
+    out.store_ptr_disp32(Reg::V11, 0, Reg::V0);
+    out.mov_imm64(Reg::V2, 1);
+    out.load_rbp_slot(Reg::V0, 16);
+    out.add_reg_reg(Reg::V0, Reg::V1);
+    out.store_rbp_slot(16, Reg::V0);
+    out.add_reg_reg(Reg::V11, Reg::V1);
+    out.jmp_label(inner_loop);
+    out.bind_text_label(block_dead);
+    // Dead: skip; whole-region reclamation is decided after the walk.
+    out.add_reg_reg(Reg::V11, Reg::V1);
+    out.jmp_label(inner_loop);
+
+    out.bind_text_label(inner_done);
+    // Record this region's live bytes for M7 sparsest-first selection.
+    out.load_rbp_slot(Reg::V0, 40);
+    out.shl_reg_imm8(Reg::V0, 3);
+    out.mov_data_addr(Reg::V10, region_live);
+    out.add_reg_reg(Reg::V10, Reg::V0);
+    out.load_rbp_slot(Reg::V0, 16);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.test_reg_reg(Reg::V2, Reg::V2);
+    out.jcc_label(Condition::NotEqual, next_region); // any live: keep
+    out.load_rbp_slot(Reg::V6, 56);
+    // Never reclaim the current bump region.
+    out.mov_data_addr(Reg::V10, t.heap_base);
+    out.load_ptr_disp32(Reg::V10, Reg::V10, 0);
+    out.cmp_reg_reg(Reg::V6, Reg::V10);
+    out.jcc_label(Condition::Equal, next_region);
+    // Fully dead: reclaim the run. rax = first block size (== the object
+    // size; a large run spans multiple regions, a normal region is one).
+    out.load_ptr_disp32(Reg::V0, Reg::V6, 0);
+    out.and_reg_imm32(Reg::V0, -16); // size (clears FWD + marks)
+    out.mov_reg_reg(Reg::V7, Reg::V6); // rdi = m = run base
+    out.bind_text_label(reclaim_step);
+    // Link this region into the free pool and mark it empty.
+    out.store_ptr_disp32(Reg::V7, 0, Reg::V9);
+    out.mov_reg_reg(Reg::V9, Reg::V7);
+    out.mov_reg_reg(Reg::V1, Reg::V7);
+    out.mov_data_addr(Reg::V10, t.region_base);
+    out.load_ptr_disp32(Reg::V10, Reg::V10, 0);
+    out.sub_reg_reg(Reg::V1, Reg::V10);
+    out.shr_reg_imm8(Reg::V1, GC_REGION_SHIFT);
+    out.shl_reg_imm8(Reg::V1, 3);
+    out.mov_data_addr(Reg::V10, t.region_top);
+    out.add_reg_reg(Reg::V10, Reg::V1);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V7); // region_top[idx] = base
+    out.sub_reg_imm32(Reg::V0, GC_REGION_SIZE as i32);
+    out.add_reg_imm32(Reg::V7, GC_REGION_SIZE as i32);
+    out.cmp_reg_imm8(Reg::V0, 0);
+    out.jcc_label(Condition::Greater, reclaim_step);
+
+    out.bind_text_label(next_region);
+    out.load_rbp_slot(Reg::V0, 40);
+    out.add_reg_imm32(Reg::V0, 1);
+    out.store_rbp_slot(40, Reg::V0);
+    out.jmp_label(region_loop);
+
+    out.bind_text_label(region_done);
+    out.mov_data_addr(Reg::V10, free_region_head);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V9);
     out.leave();
     out.ret();
 }

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -103,12 +103,19 @@ pub trait PortableAsm {
     fn load_ptr_disp32(&mut self, dst: Reg, base: Reg, disp: i32);
     /// `[base + disp] = src` (64-bit store).
     fn store_ptr_disp32(&mut self, base: Reg, disp: i32, src: Reg);
+    /// `dst = [rbp - offset]` -- read a local frame slot.
+    fn load_rbp_slot(&mut self, dst: Reg, offset: i32);
+    /// `[rbp - offset] = src` -- write a local frame slot.
+    fn store_rbp_slot(&mut self, offset: i32, src: Reg);
 
     fn add_reg_reg(&mut self, dst: Reg, src: Reg);
+    fn sub_reg_reg(&mut self, dst: Reg, src: Reg);
     fn cmp_reg_reg(&mut self, a: Reg, b: Reg);
     /// Compare `a & b` against zero, setting flags (x86-64 `test`).
     fn test_reg_reg(&mut self, a: Reg, b: Reg);
     fn add_reg_imm32(&mut self, dst: Reg, imm: i32);
+    fn sub_reg_imm8(&mut self, r: Reg, imm: i8);
+    fn and_reg_imm32(&mut self, r: Reg, imm: i32);
     fn cmp_reg_imm32(&mut self, r: Reg, imm: i32);
     fn shl_reg_imm8(&mut self, r: Reg, imm: u8);
     fn shr_reg_imm8(&mut self, r: Reg, imm: u8);
@@ -217,8 +224,17 @@ impl PortableAsm for crate::NativeCodeGenerator {
     fn store_ptr_disp32(&mut self, base: Reg, disp: i32, src: Reg) {
         self.asm.store_ptr_disp32(base.into(), disp, src.into());
     }
+    fn load_rbp_slot(&mut self, dst: Reg, offset: i32) {
+        self.asm.load_rbp_slot(dst.into(), offset);
+    }
+    fn store_rbp_slot(&mut self, offset: i32, src: Reg) {
+        self.asm.store_rbp_slot(offset, src.into());
+    }
     fn add_reg_reg(&mut self, dst: Reg, src: Reg) {
         self.asm.add_reg_reg(dst.into(), src.into());
+    }
+    fn sub_reg_reg(&mut self, dst: Reg, src: Reg) {
+        self.asm.sub_reg_reg(dst.into(), src.into());
     }
     fn cmp_reg_reg(&mut self, a: Reg, b: Reg) {
         self.asm.cmp_reg_reg(a.into(), b.into());
@@ -228,6 +244,12 @@ impl PortableAsm for crate::NativeCodeGenerator {
     }
     fn add_reg_imm32(&mut self, dst: Reg, imm: i32) {
         self.asm.add_reg_imm32(dst.into(), imm);
+    }
+    fn sub_reg_imm8(&mut self, r: Reg, imm: i8) {
+        self.asm.sub_reg_imm8(r.into(), imm);
+    }
+    fn and_reg_imm32(&mut self, r: Reg, imm: i32) {
+        self.asm.and_reg_imm32(r.into(), imm);
     }
     fn cmp_reg_imm32(&mut self, r: Reg, imm: i32) {
         self.asm.cmp_reg_imm32(r.into(), imm);
@@ -346,6 +368,111 @@ pub fn emit_gc_drain<E: PortableAsm>(
     out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
     out.test_reg_reg(Reg::V0, Reg::V0);
     out.jcc_label(Condition::NotEqual, drain_loop);
+    out.leave();
+    out.ret();
+}
+
+/// Data-section labels the region-walking GC routines address. Grouped
+/// so a migrated routine takes one parameter instead of a long,
+/// easy-to-misorder list of individual `DataLabel`s.
+#[derive(Clone, Copy)]
+pub struct RegionTables<D: Copy> {
+    pub heap_base: D,
+    pub heap_top: D,
+    pub region_base: D,
+    pub region_top: D,
+    pub committed_count: D,
+    pub region_fromspace: D,
+}
+
+/// Portable version of `gc_clear_all_marks`: walk every committed region
+/// and clear both header mark bits on each live block (an `and -16`,
+/// which also leaves size intact since blocks are 16-aligned). Flushes
+/// the current region's watermark first, and skips from-space (ghost)
+/// regions so their forwarding words are preserved. Uses two frame slots
+/// (`[rbp-8]` = region index, `[rbp-16]` = committed bound).
+pub fn emit_gc_clear_all_marks<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    t: RegionTables<E::DataLabel>,
+) {
+    use crate::gc_layout::GC_REGION_SHIFT;
+
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V5); // rbp
+    out.mov_reg_reg(Reg::V5, Reg::V4); // rbp = rsp
+    out.sub_reg_imm8(Reg::V4, 16);
+    // Flush the current region's watermark so its blocks are covered.
+    out.mov_data_addr(Reg::V10, t.heap_base);
+    out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+    out.mov_data_addr(Reg::V10, t.region_base);
+    out.load_ptr_disp32(Reg::V10, Reg::V10, 0);
+    out.sub_reg_reg(Reg::V11, Reg::V10);
+    out.shr_reg_imm8(Reg::V11, GC_REGION_SHIFT);
+    out.shl_reg_imm8(Reg::V11, 3);
+    out.mov_data_addr(Reg::V10, t.region_top);
+    out.add_reg_reg(Reg::V10, Reg::V11);
+    out.mov_data_addr(Reg::V8, t.heap_top);
+    out.load_ptr_disp32(Reg::V0, Reg::V8, 0);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    // bound = committed_count; idx = 0.
+    out.mov_data_addr(Reg::V10, t.committed_count);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.store_rbp_slot(16, Reg::V0);
+    out.mov_imm64(Reg::V0, 0);
+    out.store_rbp_slot(8, Reg::V0);
+
+    let region_loop = out.create_text_label();
+    let region_done = out.create_text_label();
+    let block_loop = out.create_text_label();
+    let next_region = out.create_text_label();
+    out.bind_text_label(region_loop);
+    out.load_rbp_slot(Reg::V0, 8);
+    out.load_rbp_slot(Reg::V1, 16);
+    out.cmp_reg_reg(Reg::V0, Reg::V1);
+    out.jcc_label(Condition::AboveOrEqual, region_done);
+    // base (rsi) = region_base + idx<<SHIFT; top (r8) = region_top[idx].
+    out.mov_reg_reg(Reg::V1, Reg::V0);
+    out.shl_reg_imm8(Reg::V1, GC_REGION_SHIFT);
+    out.mov_data_addr(Reg::V10, t.region_base);
+    out.load_ptr_disp32(Reg::V10, Reg::V10, 0);
+    out.add_reg_reg(Reg::V10, Reg::V1);
+    out.mov_reg_reg(Reg::V6, Reg::V10);
+    out.mov_reg_reg(Reg::V1, Reg::V0);
+    out.shl_reg_imm8(Reg::V1, 3);
+    out.mov_data_addr(Reg::V10, t.region_top);
+    out.add_reg_reg(Reg::V10, Reg::V1);
+    out.load_ptr_disp32(Reg::V8, Reg::V10, 0);
+    out.cmp_reg_reg(Reg::V8, Reg::V6);
+    out.jcc_label(Condition::Equal, next_region);
+    // M7: skip from-space (ghost) regions (inert while evac is off).
+    // clear_all_marks can run during a degrade while previous-cycle
+    // ghosts still exist; their forwarding words must not be masked.
+    out.load_rbp_slot(Reg::V0, 8);
+    out.shl_reg_imm8(Reg::V0, 3);
+    out.mov_data_addr(Reg::V10, t.region_fromspace);
+    out.add_reg_reg(Reg::V10, Reg::V0);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    out.jcc_label(Condition::NotEqual, next_region);
+    // Walk blocks base..top, clearing both mark bits on each header
+    // word0 (`and -16` also clears FWD, which is always 0 here since
+    // no block is forwarded when the from-scratch mark runs).
+    out.mov_reg_reg(Reg::V11, Reg::V6);
+    out.bind_text_label(block_loop);
+    out.cmp_reg_reg(Reg::V11, Reg::V8);
+    out.jcc_label(Condition::AboveOrEqual, next_region);
+    out.load_ptr_disp32(Reg::V0, Reg::V11, 0);
+    out.and_reg_imm32(Reg::V0, -16); // size, marks cleared
+    out.store_ptr_disp32(Reg::V11, 0, Reg::V0);
+    out.add_reg_reg(Reg::V11, Reg::V0);
+    out.jmp_label(block_loop);
+    out.bind_text_label(next_region);
+    out.load_rbp_slot(Reg::V0, 8);
+    out.add_reg_imm32(Reg::V0, 1);
+    out.store_rbp_slot(8, Reg::V0);
+    out.jmp_label(region_loop);
+    out.bind_text_label(region_done);
     out.leave();
     out.ret();
 }

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -837,6 +837,55 @@ pub fn emit_gc_mark_end<E: PortableAsm>(
     out.ret();
 }
 
+/// Portable version of `gc_relocate_finish`: flush the final to-space
+/// region's watermark back into `region_top`, clear the evac cursor, then
+/// return the collector to Idle and reset the proactive-cycle byte
+/// counter. Reuses `RegionTables` for region_base / region_top; the four
+/// evac/phase labels beyond that set are passed individually.
+pub fn emit_gc_relocate_finish<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    t: RegionTables<E::DataLabel>,
+    evac_region_base: E::DataLabel,
+    evac_top: E::DataLabel,
+    phase: E::DataLabel,
+    bytes_since_cycle: E::DataLabel,
+) {
+    use crate::gc_layout::{GC_PHASE_IDLE, GC_REGION_SHIFT};
+
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V5); // rbp
+    out.mov_reg_reg(Reg::V5, Reg::V4); // rbp = rsp
+    // Flush the final to-space region's watermark.
+    out.mov_data_addr(Reg::V10, evac_region_base);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    let no_flush = out.create_text_label();
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    out.jcc_label(Condition::Equal, no_flush);
+    out.mov_data_addr(Reg::V10, t.region_base);
+    out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+    out.sub_reg_reg(Reg::V0, Reg::V11);
+    out.shr_reg_imm8(Reg::V0, GC_REGION_SHIFT);
+    out.shl_reg_imm8(Reg::V0, 3);
+    out.mov_data_addr(Reg::V10, t.region_top);
+    out.add_reg_reg(Reg::V10, Reg::V0);
+    out.mov_data_addr(Reg::V8, evac_top);
+    out.load_ptr_disp32(Reg::V2, Reg::V8, 0);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V2);
+    out.mov_imm64(Reg::V0, 0);
+    out.mov_data_addr(Reg::V10, evac_region_base);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.bind_text_label(no_flush);
+    out.mov_data_addr(Reg::V10, phase);
+    out.mov_imm64(Reg::V0, GC_PHASE_IDLE);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.mov_data_addr(Reg::V10, bytes_since_cycle);
+    out.mov_imm64(Reg::V0, 0);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.leave();
+    out.ret();
+}
+
 /// Data cells the MarkStart color/phase setup writes and reloads.
 #[derive(Clone, Copy)]
 pub struct MarkStartCells<D: Copy> {

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -1141,6 +1141,73 @@ pub fn emit_gc_mark_visit<E: PortableAsm>(
     out.ret();
 }
 
+/// Text labels for the subroutines the synchronous `gc_collect` entry
+/// dispatches to.
+#[derive(Clone, Copy)]
+pub struct CollectTargets<T: Copy> {
+    pub stw_mark_complete: T,
+    pub free_ghost_regions: T,
+    pub sweep: T,
+    pub relocate_quantum: T,
+    pub mark_end: T,
+}
+
+/// Portable version of `gc_collect`: the synchronous collection entry
+/// (do_collect / --gc-stress). If a Mark cycle is in progress finish it
+/// via mark_end (self-bracketing its pause); if Relocate is in progress
+/// drain it synchronously with unbounded quanta; otherwise run a full
+/// from-scratch STW mark + free-ghosts + sweep, bracketed as one pause.
+/// Exactly one sweep runs either way.
+pub fn emit_gc_collect<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    timing: bool,
+    pause: PauseCells<E::DataLabel>,
+    phase: E::DataLabel,
+    targets: CollectTargets<E::TextLabel>,
+) {
+    use crate::gc_layout::{GC_PHASE_MARK, GC_PHASE_RELOCATE};
+
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V5); // rbp
+    out.mov_reg_reg(Reg::V5, Reg::V4); // rbp = rsp
+    let collect_mark = out.create_text_label();
+    let collect_reloc = out.create_text_label();
+    let collect_done = out.create_text_label();
+    out.mov_data_addr(Reg::V10, phase);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.cmp_reg_imm8(Reg::V0, GC_PHASE_MARK as i8);
+    out.jcc_label(Condition::Equal, collect_mark);
+    out.cmp_reg_imm8(Reg::V0, GC_PHASE_RELOCATE as i8);
+    out.jcc_label(Condition::Equal, collect_reloc);
+    // Idle: a full from-scratch STW mark + sweep, bracketed as one pause.
+    // Free the previous cycle's ghosts first (no-op until evac runs).
+    emit_gc_pause_start(out, timing, pause);
+    out.call_label(targets.stw_mark_complete);
+    out.call_label(targets.free_ghost_regions);
+    out.call_label(targets.sweep);
+    emit_gc_pause_end(out, timing, pause);
+    out.jmp_label(collect_done);
+    // Relocate in progress: drain the remaining evacuation synchronously
+    // (unbounded quanta) until the phase returns to Idle. Unreachable
+    // until the activation step.
+    out.bind_text_label(collect_reloc);
+    let reloc_loop = out.create_text_label();
+    out.bind_text_label(reloc_loop);
+    out.mov_imm64(Reg::V7, i64::MAX as u64);
+    out.call_label(targets.relocate_quantum);
+    out.mov_data_addr(Reg::V10, phase);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.cmp_reg_imm8(Reg::V0, GC_PHASE_RELOCATE as i8);
+    out.jcc_label(Condition::Equal, reloc_loop);
+    out.jmp_label(collect_done);
+    out.bind_text_label(collect_mark);
+    out.call_label(targets.mark_end);
+    out.bind_text_label(collect_done);
+    out.leave();
+    out.ret();
+}
+
 /// Text labels for the subroutines `gc_mark_end` chains through to close
 /// a cycle.
 #[derive(Clone, Copy)]

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -886,6 +886,88 @@ pub fn emit_gc_relocate_finish<E: PortableAsm>(
     out.ret();
 }
 
+/// Portable version of `gc_relocate_fix_roots`: at RelocateStart, walk
+/// every shadow-stack root slot and, for each root pointing into a
+/// from-space region, redirect it to the object's to-space copy --
+/// following an existing forwarding word or evacuating on demand. Uses
+/// two frame slots (`[rbp-8]` = cursor, `[rbp-16]` = end). Needs no new
+/// trait methods.
+pub fn emit_gc_relocate_fix_roots<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    shadow_stack: E::DataLabel,
+    shadow_stack_top: E::DataLabel,
+    region_base: E::DataLabel,
+    region_fromspace: E::DataLabel,
+    evacuate: E::TextLabel,
+) {
+    use crate::gc_layout::{GC_FWD, GC_REGION_SHIFT};
+
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V5); // rbp
+    out.mov_reg_reg(Reg::V5, Reg::V4); // rbp = rsp
+    out.sub_reg_imm8(Reg::V4, 16); // [rbp-8]=cursor, [rbp-16]=end
+    out.mov_data_addr(Reg::V10, shadow_stack);
+    out.load_ptr_disp32(Reg::V10, Reg::V10, 0);
+    out.store_rbp_slot(8, Reg::V10);
+    out.mov_data_addr(Reg::V8, shadow_stack_top);
+    out.load_ptr_disp32(Reg::V1, Reg::V8, 0);
+    out.shl_reg_imm8(Reg::V1, 3);
+    out.add_reg_reg(Reg::V10, Reg::V1);
+    out.store_rbp_slot(16, Reg::V10);
+    let loop_l = out.create_text_label();
+    let done_l = out.create_text_label();
+    let next_l = out.create_text_label();
+    let do_evac = out.create_text_label();
+    let store_root = out.create_text_label();
+    out.bind_text_label(loop_l);
+    out.load_rbp_slot(Reg::V10, 8);
+    out.load_rbp_slot(Reg::V11, 16);
+    out.cmp_reg_reg(Reg::V10, Reg::V11);
+    out.jcc_label(Condition::AboveOrEqual, done_l);
+    // slotaddr = [cursor]; val = [slotaddr].
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.load_ptr_disp32(Reg::V7, Reg::V0, 0);
+    out.test_reg_reg(Reg::V7, Reg::V7);
+    out.jcc_label(Condition::Equal, next_l);
+    // idx = (val - region_base) >> SHIFT ; from-space?
+    out.mov_reg_reg(Reg::V1, Reg::V7);
+    out.mov_data_addr(Reg::V10, region_base);
+    out.load_ptr_disp32(Reg::V10, Reg::V10, 0);
+    out.sub_reg_reg(Reg::V1, Reg::V10);
+    out.shr_reg_imm8(Reg::V1, GC_REGION_SHIFT);
+    out.shl_reg_imm8(Reg::V1, 3);
+    out.mov_data_addr(Reg::V10, region_fromspace);
+    out.add_reg_reg(Reg::V10, Reg::V1);
+    out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+    out.test_reg_reg(Reg::V11, Reg::V11);
+    out.jcc_label(Condition::Equal, next_l);
+    // val in from-space: new = (word0 & FWD) ? word0 & -16 : evacuate(val)
+    out.load_ptr_disp32(Reg::V11, Reg::V7, -16);
+    out.mov_reg_reg(Reg::V1, Reg::V11);
+    out.and_reg_imm32(Reg::V1, GC_FWD as i32);
+    out.test_reg_reg(Reg::V1, Reg::V1);
+    out.jcc_label(Condition::Equal, do_evac);
+    out.and_reg_imm32(Reg::V11, -16);
+    out.mov_reg_reg(Reg::V0, Reg::V11); // new
+    out.jmp_label(store_root);
+    out.bind_text_label(do_evac);
+    out.call_label(evacuate); // rdi = val -> rax = to-space
+    out.bind_text_label(store_root);
+    // [slotaddr] = new. slotaddr was clobbered by the call; reload it.
+    out.load_rbp_slot(Reg::V10, 8);
+    out.load_ptr_disp32(Reg::V10, Reg::V10, 0); // slotaddr
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.bind_text_label(next_l);
+    out.load_rbp_slot(Reg::V10, 8);
+    out.add_reg_imm32(Reg::V10, 8);
+    out.store_rbp_slot(8, Reg::V10);
+    out.jmp_label(loop_l);
+    out.bind_text_label(done_l);
+    out.leave();
+    out.ret();
+}
+
 /// Data cells the MarkStart color/phase setup writes and reloads.
 #[derive(Clone, Copy)]
 pub struct MarkStartCells<D: Copy> {

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -110,6 +110,7 @@ pub trait PortableAsm {
 
     fn add_reg_reg(&mut self, dst: Reg, src: Reg);
     fn sub_reg_reg(&mut self, dst: Reg, src: Reg);
+    fn and_reg_reg(&mut self, dst: Reg, src: Reg);
     fn or_reg_reg(&mut self, dst: Reg, src: Reg);
     fn xor_reg_reg(&mut self, dst: Reg, src: Reg);
     fn cmp_reg_reg(&mut self, a: Reg, b: Reg);
@@ -245,6 +246,9 @@ impl PortableAsm for crate::NativeCodeGenerator {
     }
     fn sub_reg_reg(&mut self, dst: Reg, src: Reg) {
         self.asm.sub_reg_reg(dst.into(), src.into());
+    }
+    fn and_reg_reg(&mut self, dst: Reg, src: Reg) {
+        self.asm.and_reg_reg(dst.into(), src.into());
     }
     fn or_reg_reg(&mut self, dst: Reg, src: Reg) {
         self.asm.or_reg_reg(dst.into(), src.into());
@@ -554,6 +558,127 @@ pub fn emit_gc_clear_all_marks<E: PortableAsm>(
     out.store_rbp_slot(8, Reg::V0);
     out.jmp_label(region_loop);
     out.bind_text_label(region_done);
+    out.leave();
+    out.ret();
+}
+
+/// Portable version of `gc_trace` (V7/rdi = pop budget): drain the mark
+/// worklist up to the budget, walking each popped pointer object's
+/// payload -- stripping the color off each child slot, following an M7
+/// forwarding word, recoloring the slot to the good/to-space value, then
+/// marking the child (the strong tricolor closure). Handles the
+/// pointer-list tag's leading length qword. Frame slots: 8 = remaining
+/// budget, 24 = field cursor, 32 = field end. Uses the reserved
+/// ColorStrip (R13) and GoodColor (R14) registers.
+pub fn emit_gc_trace<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    mark_worklist_top: E::DataLabel,
+    mark_worklist: E::DataLabel,
+    mark_visit: E::TextLabel,
+) {
+    use crate::gc_layout::{GC_FWD, GC_TYPE_POINTER_LIST, GC_TYPE_POINTER_RECORD};
+
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V5); // rbp
+    out.mov_reg_reg(Reg::V5, Reg::V4); // rbp = rsp
+    out.sub_reg_imm8(Reg::V4, 32);
+    // rdi = pop budget for this quantum; [rbp-8] holds the remaining
+    // budget, [rbp-24] the field cursor, [rbp-32] the field end.
+    out.store_rbp_slot(8, Reg::V7);
+    let trace_loop = out.create_text_label();
+    let trace_done = out.create_text_label();
+    let trace_field_loop = out.create_text_label();
+    let trace_skip_field = out.create_text_label();
+    out.bind_text_label(trace_loop);
+    // Budget exhausted? (an incremental quantum stops here; gc_drain
+    // passes a large budget and loops until the worklist empties.)
+    out.load_rbp_slot(Reg::V0, 8);
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    out.jcc_label(Condition::Equal, trace_done);
+    out.mov_data_addr(Reg::V10, mark_worklist_top);
+    out.load_ptr_disp32(Reg::V1, Reg::V10, 0);
+    out.test_reg_reg(Reg::V1, Reg::V1);
+    out.jcc_label(Condition::Equal, trace_done);
+    // We have work: spend one budget unit (rax still holds it).
+    out.sub_reg_imm8(Reg::V0, 1);
+    out.store_rbp_slot(8, Reg::V0);
+    // top--, fetch worklist[top]
+    out.sub_reg_imm8(Reg::V1, 1);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V1);
+    out.mov_data_addr(Reg::V8, mark_worklist);
+    out.load_ptr_disp32(Reg::V8, Reg::V8, 0);
+    out.mov_reg_reg(Reg::V9, Reg::V1);
+    out.shl_reg_imm8(Reg::V9, 3);
+    out.add_reg_reg(Reg::V8, Reg::V9);
+    out.load_ptr_disp32(Reg::V0, Reg::V8, 0);
+    // type at [rax - 8]
+    out.load_ptr_disp32(Reg::V1, Reg::V0, -8);
+    // Save the type tag because the upcoming size load reuses rcx.
+    out.mov_reg_reg(Reg::V8, Reg::V1);
+    // Tags below GC_TYPE_POINTER_RECORD (free / raw bytes) carry no
+    // pointer fields; tags >= it are walked as a packed pointer array,
+    // optionally skipping a leading length qword for the list tag.
+    out.cmp_reg_imm8(Reg::V1, GC_TYPE_POINTER_RECORD as i8);
+    out.jcc_label(Condition::Below, trace_loop);
+    // Pointer record / array / list: payload_size = (size & -16) - 16.
+    out.load_ptr_disp32(Reg::V1, Reg::V0, -16);
+    out.and_reg_imm32(Reg::V1, -16);
+    out.sub_reg_imm8(Reg::V1, 16);
+    // GC_TYPE_POINTER_LIST stores an integer length at payload offset 0 --
+    // skip it so the mark phase does not chase the length as a pointer.
+    let after_list_skip = out.create_text_label();
+    out.cmp_reg_imm8(Reg::V8, GC_TYPE_POINTER_LIST as i8);
+    out.jcc_label(Condition::NotEqual, after_list_skip);
+    out.add_reg_imm32(Reg::V0, 8);
+    out.sub_reg_imm8(Reg::V1, 8);
+    out.bind_text_label(after_list_skip);
+    // trace_end = rax + payload_size; trace_cursor = rax
+    out.mov_reg_reg(Reg::V9, Reg::V0);
+    out.add_reg_reg(Reg::V9, Reg::V1);
+    out.store_rbp_slot(32, Reg::V9);
+    out.store_rbp_slot(24, Reg::V0);
+    out.bind_text_label(trace_field_loop);
+    out.load_rbp_slot(Reg::V10, 24);
+    out.load_rbp_slot(Reg::V11, 32);
+    out.cmp_reg_reg(Reg::V10, Reg::V11);
+    out.jcc_label(Condition::AboveOrEqual, trace_loop);
+    out.load_ptr_disp32(Reg::V7, Reg::V10, 0);
+    // Heap slots hold colored pointers; strip the color before
+    // gc_mark_visit dereferences the block header at [rdi-16].
+    out.and_reg_reg(Reg::V7, Reg::ColorStrip);
+    out.test_reg_reg(Reg::V7, Reg::V7);
+    out.jcc_label(Condition::Equal, trace_skip_field);
+    // M7: follow forwarding BEFORE recoloring/healing the slot. If the
+    // child was already evacuated, its header is a forwarding word; heal
+    // the slot to the TO-SPACE address, not a good-colored ghost pointer
+    // (a later fast-path load would deref it as a forwarding word ->
+    // use-after-free). Inert while evac is off. r11 is scratch here.
+    let trace_child_not_fwd = out.create_text_label();
+    out.load_ptr_disp32(Reg::V11, Reg::V7, -16);
+    out.and_reg_imm32(Reg::V11, GC_FWD as i32);
+    out.test_reg_reg(Reg::V11, Reg::V11);
+    out.jcc_label(Condition::Equal, trace_child_not_fwd);
+    out.load_ptr_disp32(Reg::V11, Reg::V7, -16);
+    out.and_reg_imm32(Reg::V11, -16); // to-space user ptr
+    out.mov_reg_reg(Reg::V7, Reg::V11);
+    out.bind_text_label(trace_child_not_fwd);
+    // Recolor-on-trace: write the good-colored (to-space) child back into
+    // this field slot (r10 = slot address) BEFORE marking, so a later
+    // barriered load of the same field takes the fast path instead of
+    // re-entering the slow path. Must precede the call, which clobbers
+    // r10; the cursor is reloaded afterward. Inert until the mark color
+    // flips (recoloring good->good is a no-op).
+    out.mov_reg_reg(Reg::V11, Reg::V7);
+    out.or_reg_reg(Reg::V11, Reg::GoodColor);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V11);
+    out.call_label(mark_visit);
+    out.bind_text_label(trace_skip_field);
+    out.load_rbp_slot(Reg::V10, 24);
+    out.add_reg_imm32(Reg::V10, 8);
+    out.store_rbp_slot(24, Reg::V10);
+    out.jmp_label(trace_field_loop);
+    out.bind_text_label(trace_done);
     out.leave();
     out.ret();
 }

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -282,43 +282,53 @@ impl PortableAsm for crate::NativeCodeGenerator {
     }
 }
 
+/// The three `--gc-log` STW-pause accumulator cells, grouped so pause
+/// timing threads through the collector as one parameter.
+#[derive(Clone, Copy)]
+pub struct PauseCells<D: Copy> {
+    /// Timestamp captured at pause entry.
+    pub start_ns: D,
+    /// Running sum of all pause durations.
+    pub total_ns: D,
+    /// Longest single pause seen.
+    pub max_ns: D,
+}
+
 /// Portable version of the `gc_pause_start` STW-pause helper: when
 /// `timing` is set (the `--gc-log` build on a platform whose clock the
-/// backend supports), capture the monotonic clock into `pause_start_ns`;
+/// backend supports), capture the monotonic clock into `cells.start_ns`;
 /// otherwise emit nothing. Inlined at the start of every STW pause.
 pub fn emit_gc_pause_start<E: PortableAsm>(
     out: &mut E,
     timing: bool,
-    pause_start_ns: E::DataLabel,
+    cells: PauseCells<E::DataLabel>,
 ) {
     if timing {
         out.plat_read_monotonic_ns();
-        out.mov_data_addr(Reg::V10, pause_start_ns);
+        out.mov_data_addr(Reg::V10, cells.start_ns);
         out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
     }
 }
 
 /// Portable version of the `gc_pause_end` STW-pause helper: when `timing`
-/// is set, fold the elapsed pause (`now - pause_start_ns`) into the total
+/// is set, fold the elapsed pause (`now - cells.start_ns`) into the total
 /// and max accumulators; otherwise emit nothing. Inlined at the end of
 /// every STW pause.
 pub fn emit_gc_pause_end<E: PortableAsm>(
     out: &mut E,
     timing: bool,
-    pause_start_ns: E::DataLabel,
-    pause_total_ns: E::DataLabel,
-    pause_max_ns: E::DataLabel,
+    cells: PauseCells<E::DataLabel>,
 ) {
     if timing {
         out.plat_read_monotonic_ns();
-        out.mov_data_addr(Reg::V10, pause_start_ns);
+        out.mov_data_addr(Reg::V10, cells.start_ns);
         out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
         out.sub_reg_reg(Reg::V0, Reg::V11); // rax = delta ns
-        out.mov_data_addr(Reg::V10, pause_total_ns);
+        out.mov_data_addr(Reg::V10, cells.total_ns);
         out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
         out.add_reg_reg(Reg::V11, Reg::V0);
         out.store_ptr_disp32(Reg::V10, 0, Reg::V11);
-        out.mov_data_addr(Reg::V10, pause_max_ns);
+        out.mov_data_addr(Reg::V10, cells.max_ns);
         out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
         out.cmp_reg_reg(Reg::V0, Reg::V11);
         let keep_max = out.create_text_label();
@@ -756,6 +766,69 @@ pub fn emit_gc_mark_visit<E: PortableAsm>(
     out.mov_data_addr(Reg::V10, w.stw_fallback_pending);
     out.mov_imm64(Reg::V0, 1);
     out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.leave();
+    out.ret();
+}
+
+/// Text labels for the subroutines `gc_mark_end` chains through to close
+/// a cycle.
+#[derive(Clone, Copy)]
+pub struct MarkEndTargets<T: Copy> {
+    pub drain: T,
+    pub stw_mark_complete: T,
+    pub free_ghost_regions: T,
+    pub sweep: T,
+    pub relocate_start: T,
+}
+
+/// Portable version of `gc_mark_end` (short STW pause): finish the cycle.
+/// If the worklist overflowed during the incremental quanta, degrade to a
+/// from-scratch STW re-mark; otherwise drain the remaining frontier to
+/// fixpoint (a straggler may have been added by the barrier), and if THAT
+/// overflows, degrade. Then free ghosts, sweep, and close via
+/// `relocate_start`. Wraps the body in the portable pause-timing helpers.
+pub fn emit_gc_mark_end<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    timing: bool,
+    pause: PauseCells<E::DataLabel>,
+    targets: MarkEndTargets<E::TextLabel>,
+    stw_fallback_pending: E::DataLabel,
+    stw_fallbacks: E::DataLabel,
+) {
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V5); // rbp
+    out.mov_reg_reg(Reg::V5, Reg::V4); // rbp = rsp
+    emit_gc_pause_start(out, timing, pause); // MarkEnd STW pause (final drain + sweep).
+    let do_degrade = out.create_text_label();
+    let after_mark = out.create_text_label();
+    out.mov_data_addr(Reg::V10, stw_fallback_pending);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    out.jcc_label(Condition::NotEqual, do_degrade);
+    out.call_label(targets.drain);
+    out.mov_data_addr(Reg::V10, stw_fallback_pending);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    out.jcc_label(Condition::Equal, after_mark);
+    out.bind_text_label(do_degrade);
+    out.mov_data_addr(Reg::V10, stw_fallbacks);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.add_reg_imm32(Reg::V0, 1);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.call_label(targets.stw_mark_complete);
+    out.bind_text_label(after_mark);
+    // Free the previous cycle's ghost (from-space) regions: the mark just
+    // reached fixpoint, so no live slot references them (soundness
+    // invariant III). A no-op until evacuation runs.
+    out.call_label(targets.free_ghost_regions);
+    out.call_label(targets.sweep);
+    // Close the cycle. gc_relocate_start selects from-space regions, fixes
+    // roots, and enters the Relocate phase when evacuation is active;
+    // until the activation step it just returns to Idle and resets the
+    // proactive-trigger counter.
+    out.call_label(targets.relocate_start);
+    emit_gc_pause_end(out, timing, pause);
     out.leave();
     out.ret();
 }

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -1531,6 +1531,125 @@ pub fn emit_gc_acquire_region<E: PortableAsm>(
     out.ret();
 }
 
+/// Data cells the evacuation-region acquire path reads and writes: the
+/// dedicated to-space bump (`evac_*`), the region arrays, and the free
+/// pool. Distinct from the mutator's `gc_heap_*` bump.
+#[derive(Clone, Copy)]
+pub struct EvacRegionCells<D: Copy> {
+    pub evac_region_base: D,
+    pub evac_top: D,
+    pub evac_end: D,
+    pub region_base: D,
+    pub region_top: D,
+    pub committed_count: D,
+    pub free_region_head: D,
+}
+
+/// Portable version of `gc_acquire_evac_region`: obtain a fresh to-space
+/// region into the dedicated evacuation bump (NOT the mutator's bump).
+/// Flushes the previous evac region's watermark, then pops the free pool
+/// (zeroing the reused region) or commits the next tail region -- aborting
+/// via the exhaustion diagnostic if that would pass the reservation (a
+/// safety net; the headroom cap makes it unreachable). Installs the evac
+/// bump globals and sets the new region's watermark to base. Leaf (no
+/// frame). `exhausted_msg` / `exhausted_len` / `stderr_fd` describe the
+/// abort diagnostic; the message label is built by the caller.
+pub fn emit_gc_acquire_evac_region<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    c: EvacRegionCells<E::DataLabel>,
+    exhausted_msg: E::DataLabel,
+    exhausted_len: usize,
+    stderr_fd: u64,
+) {
+    use crate::gc_layout::{GC_REGION_SHIFT, GC_REGION_SIZE, GC_RESERVE_REGIONS};
+
+    out.bind_text_label(entry);
+    let no_flush = out.create_text_label();
+    let from_tail = out.create_text_label();
+    let install = out.create_text_label();
+    // Flush the previous evac region's watermark, if any.
+    out.mov_data_addr(Reg::V10, c.evac_region_base);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    out.jcc_label(Condition::Equal, no_flush);
+    out.mov_data_addr(Reg::V10, c.region_base);
+    out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+    out.sub_reg_reg(Reg::V0, Reg::V11);
+    out.shr_reg_imm8(Reg::V0, GC_REGION_SHIFT);
+    out.shl_reg_imm8(Reg::V0, 3);
+    out.mov_data_addr(Reg::V10, c.region_top);
+    out.add_reg_reg(Reg::V10, Reg::V0);
+    out.mov_data_addr(Reg::V8, c.evac_top);
+    out.load_ptr_disp32(Reg::V2, Reg::V8, 0);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V2);
+    out.bind_text_label(no_flush);
+    // (1) Free-region pool.
+    out.mov_data_addr(Reg::V10, c.free_region_head);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    out.jcc_label(Condition::Equal, from_tail);
+    out.load_ptr_disp32(Reg::V1, Reg::V0, 0);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V1); // pop
+    // Zero the reused region.
+    let zero_loop = out.create_text_label();
+    let zero_done = out.create_text_label();
+    out.mov_reg_reg(Reg::V8, Reg::V0);
+    out.mov_reg_reg(Reg::V11, Reg::V0);
+    out.add_reg_imm32(Reg::V11, GC_REGION_SIZE as i32);
+    out.mov_imm64(Reg::V9, 0);
+    out.bind_text_label(zero_loop);
+    out.cmp_reg_reg(Reg::V8, Reg::V11);
+    out.jcc_label(Condition::AboveOrEqual, zero_done);
+    out.store_ptr_disp32(Reg::V8, 0, Reg::V9);
+    out.add_reg_imm32(Reg::V8, 8);
+    out.jmp_label(zero_loop);
+    out.bind_text_label(zero_done);
+    out.jmp_label(install);
+    // (2) Commit the next tail region. Hard safety net: never commit past
+    // the reservation. The headroom cap in gc_relocate_start makes this
+    // unreachable, but an out-of-bounds to-space write would be silent
+    // corruption, so abort cleanly if the accounting is ever wrong.
+    out.bind_text_label(from_tail);
+    out.mov_data_addr(Reg::V10, c.committed_count);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    let evac_ok = out.create_text_label();
+    out.cmp_reg_imm32(Reg::V0, GC_RESERVE_REGIONS as i32);
+    out.jcc_label(Condition::Below, evac_ok);
+    out.plat_write_data(stderr_fd, exhausted_msg, exhausted_len);
+    out.plat_exit(1);
+    out.bind_text_label(evac_ok);
+    out.mov_reg_reg(Reg::V1, Reg::V0);
+    out.shl_reg_imm8(Reg::V1, GC_REGION_SHIFT);
+    out.mov_data_addr(Reg::V8, c.region_base);
+    out.load_ptr_disp32(Reg::V8, Reg::V8, 0);
+    out.add_reg_reg(Reg::V8, Reg::V1);
+    out.add_reg_imm32(Reg::V0, 1);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.mov_reg_reg(Reg::V0, Reg::V8); // rax = new base
+    // install: set the evac bump globals (NOT the mutator's).
+    out.bind_text_label(install);
+    out.mov_data_addr(Reg::V10, c.evac_region_base);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.mov_data_addr(Reg::V10, c.evac_top);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.mov_reg_reg(Reg::V1, Reg::V0);
+    out.add_reg_imm32(Reg::V1, GC_REGION_SIZE as i32);
+    out.mov_data_addr(Reg::V10, c.evac_end);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V1);
+    // region_top[newidx] = base (empty until the watermark is flushed).
+    out.mov_reg_reg(Reg::V1, Reg::V0);
+    out.mov_data_addr(Reg::V10, c.region_base);
+    out.load_ptr_disp32(Reg::V10, Reg::V10, 0);
+    out.sub_reg_reg(Reg::V1, Reg::V10);
+    out.shr_reg_imm8(Reg::V1, GC_REGION_SHIFT);
+    out.shl_reg_imm8(Reg::V1, 3);
+    out.mov_data_addr(Reg::V10, c.region_top);
+    out.add_reg_reg(Reg::V10, Reg::V1);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.ret();
+}
+
 /// Portable version of `gc_relocate_fix_roots`: at RelocateStart, walk
 /// every shadow-stack root slot and, for each root pointing into a
 /// from-space region, redirect it to the object's to-space copy --

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -88,8 +88,13 @@ pub trait PortableAsm {
     fn bind_text_label(&mut self, label: Self::TextLabel);
     fn jmp_label(&mut self, label: Self::TextLabel);
     fn jcc_label(&mut self, cond: Condition, label: Self::TextLabel);
+    /// Direct call to a code-section label (pushes a return address).
+    fn call_label(&mut self, label: Self::TextLabel);
     fn ret(&mut self);
+    /// Standard frame teardown (`mov rsp, rbp; pop rbp` on x86-64).
+    fn leave(&mut self);
 
+    fn push_reg(&mut self, r: Reg);
     fn mov_reg_reg(&mut self, dst: Reg, src: Reg);
     fn mov_imm64(&mut self, dst: Reg, imm: u64);
     fn mov_data_addr(&mut self, dst: Reg, label: Self::DataLabel);
@@ -101,6 +106,8 @@ pub trait PortableAsm {
 
     fn add_reg_reg(&mut self, dst: Reg, src: Reg);
     fn cmp_reg_reg(&mut self, a: Reg, b: Reg);
+    /// Compare `a & b` against zero, setting flags (x86-64 `test`).
+    fn test_reg_reg(&mut self, a: Reg, b: Reg);
     fn add_reg_imm32(&mut self, dst: Reg, imm: i32);
     fn cmp_reg_imm32(&mut self, r: Reg, imm: i32);
     fn shl_reg_imm8(&mut self, r: Reg, imm: u8);
@@ -183,8 +190,17 @@ impl PortableAsm for crate::NativeCodeGenerator {
     fn jcc_label(&mut self, cond: Condition, label: Self::TextLabel) {
         self.asm.jcc_label(cond.into(), label);
     }
+    fn call_label(&mut self, label: Self::TextLabel) {
+        self.asm.call_label(label);
+    }
     fn ret(&mut self) {
         self.asm.ret();
+    }
+    fn leave(&mut self) {
+        self.asm.leave();
+    }
+    fn push_reg(&mut self, r: Reg) {
+        self.asm.push_reg(r.into());
     }
     fn mov_reg_reg(&mut self, dst: Reg, src: Reg) {
         self.asm.mov_reg_reg(dst.into(), src.into());
@@ -206,6 +222,9 @@ impl PortableAsm for crate::NativeCodeGenerator {
     }
     fn cmp_reg_reg(&mut self, a: Reg, b: Reg) {
         self.asm.cmp_reg_reg(a.into(), b.into());
+    }
+    fn test_reg_reg(&mut self, a: Reg, b: Reg) {
+        self.asm.test_reg_reg(a.into(), b.into());
     }
     fn add_reg_imm32(&mut self, dst: Reg, imm: i32) {
         self.asm.add_reg_imm32(dst.into(), imm);
@@ -301,4 +320,32 @@ pub fn emit_gc_bounds_error<E: PortableAsm>(
     out.bind_text_label(entry);
     out.plat_write_data(2, text, text_len);
     out.plat_exit(1);
+}
+
+/// Portable version of `gc_drain`: run mark quanta until the worklist is
+/// empty. Each iteration traces up to `GC_QUANTUM_POPS` objects via the
+/// `gc_trace` subroutine, then loops while `gc_mark_worklist_top != 0`.
+/// Sets up a frame (some callees expect an aligned stack) and tears it
+/// down with `leave`.
+pub fn emit_gc_drain<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    gc_trace: E::TextLabel,
+    mark_worklist_top: E::DataLabel,
+) {
+    use crate::gc_layout::GC_QUANTUM_POPS;
+
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V5); // rbp
+    out.mov_reg_reg(Reg::V5, Reg::V4); // rbp = rsp
+    let drain_loop = out.create_text_label();
+    out.bind_text_label(drain_loop);
+    out.mov_imm64(Reg::V7, GC_QUANTUM_POPS); // rdi = quantum
+    out.call_label(gc_trace);
+    out.mov_data_addr(Reg::V10, mark_worklist_top);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    out.jcc_label(Condition::NotEqual, drain_loop);
+    out.leave();
+    out.ret();
 }

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -1580,6 +1580,293 @@ pub fn emit_gc_relocate_finish<E: PortableAsm>(
     out.ret();
 }
 
+/// Data cells the mutator allocation entry reads/writes.
+#[derive(Clone, Copy)]
+pub struct AllocCells<D: Copy> {
+    pub phase: D,
+    pub bytes_since_cycle: D,
+    pub budget_regions: D,
+    pub bytes_since_quantum: D,
+    pub mark_worklist_top: D,
+    pub header_mark: D,
+    pub alloc_count: D,
+    pub bytes_allocated: D,
+    pub heap_top: D,
+    pub heap_end: D,
+    pub oom_text: D,
+}
+
+/// Text labels the mutator allocation entry dispatches to.
+#[derive(Clone, Copy)]
+pub struct AllocTargets<T: Copy> {
+    pub mark_start: T,
+    pub trace: T,
+    pub mark_end: T,
+    pub relocate_quantum: T,
+    pub collect: T,
+    pub grow_budget: T,
+    pub acquire_region: T,
+    pub alloc_large: T,
+}
+
+/// Host-config flags that gate mutator-allocation codegen.
+#[derive(Clone, Copy)]
+pub struct AllocFlags {
+    /// `--gc-stress`: collect before every allocation attempt.
+    pub stress: bool,
+    /// `--gc-log`: count allocations and bytes.
+    pub log: bool,
+}
+
+/// One allocation attempt: bump within the current region (acquiring a
+/// fresh one on the boundary), or the large-object run for requests
+/// bigger than one region. Jumps to `fail` when no region can satisfy the
+/// request and to `success` (V0 = user pointer) on success. Reads the
+/// aligned total from frame slot 16 and the type tag from slot 24 (set by
+/// the caller). Emitted inline three times by `emit_gc_alloc`.
+pub fn emit_gc_alloc_attempt<E: PortableAsm>(
+    out: &mut E,
+    fail: E::TextLabel,
+    success: E::TextLabel,
+    heap_top: E::DataLabel,
+    heap_end: E::DataLabel,
+    acquire_region: E::TextLabel,
+    alloc_large: E::TextLabel,
+) {
+    use crate::gc_layout::GC_REGION_SIZE;
+
+    let large = out.create_text_label();
+    let need_region = out.create_text_label();
+    let do_bump = out.create_text_label();
+
+    // total = [rbp - 16]; requests larger than a region go the large path.
+    out.load_rbp_slot(Reg::V7, 16);
+    out.mov_imm64(Reg::V1, GC_REGION_SIZE);
+    out.cmp_reg_reg(Reg::V7, Reg::V1);
+    out.jcc_label(Condition::Above, large);
+
+    // ---- Bump within the current region ----
+    out.bind_text_label(do_bump);
+    out.mov_data_addr(Reg::V10, heap_top);
+    out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+    out.load_rbp_slot(Reg::V7, 16);
+    out.mov_reg_reg(Reg::V1, Reg::V11);
+    out.add_reg_reg(Reg::V1, Reg::V7);
+    out.mov_data_addr(Reg::V8, heap_end);
+    out.load_ptr_disp32(Reg::V8, Reg::V8, 0);
+    out.cmp_reg_reg(Reg::V1, Reg::V8);
+    out.jcc_label(Condition::Above, need_region);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V1);
+    out.store_ptr_disp32(Reg::V11, 0, Reg::V7);
+    out.load_rbp_slot(Reg::V6, 24);
+    out.store_ptr_disp32(Reg::V11, 8, Reg::V6);
+    out.mov_reg_reg(Reg::V0, Reg::V11);
+    out.add_reg_imm32(Reg::V0, 16);
+    out.jmp_label(success);
+
+    // Current region is full: acquire a fresh empty one and retry the bump
+    // (guaranteed to fit, since total <= region size).
+    out.bind_text_label(need_region);
+    out.call_label(acquire_region);
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    out.jcc_label(Condition::Equal, fail);
+    out.jmp_label(do_bump);
+
+    // ---- Large object (> one region): contiguous region run. ----
+    out.bind_text_label(large);
+    out.load_rbp_slot(Reg::V7, 16);
+    out.load_rbp_slot(Reg::V6, 24);
+    out.call_label(alloc_large);
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    out.jcc_label(Condition::Equal, fail);
+    out.jmp_label(success);
+}
+
+/// Portable version of `gc_alloc` (V7/rdi = payload size, V6/rsi = type
+/// tag -> V0/rax = user pointer). The mutator's allocation entry: runs the
+/// incremental-mark driver (proactive cycle start / one mark or relocate
+/// quantum), optionally `--gc-stress`-collects, then attempts the bump,
+/// retrying after a collect and a budget grow before OOM. Sets the
+/// allocate-black mark during Mark and bumps the `--gc-log` counters.
+/// Frame: pushes rbx, slot 16 = aligned total, slot 24 = type tag.
+pub fn emit_gc_alloc<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    c: AllocCells<E::DataLabel>,
+    t: AllocTargets<E::TextLabel>,
+    flags: AllocFlags,
+    oom_len: usize,
+    stderr_fd: u64,
+) {
+    use crate::gc_layout::{
+        GC_PHASE_MARK, GC_PHASE_RELOCATE, GC_QUANTUM_BYTES, GC_QUANTUM_POPS, GC_REGION_SHIFT,
+    };
+
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V5); // rbp
+    out.mov_reg_reg(Reg::V5, Reg::V4); // rbp = rsp
+    out.push_reg(Reg::V3); // rbx
+    // Reserve two qwords for locals.
+    out.sub_reg_imm8(Reg::V4, 16);
+    // total = align_up(rdi + 16, 16)
+    out.add_reg_imm32(Reg::V7, 16 + 15);
+    out.and_reg_imm32(Reg::V7, -16);
+    out.store_rbp_slot(16, Reg::V7);
+    out.store_rbp_slot(24, Reg::V6);
+
+    let success = out.create_text_label();
+    let do_collect = out.create_text_label();
+    let do_grow = out.create_text_label();
+    let oom = out.create_text_label();
+    let after_collect = out.create_text_label();
+
+    // ---- M6 incremental-mark driver (before the attempt, so it observes
+    // only the mutator's already-rooted state). None of the routines here
+    // allocate, so gc_alloc is not re-entered.
+    let driver_mark = out.create_text_label();
+    let driver_reloc = out.create_text_label();
+    let driver_done = out.create_text_label();
+    out.mov_data_addr(Reg::V10, c.phase);
+    out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+    out.cmp_reg_imm8(Reg::V11, GC_PHASE_MARK as i8);
+    out.jcc_label(Condition::Equal, driver_mark);
+    out.cmp_reg_imm8(Reg::V11, GC_PHASE_RELOCATE as i8);
+    out.jcc_label(Condition::Equal, driver_reloc);
+    // Idle: accumulate allocation pressure and start a cycle proactively
+    // once it crosses half the soft budget.
+    out.mov_data_addr(Reg::V10, c.bytes_since_cycle);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.load_rbp_slot(Reg::V11, 16); // total block bytes
+    out.add_reg_reg(Reg::V0, Reg::V11);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    // threshold = budget_regions * REGION_SIZE / 2 = budget << (SHIFT-1).
+    out.mov_data_addr(Reg::V10, c.budget_regions);
+    out.load_ptr_disp32(Reg::V1, Reg::V10, 0);
+    out.shl_reg_imm8(Reg::V1, GC_REGION_SHIFT - 1);
+    out.cmp_reg_reg(Reg::V0, Reg::V1);
+    out.jcc_label(Condition::Below, driver_done);
+    out.call_label(t.mark_start);
+    out.jmp_label(driver_done);
+    // Mark: run one bounded quantum per GC_QUANTUM_BYTES allocated; when
+    // the worklist empties finish the cycle via MarkEnd.
+    out.bind_text_label(driver_mark);
+    out.mov_data_addr(Reg::V10, c.bytes_since_quantum);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.load_rbp_slot(Reg::V11, 16);
+    out.add_reg_reg(Reg::V0, Reg::V11);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.cmp_reg_imm32(Reg::V0, GC_QUANTUM_BYTES as i32);
+    out.jcc_label(Condition::Below, driver_done);
+    out.mov_imm64(Reg::V0, 0);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0); // reset counter
+    out.mov_imm64(Reg::V7, GC_QUANTUM_POPS);
+    out.call_label(t.trace);
+    out.mov_data_addr(Reg::V10, c.mark_worklist_top);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    out.jcc_label(Condition::NotEqual, driver_done);
+    out.call_label(t.mark_end);
+    out.jmp_label(driver_done);
+    // Relocate: run one bounded evacuation quantum per GC_QUANTUM_BYTES.
+    out.bind_text_label(driver_reloc);
+    out.mov_data_addr(Reg::V10, c.bytes_since_quantum);
+    out.load_ptr_disp32(Reg::V0, Reg::V10, 0);
+    out.load_rbp_slot(Reg::V11, 16);
+    out.add_reg_reg(Reg::V0, Reg::V11);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.cmp_reg_imm32(Reg::V0, GC_QUANTUM_BYTES as i32);
+    out.jcc_label(Condition::Below, driver_done);
+    out.mov_imm64(Reg::V0, 0);
+    out.store_ptr_disp32(Reg::V10, 0, Reg::V0);
+    out.mov_imm64(Reg::V7, GC_QUANTUM_BYTES);
+    out.call_label(t.relocate_quantum);
+    out.bind_text_label(driver_done);
+
+    // --gc-stress: collect before every allocation attempt.
+    if flags.stress {
+        out.call_label(t.collect);
+    }
+
+    emit_gc_alloc_attempt(
+        out,
+        do_collect,
+        success,
+        c.heap_top,
+        c.heap_end,
+        t.acquire_region,
+        t.alloc_large,
+    );
+    // First attempt failed; run collector then retry.
+    out.bind_text_label(do_collect);
+    out.call_label(t.collect);
+    out.bind_text_label(after_collect);
+    emit_gc_alloc_attempt(
+        out,
+        do_grow,
+        success,
+        c.heap_top,
+        c.heap_end,
+        t.acquire_region,
+        t.alloc_large,
+    );
+
+    // Collector freed no usable region -- raise the soft budget and retry
+    // once more. gc_grow_budget returns 1 on success, 0 when even the full
+    // reservation cannot hold the request.
+    out.bind_text_label(do_grow);
+    out.load_rbp_slot(Reg::V7, 16);
+    out.call_label(t.grow_budget);
+    out.test_reg_reg(Reg::V0, Reg::V0);
+    out.jcc_label(Condition::Equal, oom);
+    emit_gc_alloc_attempt(
+        out,
+        oom,
+        success,
+        c.heap_top,
+        c.heap_end,
+        t.acquire_region,
+        t.alloc_large,
+    );
+
+    out.bind_text_label(oom);
+    out.plat_write_data(stderr_fd, c.oom_text, oom_len);
+    out.plat_exit(1);
+
+    out.bind_text_label(success);
+    // Allocate-black: an object allocated during Mark is born live this
+    // cycle (its current-parity header mark bit is set). rax = user
+    // pointer must survive, so this uses r10/r11 only. Only during Mark.
+    let skip_black = out.create_text_label();
+    out.mov_data_addr(Reg::V10, c.phase);
+    out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+    out.cmp_reg_imm8(Reg::V11, GC_PHASE_MARK as i8);
+    out.jcc_label(Condition::NotEqual, skip_black);
+    out.load_ptr_disp32(Reg::V11, Reg::V0, -16);
+    out.mov_data_addr(Reg::V10, c.header_mark);
+    out.load_ptr_disp32(Reg::V10, Reg::V10, 0);
+    out.or_reg_reg(Reg::V11, Reg::V10);
+    out.store_ptr_disp32(Reg::V0, -16, Reg::V11);
+    out.bind_text_label(skip_black);
+    // --gc-log: count this allocation and its byte size. rax holds the
+    // user pointer and must survive, so the counter bumps use r10/r11/rbx.
+    if flags.log {
+        out.mov_data_addr(Reg::V10, c.alloc_count);
+        out.load_ptr_disp32(Reg::V11, Reg::V10, 0);
+        out.add_reg_imm32(Reg::V11, 1);
+        out.store_ptr_disp32(Reg::V10, 0, Reg::V11);
+        out.load_rbp_slot(Reg::V11, 16); // total block bytes
+        out.mov_data_addr(Reg::V10, c.bytes_allocated);
+        out.load_ptr_disp32(Reg::V3, Reg::V10, 0);
+        out.add_reg_reg(Reg::V3, Reg::V11);
+        out.store_ptr_disp32(Reg::V10, 0, Reg::V3);
+    }
+    // Tear down locals and return.
+    out.add_reg_imm32(Reg::V4, 16);
+    out.pop_reg(Reg::V3);
+    out.leave();
+    out.ret();
+}
+
 /// Portable version of `gc_alloc_large` (V7/rdi = total size, V6/rsi =
 /// type tag -> V0/rax = user pointer, or 0 on budget exhaustion). Commits
 /// a contiguous run of `N = ceil(total / REGION_SIZE)` tail regions, lays


### PR DESCRIPTION
## What & why

The hand-written ZGC collector in `crates/klassic-native/src/lib.rs` was x86-64-only machine code. This PR makes **every one of its 24 `emit_gc_*_runtime` routines architecture-independent** by routing them through a new `PortableAsm` trait, so a future direct AArch64 backend can reuse the entire collector design instead of reimplementing it. The "no toolchain" philosophy is preserved — this is not a move to an external assembler or LLVM.

## Approach

A **trait**, not a virtual-register IR: `crates/klassic-native/src/portable_asm.rs` defines `PortableAsm`, a thin instruction-emission interface. Each GC routine becomes a generic free function `fn emit_gc_X<E: PortableAsm>(out: &mut E, …)`. Physical registers stay manually assigned (via a semantic `Reg` enum: `V0..V11` plus `ColorStrip`/`GoodColor`/`BadMask` for the reserved color registers). The x86-64 impl of the trait is a 1:1 wrapper over the existing `Assembler`, so migrated code emits **byte-for-byte identical** machine code.

The genuinely platform-dependent operations — the OS interface, not instruction encodings — are isolated behind platform primitives (`plat_write_data`, `plat_exit`, `plat_read_monotonic_ns`, plus `rep_movsb`). The trait is implemented on `NativeCodeGenerator` (not the bare `Assembler`) so those primitives reuse the existing, tested `emit_write_data` / `emit_exit_code` / clock helpers that already choose a Linux/macOS syscall vs a Windows shim call. Architecture-independent GC design constants and the object-format ABI moved to `crates/klassic-native/src/gc_layout.rs`.

Host-config flags that gate codegen (`gc_log`/`is_windows` → pause timing, `gc_evac_off`, `gc_poison`, `gc_stress`) are computed in the thin lib.rs wrappers and passed to the portable functions as parameters, so the same code path is emitted that the original inline `if`s chose.

## Scope

All 24 GC runtime functions now delegate to `portable_asm::` (verified: none still emit `self.asm.*` inline):

- **Mark**: alloc-driver, mark_start, mark_end, mark_roots, mark_visit, trace, drain, sweep, clear_all_marks, stw_mark_complete, pause-timing helpers
- **Moving collector**: load_barrier_slow, evacuate, relocate_quantum, relocate_start, relocate_fix_roots, relocate_finish, free_ghost_regions, acquire_evac_region
- **Allocation**: alloc (+ its inline attempt helper), alloc_large, acquire_region, grow_budget, bounds_error, deep_equal

`lib.rs` shrinks by ~2.5k lines (bodies moved to `portable_asm.rs`); the default native build path is unchanged.

Also includes a `CLAUDE.md` refresh (LLVM backend, C GC, multi-target reality) that predated the work on this branch.

## Porting to AArch64 later

Implement `PortableAsm` on an AArch64 generator type and provide the four platform primitives as `svc`-based emission. The ~24 GC functions and all `gc_layout` constants are then reused unchanged.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test` — 718 passed, 0 failed (green after **every** one of the 27 commits)
- [x] **Byte-identical verification per commit**: a GC-exercising probe (`enum`+`match` recursion, list, string interpolation) compiled with the branch compiler vs a `main` worktree compiler, then `cmp`'d — across `{Linux ELF, Windows PE64}` × `{plain, --gc-log, --gc-poison, --gc-stress}`. `--gc-log` exercises the clock/timing emission, `--gc-poison` the color bad-mask branch, `--gc-stress` alloc's pre-attempt collect. Every combination IDENTICAL to main.

Because the emitted machine code is provably unchanged, this is a pure refactor with zero runtime behavior change on the x86-64 (ELF/PE) target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
