### PR TITLE
aarch64 GC port foundation: instruction primitives, __DATA segment, data labels, PortableAsm impl (M1-M4)

### DIFF
--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -3986,11 +3986,15 @@ pub(crate) fn emit_macho_program(
     }
 
     emitter.asm.finish();
+    // No writable data segment yet: the GC's __bss cells arrive with the
+    // data-label machinery (M3) and the GC runtime wiring (M5). Until
+    // then pass 0 so the image is byte-for-byte the pre-GC layout.
     Ok(macho::write_executable(
         emitter.asm.code,
         emitter.asm.rodata,
         &emitter.asm.fixups,
         "klassic",
+        0,
     ))
 }
 

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use klassic_span::{Diagnostic, Span};
 use klassic_syntax::{BinaryOp, Expr, StringPart};
 
-use crate::macho::{self, DataFixup};
+use crate::macho::{self, DataFixup, FixupSection};
 
 const SYS_EXIT: u16 = 1;
 const SYS_WRITE: u16 = 4;
@@ -172,6 +172,12 @@ impl Cond {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct Label(usize);
 
+/// Handle to a zero-initialized cell in the writable `__DATA,__bss`
+/// section; the value is the byte offset from the segment base. The
+/// AArch64 analog of the x86-64 backend's data label.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DataLabel(usize);
+
 enum BranchKind {
     /// `b label` — 26-bit signed word offset.
     Unconditional,
@@ -198,6 +204,9 @@ struct Assembler {
     fixups: Vec<DataFixup>,
     labels: Vec<Option<usize>>,
     branches: Vec<BranchFixup>,
+    /// Total bytes reserved in `__DATA,__bss` (the GC's zero-init cells).
+    /// Zero for pre-GC programs, so no writable segment is emitted.
+    bss_len: usize,
 }
 
 impl Assembler {
@@ -440,6 +449,39 @@ impl Assembler {
             adrp_offset,
             add_offset,
             data_offset,
+            section: FixupSection::Rodata,
+        });
+    }
+
+    /// Reserve `count` zero-initialized 8-byte cells in the writable
+    /// `__DATA,__bss` section and return a handle to the first. The GC's
+    /// mutable globals (heap pointers, phase, mark worklist, region
+    /// tables, counters, ...) live here — the AArch64 analog of the
+    /// x86-64 backend's `data_label_with_i64s(&[0; count])`. Inert until
+    /// the GC runtime wiring (M5) reserves and addresses cells.
+    #[allow(dead_code)]
+    fn reserve_data_cells(&mut self, count: usize) -> DataLabel {
+        let label = DataLabel(self.bss_len);
+        self.bss_len += count * 8;
+        label
+    }
+
+    /// `adrp xd, <page>` + `add xd, xd, #<pageoff>` addressing a cell in
+    /// `__DATA,__bss`; the immediates are zero placeholders patched by the
+    /// Mach-O writer against the segment vmaddr once the layout is final.
+    /// The GC port lowers `mov_data_addr` here.
+    #[allow(dead_code)]
+    fn load_data_address(&mut self, reg: Reg, label: DataLabel) {
+        let adrp_offset = self.code.len();
+        self.word(0x9000_0000 | reg as u32);
+        let add_offset = self.code.len();
+        let rn = reg as u32;
+        self.word(0x9100_0000 | (rn << 5) | rn);
+        self.fixups.push(DataFixup {
+            adrp_offset,
+            add_offset,
+            data_offset: label.0,
+            section: FixupSection::Data,
         });
     }
 
@@ -3986,15 +4028,17 @@ pub(crate) fn emit_macho_program(
     }
 
     emitter.asm.finish();
-    // No writable data segment yet: the GC's __bss cells arrive with the
-    // data-label machinery (M3) and the GC runtime wiring (M5). Until
-    // then pass 0 so the image is byte-for-byte the pre-GC layout.
+    // `bss_len` is 0 for every program today (no codegen reserves GC
+    // cells until M5), so no writable segment is emitted and the image
+    // stays byte-for-byte the pre-GC layout. The data-label machinery
+    // (reserve_data_cells / load_data_address) is wired to it and ready.
+    let bss_len = emitter.asm.bss_len as u64;
     Ok(macho::write_executable(
         emitter.asm.code,
         emitter.asm.rodata,
         &emitter.asm.fixups,
         "klassic",
-        0,
+        bss_len,
     ))
 }
 

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -136,13 +136,22 @@ const FP: u32 = 29;
 enum Cond {
     Eq = 0,
     Ne = 1,
+    /// Unsigned "higher or same" (carry set). Also the GC port's
+    /// `AboveOrEqual`. Same encoding as ARM `CS`. Inert until the
+    /// PortableAsm condition mapping (M4) constructs it.
+    #[allow(dead_code)]
+    Hs = 2,
     /// Carry clear. Darwin's `svc #0x80` convention signals a
     /// *successful* syscall this way (carry set = failure, x0 holds
     /// the positive errno) — the mirror image of Linux's
-    /// negative-rax convention.
+    /// negative-rax convention. Also the GC port's unsigned `Below`.
     Cc = 3,
     /// After `fcmp`: strictly less, unordered fails — the float `<`.
     Mi = 4,
+    /// Unsigned "higher" (strictly greater). The GC port's `Above`.
+    /// Inert until the PortableAsm condition mapping (M4).
+    #[allow(dead_code)]
+    Hi = 8,
     /// After `fcmp`: less-or-equal, unordered fails — the float `<=`.
     Ls = 9,
     Ge = 10,
@@ -304,6 +313,39 @@ impl Assembler {
         self.word(0xeb00_001f | ((rhs as u32) << 16) | ((lhs as u32) << 5));
     }
 
+    // The logical-register and unscaled load/store primitives below are
+    // added for the AArch64 GC port and stay inert (dead code) until the
+    // PortableAsm impl (M4) lowers `and/or/xor/test_reg_reg`,
+    // `load/store_ptr_disp32`, and `bt_reg_imm8` onto them.
+
+    /// `and xd, xn, xm` (logical AND, shifted register, shift 0).
+    #[allow(dead_code)]
+    fn and_reg(&mut self, dst: Reg, lhs: Reg, rhs: Reg) {
+        self.word(0x8a00_0000 | ((rhs as u32) << 16) | ((lhs as u32) << 5) | dst as u32);
+    }
+
+    /// `orr xd, xn, xm` (logical OR). `mov xd, xm` is the `xn = xzr` case.
+    #[allow(dead_code)]
+    fn orr_reg(&mut self, dst: Reg, lhs: Reg, rhs: Reg) {
+        self.word(0xaa00_0000 | ((rhs as u32) << 16) | ((lhs as u32) << 5) | dst as u32);
+    }
+
+    /// `eor xd, xn, xm` (logical XOR).
+    #[allow(dead_code)]
+    fn eor_reg(&mut self, dst: Reg, lhs: Reg, rhs: Reg) {
+        self.word(0xca00_0000 | ((rhs as u32) << 16) | ((lhs as u32) << 5) | dst as u32);
+    }
+
+    /// `tst xn, xm` (ands xzr, xn, xm) — flag-setting AND that discards
+    /// its result, setting Z = ((xn & xm) == 0). The GC port lowers
+    /// `test_reg_reg` here, and its bit-test to `tst xn, scratch` with a
+    /// materialized `1 << bit` mask (avoiding the logical-immediate
+    /// encoder), then remaps the following conditional branch.
+    #[allow(dead_code)]
+    fn tst_reg(&mut self, lhs: Reg, rhs: Reg) {
+        self.word(0xea00_001f | ((rhs as u32) << 16) | ((lhs as u32) << 5));
+    }
+
     /// `cset xd, cond`
     fn cset(&mut self, dst: Reg, cond: Cond) {
         self.word(0x9a9f_07e0 | (cond.inverted_bits() << 12) | dst as u32);
@@ -359,6 +401,25 @@ impl Assembler {
     fn load_local(&mut self, reg: Reg, offset: u32) {
         debug_assert!(offset.is_multiple_of(8) && offset / 8 < 4096);
         self.word(0xf940_0000 | ((offset / 8) << 10) | (FP << 5) | reg as u32);
+    }
+
+    /// `ldur xt, [xn, #simm9]` — unscaled load, signed 9-bit byte offset
+    /// in `-256..=255`. The GC port needs this for the object header's
+    /// `[base-16]` (word0) / `[base-8]` (type tag) accesses, which the
+    /// scaled `ldr` immediate form cannot express (it is non-negative).
+    #[allow(dead_code)]
+    fn ldur(&mut self, reg: Reg, base: Reg, offset: i32) {
+        debug_assert!((-256..=255).contains(&offset));
+        let imm9 = (offset as u32) & 0x1ff;
+        self.word(0xf840_0000 | (imm9 << 12) | ((base as u32) << 5) | reg as u32);
+    }
+
+    /// `stur xt, [xn, #simm9]` — unscaled store, signed 9-bit byte offset.
+    #[allow(dead_code)]
+    fn stur(&mut self, reg: Reg, base: Reg, offset: i32) {
+        debug_assert!((-256..=255).contains(&offset));
+        let imm9 = (offset as u32) & 0x1ff;
+        self.word(0xf800_0000 | (imm9 << 12) | ((base as u32) << 5) | reg as u32);
     }
 
     /// `strb wt, [xn, #-1]!`
@@ -3982,6 +4043,51 @@ mod tests {
                 0xf940_07a2, // ldr x2, [x29, #8]
             ]
         );
+    }
+
+    #[test]
+    fn encodes_gc_port_instructions() {
+        // Golden words generated with keystone-engine (ARM64) and
+        // round-tripped through capstone; see the aarch64 GC port plan.
+        // These primitives are inert until the PortableAsm impl (M4)
+        // references them.
+        let mut asm = Assembler::default();
+        asm.and_reg(Reg::X0, Reg::X1, Reg::X2);
+        asm.orr_reg(Reg::X0, Reg::X1, Reg::X2);
+        asm.eor_reg(Reg::X0, Reg::X1, Reg::X2);
+        asm.tst_reg(Reg::X0, Reg::X1);
+        asm.ldur(Reg::X0, Reg::X7, -16);
+        asm.ldur(Reg::X0, Reg::X7, -8);
+        asm.stur(Reg::X11, Reg::X10, -16);
+        asm.ldur(Reg::X0, Reg::X7, 255);
+        assert_eq!(
+            words(&asm),
+            vec![
+                0x8a02_0020, // and x0, x1, x2
+                0xaa02_0020, // orr x0, x1, x2
+                0xca02_0020, // eor x0, x1, x2
+                0xea01_001f, // tst x0, x1  (ands xzr, x0, x1)
+                0xf85f_00e0, // ldur x0, [x7, #-16]
+                0xf85f_80e0, // ldur x0, [x7, #-8]
+                0xf81f_014b, // stur x11, [x10, #-16]
+                0xf84f_f0e0, // ldur x0, [x7, #255]
+            ]
+        );
+    }
+
+    #[test]
+    fn encodes_unsigned_conditional_branches() {
+        // b.hi (Above) = cond 8, b.hs/b.cs (AboveOrEqual) = cond 2.
+        let mut asm = Assembler::default();
+        let target = asm.new_label();
+        asm.branch(target, BranchKind::Conditional(Cond::Hi));
+        asm.branch(target, BranchKind::Conditional(Cond::Hs));
+        asm.bind(target);
+        asm.finish();
+        let w = words(&asm);
+        // b.cond encodes cond in the low 4 bits; offset patched to +N words.
+        assert_eq!(w[0] & 0xff00_001f, 0x5400_0008); // b.hi
+        assert_eq!(w[1] & 0xff00_001f, 0x5400_0002); // b.hs
     }
 
     #[test]

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -20,6 +20,7 @@ use klassic_span::{Diagnostic, Span};
 use klassic_syntax::{BinaryOp, Expr, StringPart};
 
 use crate::macho::{self, DataFixup, FixupSection};
+use crate::portable_asm;
 
 const SYS_EXIT: u16 = 1;
 const SYS_WRITE: u16 = 4;
@@ -112,6 +113,21 @@ enum Reg {
     X22 = 22,
     /// Callee-saved: `envp`, captured from dyld's `LC_MAIN` entry.
     X23 = 23,
+    /// Callee-saved: GC load-barrier colour-strip mask (`ColorStrip`).
+    /// Seeded once at startup; the portable collector keeps it live.
+    #[allow(dead_code)]
+    X24 = 24,
+    /// Callee-saved: GC current good colour (`GoodColor`).
+    #[allow(dead_code)]
+    X25 = 25,
+    /// Callee-saved: GC bad-colour test mask (`BadMask`).
+    #[allow(dead_code)]
+    X26 = 26,
+    /// The frame pointer, as a base register for the GC's rbp-relative
+    /// frame slots (`[x29, #-offset]`). The rest of the backend addresses
+    /// the frame through the bare `FP` const and `mov_fp_sp`.
+    #[allow(dead_code)]
+    X29 = 29,
 }
 
 /// AAPCS64 integer argument registers, in order.
@@ -207,6 +223,12 @@ struct Assembler {
     /// Total bytes reserved in `__DATA,__bss` (the GC's zero-init cells).
     /// Zero for pre-GC programs, so no writable segment is emitted.
     bss_len: usize,
+    /// Set by the PortableAsm `bt_reg_imm8` lowering (which becomes a
+    /// flag-setting `tst reg, #(1<<bit)` → Z = (bit == 0)); the next
+    /// `jcc_label` consumes it to remap the x86 carry-based condition to
+    /// the AArch64 zero-based one. The GC always emits the branch
+    /// immediately after the bit test.
+    bt_pending: bool,
 }
 
 impl Assembler {
@@ -809,6 +831,312 @@ impl Assembler {
     /// `ret`
     fn ret(&mut self) {
         self.word(0xd65f_03c0);
+    }
+}
+
+/// Address of a datum the portable GC codegen references through
+/// `mov_data_addr`: a byte in read-only `__TEXT,__const` (constants,
+/// diagnostic strings) or a cell in writable `__DATA,__bss` (the
+/// collector's mutable globals). The AArch64 `PortableAsm::DataLabel`.
+#[derive(Clone, Copy)]
+#[allow(dead_code)]
+enum PortDataAddr {
+    Rodata(usize),
+    Bss(DataLabel),
+}
+
+/// Scratch register for immediate materialization and large-displacement
+/// forms. It sits outside the `V0..V11` mapping, so the portable
+/// collector never holds a live value in it.
+const PORT_SCRATCH: Reg = Reg::X10;
+
+/// Map a portable register to its AArch64 home. `V4`/`V5` (the x86 rsp/
+/// rbp roles) are the stack and frame pointers; the frame-shaped methods
+/// handle them inline and never route them through here.
+fn port_reg(r: portable_asm::Reg) -> Reg {
+    use portable_asm::Reg as P;
+    match r {
+        P::V0 => Reg::X0,
+        P::V1 => Reg::X1,
+        P::V2 => Reg::X2,
+        P::V3 => Reg::X3,
+        P::V6 => Reg::X4,
+        P::V7 => Reg::X5,
+        P::V8 => Reg::X6,
+        P::V9 => Reg::X7,
+        P::V10 => Reg::X8,
+        P::V11 => Reg::X9,
+        P::ColorStrip => Reg::X24,
+        P::GoodColor => Reg::X25,
+        P::BadMask => Reg::X26,
+        P::V4 | P::V5 => {
+            unreachable!("V4/V5 (sp/fp) are handled by the frame-shaped methods")
+        }
+    }
+}
+
+fn port_cond(c: portable_asm::Condition) -> Cond {
+    use portable_asm::Condition as P;
+    match c {
+        P::Equal => Cond::Eq,
+        P::NotEqual => Cond::Ne,
+        P::Below => Cond::Cc,
+        P::Above => Cond::Hi,
+        P::AboveOrEqual => Cond::Hs,
+        P::Less => Cond::Lt,
+        P::LessEqual => Cond::Le,
+        P::Greater => Cond::Gt,
+        P::GreaterEqual => Cond::Ge,
+        P::NoOverflow | P::Parity => {
+            unreachable!("condition not emitted by any GC runtime routine")
+        }
+    }
+}
+
+/// AArch64 realization of the portable ZGC emitter. Every method lowers
+/// one x86-flavored `PortableAsm` operation to AArch64, so the ~24
+/// architecture-independent `portable_asm::emit_gc_*` routines emit into
+/// this `Assembler` unchanged. Two conventions differ from x86 and are
+/// absorbed here: the frame (x86 `push rbp` leaves the return address on
+/// the stack, but AArch64 `bl` leaves it in x30, so the prologue saves a
+/// full frame record x29/x30), and rbp-relative slots (x29 sits at the
+/// frame top, so a slot is `[x29, #-offset]`).
+impl portable_asm::PortableAsm for Assembler {
+    type TextLabel = Label;
+    type DataLabel = PortDataAddr;
+
+    fn create_text_label(&mut self) -> Label {
+        self.new_label()
+    }
+    fn bind_text_label(&mut self, label: Label) {
+        self.bind(label);
+    }
+    fn jmp_label(&mut self, label: Label) {
+        self.branch(label, BranchKind::Unconditional);
+    }
+    fn jcc_label(&mut self, cond: portable_asm::Condition, label: Label) {
+        use portable_asm::Condition as P;
+        let cond = if self.bt_pending {
+            self.bt_pending = false;
+            // The bit test lowered to `tst reg, #(1<<bit)`, setting
+            // Z = (bit == 0). x86 `Below` (bit set) becomes `Ne`;
+            // `AboveOrEqual` (bit clear) becomes `Eq`.
+            match cond {
+                P::Below => Cond::Ne,
+                P::AboveOrEqual => Cond::Eq,
+                other => port_cond(other),
+            }
+        } else {
+            port_cond(cond)
+        };
+        self.branch(label, BranchKind::Conditional(cond));
+    }
+    fn call_label(&mut self, label: Label) {
+        self.branch(label, BranchKind::Link);
+    }
+    fn ret(&mut self) {
+        Assembler::ret(self);
+    }
+    fn leave(&mut self) {
+        self.word(0x9100_03bf); // mov sp, x29 (add sp, x29, #0)
+        self.pop_frame_record(); // ldp x29, x30, [sp], #16
+    }
+
+    fn push_reg(&mut self, r: portable_asm::Reg) {
+        match r {
+            portable_asm::Reg::V5 => self.push_frame_record(), // save fp+lr
+            other => self.push(port_reg(other)),
+        }
+    }
+    fn pop_reg(&mut self, r: portable_asm::Reg) {
+        match r {
+            portable_asm::Reg::V5 => self.pop_frame_record(),
+            other => self.pop(port_reg(other)),
+        }
+    }
+    fn mov_reg_reg(&mut self, dst: portable_asm::Reg, src: portable_asm::Reg) {
+        use portable_asm::Reg as P;
+        match (dst, src) {
+            (P::V5, P::V4) => self.mov_fp_sp(), // mov x29, sp
+            _ => self.mov_reg(port_reg(dst), port_reg(src)),
+        }
+    }
+    fn mov_imm64(&mut self, dst: portable_asm::Reg, imm: u64) {
+        Assembler::mov_imm64(self, port_reg(dst), imm);
+    }
+    fn mov_data_addr(&mut self, dst: portable_asm::Reg, label: PortDataAddr) {
+        let reg = port_reg(dst);
+        match label {
+            PortDataAddr::Rodata(off) => self.load_rodata_address(reg, off),
+            PortDataAddr::Bss(dl) => self.load_data_address(reg, dl),
+        }
+    }
+
+    fn load_ptr_disp32(&mut self, dst: portable_asm::Reg, base: portable_asm::Reg, disp: i32) {
+        let (d, b) = (port_reg(dst), port_reg(base));
+        if disp >= 0 && disp % 8 == 0 && disp / 8 < 4096 {
+            self.ldr_imm(d, b, disp as u32);
+        } else if (-256..=255).contains(&disp) {
+            self.ldur(d, b, disp);
+        } else {
+            Assembler::mov_imm64(self, PORT_SCRATCH, disp as i64 as u64);
+            self.ldr_reg_offset(d, b, PORT_SCRATCH);
+        }
+    }
+    fn store_ptr_disp32(&mut self, base: portable_asm::Reg, disp: i32, src: portable_asm::Reg) {
+        let (s, b) = (port_reg(src), port_reg(base));
+        if disp >= 0 && disp % 8 == 0 && disp / 8 < 4096 {
+            self.str_imm(s, b, disp as u32);
+        } else if (-256..=255).contains(&disp) {
+            self.stur(s, b, disp);
+        } else {
+            Assembler::mov_imm64(self, PORT_SCRATCH, disp as i64 as u64);
+            self.str_reg_offset(s, b, PORT_SCRATCH);
+        }
+    }
+    fn load_rbp_slot(&mut self, dst: portable_asm::Reg, offset: i32) {
+        // x86 `[rbp - offset]`; x29 sits at the frame top, so `[x29, -off]`.
+        self.ldur(port_reg(dst), Reg::X29, -offset);
+    }
+    fn store_rbp_slot(&mut self, offset: i32, src: portable_asm::Reg) {
+        self.stur(port_reg(src), Reg::X29, -offset);
+    }
+
+    fn add_reg_reg(&mut self, dst: portable_asm::Reg, src: portable_asm::Reg) {
+        let (d, s) = (port_reg(dst), port_reg(src));
+        self.add_reg(d, d, s);
+    }
+    fn sub_reg_reg(&mut self, dst: portable_asm::Reg, src: portable_asm::Reg) {
+        let (d, s) = (port_reg(dst), port_reg(src));
+        self.sub_reg(d, d, s);
+    }
+    fn and_reg_reg(&mut self, dst: portable_asm::Reg, src: portable_asm::Reg) {
+        let (d, s) = (port_reg(dst), port_reg(src));
+        self.and_reg(d, d, s);
+    }
+    fn or_reg_reg(&mut self, dst: portable_asm::Reg, src: portable_asm::Reg) {
+        let (d, s) = (port_reg(dst), port_reg(src));
+        self.orr_reg(d, d, s);
+    }
+    fn xor_reg_reg(&mut self, dst: portable_asm::Reg, src: portable_asm::Reg) {
+        let (d, s) = (port_reg(dst), port_reg(src));
+        self.eor_reg(d, d, s);
+    }
+    fn cmp_reg_reg(&mut self, a: portable_asm::Reg, b: portable_asm::Reg) {
+        self.cmp_reg(port_reg(a), port_reg(b));
+    }
+    fn test_reg_reg(&mut self, a: portable_asm::Reg, b: portable_asm::Reg) {
+        self.tst_reg(port_reg(a), port_reg(b));
+    }
+
+    fn add_reg_imm32(&mut self, dst: portable_asm::Reg, imm: i32) {
+        if dst == portable_asm::Reg::V4 {
+            debug_assert!((0..4096).contains(&imm));
+            self.add_sp_imm(imm as u32);
+        } else {
+            let d = port_reg(dst);
+            if (0..4096).contains(&imm) {
+                self.add_reg_imm(d, d, imm as u32);
+            } else if (-4095..0).contains(&imm) {
+                self.sub_reg_imm(d, d, (-imm) as u32);
+            } else {
+                Assembler::mov_imm64(self, PORT_SCRATCH, imm as i64 as u64);
+                self.add_reg(d, d, PORT_SCRATCH);
+            }
+        }
+    }
+    fn sub_reg_imm8(&mut self, r: portable_asm::Reg, imm: i8) {
+        if r == portable_asm::Reg::V4 {
+            self.sub_sp_imm(imm as u32);
+        } else {
+            let d = port_reg(r);
+            self.sub_reg_imm(d, d, imm as u32);
+        }
+    }
+    fn sub_reg_imm32(&mut self, r: portable_asm::Reg, imm: i32) {
+        let d = port_reg(r);
+        if (0..4096).contains(&imm) {
+            self.sub_reg_imm(d, d, imm as u32);
+        } else {
+            Assembler::mov_imm64(self, PORT_SCRATCH, imm as i64 as u64);
+            self.sub_reg(d, d, PORT_SCRATCH);
+        }
+    }
+    fn and_reg_imm32(&mut self, r: portable_asm::Reg, imm: i32) {
+        // Materialize the mask and AND register-register, sidestepping the
+        // AArch64 logical-immediate (N:immr:imms) encoder.
+        let d = port_reg(r);
+        Assembler::mov_imm64(self, PORT_SCRATCH, imm as i64 as u64);
+        self.and_reg(d, d, PORT_SCRATCH);
+    }
+    fn cmp_reg_imm8(&mut self, r: portable_asm::Reg, imm: i8) {
+        let d = port_reg(r);
+        if imm >= 0 {
+            self.cmp_imm(d, imm as u32);
+        } else {
+            Assembler::mov_imm64(self, PORT_SCRATCH, imm as i64 as u64);
+            self.cmp_reg(d, PORT_SCRATCH);
+        }
+    }
+    fn cmp_reg_imm32(&mut self, r: portable_asm::Reg, imm: i32) {
+        let d = port_reg(r);
+        if (0..4096).contains(&imm) {
+            self.cmp_imm(d, imm as u32);
+        } else {
+            Assembler::mov_imm64(self, PORT_SCRATCH, imm as i64 as u64);
+            self.cmp_reg(d, PORT_SCRATCH);
+        }
+    }
+    fn shl_reg_imm8(&mut self, r: portable_asm::Reg, imm: u8) {
+        let d = port_reg(r);
+        self.lsl_imm(d, d, u32::from(imm));
+    }
+    fn shr_reg_imm8(&mut self, r: portable_asm::Reg, imm: u8) {
+        let d = port_reg(r);
+        self.lsr_imm(d, d, u32::from(imm));
+    }
+    fn bt_reg_imm8(&mut self, r: portable_asm::Reg, bit: u8) {
+        // Flag-setting `tst reg, #(1<<bit)` via a materialized mask;
+        // `jcc_label` remaps the following branch (see `bt_pending`).
+        Assembler::mov_imm64(self, PORT_SCRATCH, 1u64 << bit);
+        self.tst_reg(port_reg(r), PORT_SCRATCH);
+        self.bt_pending = true;
+    }
+    fn rep_movsb(&mut self) {
+        // Copy V1 (rcx=x1) bytes from [V6 (rsi=x4)] to [V7 (rdi=x5)].
+        let (count, src, dst) = (Reg::X1, Reg::X4, Reg::X5);
+        let copy_loop = self.new_label();
+        let done = self.new_label();
+        self.bind(copy_loop);
+        self.branch(done, BranchKind::CompareZero(count));
+        self.ldrb_post_increment(PORT_SCRATCH, src);
+        self.strb_post_increment(PORT_SCRATCH, dst);
+        self.sub_reg_imm(count, count, 1);
+        self.branch(copy_loop, BranchKind::Unconditional);
+        self.bind(done);
+    }
+
+    fn plat_write_data(&mut self, fd: u64, data: PortDataAddr, len: usize) {
+        Assembler::mov_imm64(self, Reg::X0, fd);
+        match data {
+            PortDataAddr::Rodata(off) => self.load_rodata_address(Reg::X1, off),
+            PortDataAddr::Bss(dl) => self.load_data_address(Reg::X1, dl),
+        }
+        Assembler::mov_imm64(self, Reg::X2, len as u64);
+        Assembler::mov_imm64(self, Reg::X16, u64::from(SYS_WRITE));
+        self.svc_0x80();
+    }
+    fn plat_exit(&mut self, code: u64) {
+        Assembler::mov_imm64(self, Reg::X0, code);
+        Assembler::mov_imm64(self, Reg::X16, u64::from(SYS_EXIT));
+        self.svc_0x80();
+    }
+    fn plat_read_monotonic_ns(&mut self) {
+        // Minimal: report 0 ns (like the x86 Windows path, whose pauses
+        // also read 0). The GC wiring keeps `--gc-log` timing disabled on
+        // AArch64, so this is never emitted; a real monotonic clock can
+        // replace it later.
+        Assembler::mov_imm64(self, Reg::X0, 0);
     }
 }
 
@@ -4136,6 +4464,66 @@ mod tests {
         // b.cond encodes cond in the low 4 bits; offset patched to +N words.
         assert_eq!(w[0] & 0xff00_001f, 0x5400_0008); // b.hi
         assert_eq!(w[1] & 0xff00_001f, 0x5400_0002); // b.hs
+    }
+
+    #[test]
+    fn portable_gc_routines_emit_valid_aarch64() {
+        // Emit whole architecture-independent GC routines through the
+        // AArch64 PortableAsm impl and sanity-check the byte stream. Set
+        // KLASSIC_AA_DUMP to a path to dump the code for capstone disasm.
+        let mut asm = Assembler::default();
+
+        let cc = PortDataAddr::Bss(asm.reserve_data_cells(1));
+        let br = PortDataAddr::Bss(asm.reserve_data_cells(1));
+        let grow = asm.new_label();
+        crate::portable_asm::emit_gc_grow_budget(&mut asm, grow, cc, br);
+
+        let bounds = asm.new_label();
+        crate::portable_asm::emit_gc_bounds_error(&mut asm, bounds, PortDataAddr::Rodata(0), 32);
+
+        let worklist_top = PortDataAddr::Bss(asm.reserve_data_cells(1));
+        let drain = asm.new_label();
+        let trace = asm.new_label();
+        asm.bind(trace); // a stand-in body so `finish` can resolve the call
+        asm.ret();
+        crate::portable_asm::emit_gc_drain(&mut asm, drain, trace, worklist_top);
+
+        // mark_roots exercises the rbp-relative frame slots ([x29,#-N]).
+        let shadow = PortDataAddr::Bss(asm.reserve_data_cells(1));
+        let shadow_top = PortDataAddr::Bss(asm.reserve_data_cells(1));
+        let mark_visit = asm.new_label();
+        asm.bind(mark_visit);
+        asm.ret();
+        let mark_roots = asm.new_label();
+        crate::portable_asm::emit_gc_mark_roots(
+            &mut asm, mark_roots, shadow, shadow_top, mark_visit,
+        );
+
+        // load_barrier_slow exercises the bit-test remap and the reserved
+        // colour registers (x24/x25/x26) and the [base-16] header access.
+        let phase = PortDataAddr::Bss(asm.reserve_data_cells(1));
+        let region_base = PortDataAddr::Bss(asm.reserve_data_cells(1));
+        let region_fromspace = PortDataAddr::Bss(asm.reserve_data_cells(1));
+        let evacuate = asm.new_label();
+        asm.bind(evacuate);
+        asm.ret();
+        let lbs = asm.new_label();
+        crate::portable_asm::emit_gc_load_barrier_slow(
+            &mut asm,
+            lbs,
+            phase,
+            region_base,
+            region_fromspace,
+            evacuate,
+            mark_visit,
+        );
+
+        asm.finish();
+        assert!(!asm.code.is_empty());
+        assert_eq!(asm.code.len() % 4, 0, "every instruction is a 32-bit word");
+        if let Ok(path) = std::env::var("KLASSIC_AA_DUMP") {
+            std::fs::write(path, &asm.code).unwrap();
+        }
     }
 
     #[test]

--- a/crates/klassic-native/src/macho.rs
+++ b/crates/klassic-native/src/macho.rs
@@ -13,13 +13,23 @@
 //! — and no external `codesign` / `cc` / `ld` is involved, keeping
 //! the no-toolchain policy of the direct backends.
 
-/// An `adrp`+`add` pair in `code` that must be patched to address a
-/// byte in `rodata` once the final image layout is known.
+/// Which segment a `DataFixup` addresses: the read-only `__TEXT,__const`
+/// (constants, strings) or the writable `__DATA,__bss` (the GC's cells).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FixupSection {
+    Rodata,
+    Data,
+}
+
+/// An `adrp`+`add` pair in `code` that must be patched to address a byte
+/// in `section` (at `data_offset` within it) once the final image layout
+/// is known.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct DataFixup {
     pub adrp_offset: usize,
     pub add_offset: usize,
     pub data_offset: usize,
+    pub section: FixupSection,
 }
 
 const PAGE_SIZE: u64 = 16384;
@@ -154,7 +164,13 @@ pub(crate) fn write_executable(
     };
 
     for fixup in fixups {
-        patch_data_fixup(&mut code, code_offset, rodata_offset, fixup);
+        let section_base = match fixup.section {
+            FixupSection::Rodata => TEXT_BASE + rodata_offset,
+            // __DATA maps right after __TEXT; the zero-fill __bss shares
+            // the segment's vmaddr (its file offset is meaningless).
+            FixupSection::Data => data_vmaddr,
+        };
+        patch_data_fixup(&mut code, code_offset, section_base, fixup);
     }
 
     let identifier_bytes = identifier.as_bytes();
@@ -339,9 +355,9 @@ pub(crate) fn write_executable(
     out.bytes
 }
 
-fn patch_data_fixup(code: &mut [u8], code_offset: u64, rodata_offset: u64, fixup: &DataFixup) {
+fn patch_data_fixup(code: &mut [u8], code_offset: u64, section_base: u64, fixup: &DataFixup) {
     let place = TEXT_BASE + code_offset + fixup.adrp_offset as u64;
-    let target = TEXT_BASE + rodata_offset + fixup.data_offset as u64;
+    let target = section_base + fixup.data_offset as u64;
     let page_delta = ((target >> 12) as i64 - (place >> 12) as i64) as u64;
     let immlo = (page_delta & 0x3) as u32;
     let immhi = ((page_delta >> 2) & 0x7_ffff) as u32;
@@ -652,6 +668,7 @@ mod tests {
             adrp_offset: 0,
             add_offset: 4,
             data_offset: 0,
+            section: FixupSection::Rodata,
         }];
         let image = write_executable(code, b"x".to_vec(), &fixups, "klassic", 0);
         // Locate the code from the layout formula: header (32) +
@@ -663,5 +680,50 @@ mod tests {
         let add = u32::from_le_bytes(image[code_offset + 4..code_offset + 8].try_into().unwrap());
         let rodata_offset = align_to(code_offset as u64 + 8, 8) as u32;
         assert_eq!(add, 0x9100_0021 | (rodata_offset << 10));
+    }
+
+    /// Decode an `adrp xd, <page>` + `add xd, xd, #<off>` pair back to the
+    /// absolute address it computes, independent of the writer's formula.
+    fn decode_adrp_add(image: &[u8], adrp_at: usize) -> u64 {
+        let adrp = u32::from_le_bytes(image[adrp_at..adrp_at + 4].try_into().unwrap());
+        let add = u32::from_le_bytes(image[adrp_at + 4..adrp_at + 8].try_into().unwrap());
+        let immlo = ((adrp >> 29) & 0x3) as u64;
+        let immhi = ((adrp >> 5) & 0x7_ffff) as u64;
+        let mut page_delta = (immhi << 2) | immlo; // 21-bit signed
+        if page_delta & (1 << 20) != 0 {
+            page_delta |= !0 << 21; // sign-extend
+        }
+        let place = TEXT_BASE + adrp_at as u64;
+        let target_page = (place & !0xfff).wrapping_add(page_delta.wrapping_shl(12));
+        let imm12 = ((add >> 10) & 0xfff) as u64;
+        target_page + imm12
+    }
+
+    #[test]
+    fn data_section_fixups_resolve_against_data_segment() {
+        // adrp/add addressing the second GC cell (byte offset 8) in
+        // __DATA,__bss. Its target is a full segment away from the code,
+        // so the adrp page delta is non-zero (unlike the rodata case).
+        let code = vec![
+            0x01, 0x00, 0x00, 0x90, // adrp x1, 0 (placeholder)
+            0x21, 0x00, 0x00, 0x91, // add x1, x1, #0 (placeholder)
+        ];
+        let fixups = [DataFixup {
+            adrp_offset: 0,
+            add_offset: 4,
+            data_offset: 8,
+            section: FixupSection::Data,
+        }];
+        let image = write_executable(code, b"x".to_vec(), &fixups, "klassic", 16);
+
+        let ncmds = u32::from_le_bytes(image[16..20].try_into().unwrap());
+        let text = find_segment(&image, ncmds, "__TEXT").unwrap();
+        let text_filesize = u64::from_le_bytes(image[text + 32..text + 40].try_into().unwrap());
+        let data_vmaddr = TEXT_BASE + text_filesize;
+
+        let sizeofcmds = u32::from_le_bytes(image[20..24].try_into().unwrap()) as u64;
+        let code_offset = align_to(32 + sizeofcmds, 16) as usize;
+        let resolved = decode_adrp_add(&image, code_offset);
+        assert_eq!(resolved, data_vmaddr + 8);
     }
 }

--- a/crates/klassic-native/src/macho.rs
+++ b/crates/klassic-native/src/macho.rs
@@ -42,7 +42,14 @@ const LC_BUILD_VERSION: u32 = 0x32;
 const LC_CODE_SIGNATURE: u32 = 0x1d;
 
 const VM_PROT_READ: u32 = 0x1;
+const VM_PROT_WRITE: u32 = 0x2;
 const VM_PROT_EXECUTE: u32 = 0x4;
+
+/// `S_ZEROFILL` section type: no file backing, zeroed at map time. The
+/// GC's mutable global cells live in a `__DATA,__bss` section of this
+/// type, so they add no on-disk bytes and fall outside the code
+/// signature's `codeLimit`.
+const S_ZEROFILL: u32 = 0x1;
 
 const SEGMENT_COMMAND_SIZE: u32 = 72;
 const SECTION_SIZE: u32 = 80;
@@ -104,9 +111,23 @@ pub(crate) fn write_executable(
     rodata: Vec<u8>,
     fixups: &[DataFixup],
     identifier: &str,
+    bss_size: u64,
 ) -> Vec<u8> {
+    // A writable `__DATA` segment (one zero-fill `__bss` section) is
+    // emitted only when the codegen requested mutable global cells (the
+    // GC's). It carries no on-disk bytes, so it shifts nothing in the
+    // payload or the signature — only the two extra load commands grow
+    // `sizeofcmds`, which cascades through the file offsets. When
+    // `bss_size == 0` the layout is byte-for-byte the pre-GC image.
+    let has_data = bss_size > 0;
+    let data_cmd_size = if has_data {
+        SEGMENT_COMMAND_SIZE + SECTION_SIZE
+    } else {
+        0
+    };
     let sizeofcmds = SEGMENT_COMMAND_SIZE          // __PAGEZERO
         + SEGMENT_COMMAND_SIZE + 2 * SECTION_SIZE  // __TEXT (__text, __const)
+        + data_cmd_size                            // __DATA (__bss), if any
         + SEGMENT_COMMAND_SIZE                     // __LINKEDIT
         + LOAD_DYLINKER_COMMAND_SIZE
         + MAIN_COMMAND_SIZE
@@ -114,12 +135,23 @@ pub(crate) fn write_executable(
         + DYSYMTAB_COMMAND_SIZE
         + BUILD_VERSION_COMMAND_SIZE
         + CODE_SIGNATURE_COMMAND_SIZE;
-    let ncmds = 9u32;
+    let ncmds = if has_data { 10u32 } else { 9u32 };
     let header_end = 32 + u64::from(sizeofcmds);
     let code_offset = align_to(header_end, 16);
     let rodata_offset = align_to(code_offset + code.len() as u64, 8);
     let text_filesize = align_to(rodata_offset + rodata.len() as u64, PAGE_SIZE);
+    // The zero-fill __bss adds no file bytes, so the signature still
+    // begins at the end of __TEXT regardless of the data segment.
     let signature_offset = text_filesize;
+    // __DATA maps in VM immediately after __TEXT; __LINKEDIT then moves
+    // past __DATA's (page-rounded) vm size.
+    let data_vmaddr = TEXT_BASE + text_filesize;
+    let data_vmsize = align_to(bss_size, PAGE_SIZE);
+    let linkedit_vmaddr = if has_data {
+        data_vmaddr + data_vmsize
+    } else {
+        TEXT_BASE + text_filesize
+    };
 
     for fixup in fixups {
         patch_data_fixup(&mut code, code_offset, rodata_offset, fixup);
@@ -200,11 +232,42 @@ pub(crate) fn write_executable(
     out.u32(0);
     out.u32(0);
 
+    // __DATA: the GC's writable globals. One zero-fill __bss section, so
+    // the segment has no on-disk bytes (fileoff points just past __TEXT,
+    // filesize 0) and dyld zeroes the whole vm range at map time.
+    if has_data {
+        out.u32(LC_SEGMENT_64);
+        out.u32(SEGMENT_COMMAND_SIZE + SECTION_SIZE);
+        out.name16("__DATA");
+        out.u64(data_vmaddr);
+        out.u64(data_vmsize);
+        out.u64(text_filesize); // fileoff (filesize 0, so unmapped from file)
+        out.u64(0); // filesize
+        out.u32(VM_PROT_READ | VM_PROT_WRITE);
+        out.u32(VM_PROT_READ | VM_PROT_WRITE);
+        out.u32(1); // nsects
+        out.u32(0);
+
+        // __DATA,__bss
+        out.name16("__bss");
+        out.name16("__DATA");
+        out.u64(data_vmaddr);
+        out.u64(bss_size);
+        out.u32(0); // offset: S_ZEROFILL has no file backing
+        out.u32(3); // 2^3 alignment
+        out.u32(0);
+        out.u32(0);
+        out.u32(S_ZEROFILL);
+        out.u32(0);
+        out.u32(0);
+        out.u32(0);
+    }
+
     // __LINKEDIT: holds exactly the code signature.
     out.u32(LC_SEGMENT_64);
     out.u32(SEGMENT_COMMAND_SIZE);
     out.name16("__LINKEDIT");
-    out.u64(TEXT_BASE + text_filesize);
+    out.u64(linkedit_vmaddr);
     out.u64(align_to(signature_size, PAGE_SIZE));
     out.u64(signature_offset);
     out.u64(signature_size);
@@ -466,7 +529,7 @@ mod tests {
     fn executable_layout_is_structurally_sound() {
         let code = vec![0xd2, 0x80, 0x00, 0x40]; // mov x0, #2
         let rodata = b"hi\n".to_vec();
-        let image = write_executable(code, rodata, &[], "klassic");
+        let image = write_executable(code, rodata, &[], "klassic", 0);
 
         assert_eq!(&image[0..4], &MH_MAGIC_64.to_le_bytes());
         assert_eq!(&image[4..8], &CPU_TYPE_ARM64.to_le_bytes());
@@ -500,6 +563,82 @@ mod tests {
         assert_eq!(first_hash, &sha256(&image[..SIGN_PAGE_SIZE]));
     }
 
+    /// Walk the load commands and return the file offset of the
+    /// `LC_SEGMENT_64` whose segname matches, or `None`.
+    fn find_segment(image: &[u8], ncmds: u32, segname: &str) -> Option<usize> {
+        let mut off = 32usize;
+        for _ in 0..ncmds {
+            let cmd = u32::from_le_bytes(image[off..off + 4].try_into().unwrap());
+            let cmdsize = u32::from_le_bytes(image[off + 4..off + 8].try_into().unwrap()) as usize;
+            if cmd == LC_SEGMENT_64 {
+                let name_end = image[off + 8..off + 24]
+                    .iter()
+                    .position(|&b| b == 0)
+                    .unwrap_or(16);
+                if &image[off + 8..off + 8 + name_end] == segname.as_bytes() {
+                    return Some(off);
+                }
+            }
+            off += cmdsize;
+        }
+        None
+    }
+
+    #[test]
+    fn writable_data_segment_is_gated_and_structurally_sound() {
+        let code = vec![0xd2, 0x80, 0x00, 0x40]; // mov x0, #2
+        let bss_size = 30 * 8; // ~30 zero-init GC cells
+        let image = write_executable(code, b"hi\n".to_vec(), &[], "klassic", bss_size);
+
+        // The data segment bumps the command count.
+        let ncmds = u32::from_le_bytes(image[16..20].try_into().unwrap());
+        assert_eq!(ncmds, 10);
+
+        // __TEXT gives us its (page-aligned) vmsize = text_filesize.
+        let text = find_segment(&image, ncmds, "__TEXT").expect("__TEXT present");
+        let text_filesize = u64::from_le_bytes(image[text + 32..text + 40].try_into().unwrap());
+
+        // __DATA: writable, one section, mapped right after __TEXT.
+        let data = find_segment(&image, ncmds, "__DATA").expect("__DATA present");
+        let data_vmaddr = u64::from_le_bytes(image[data + 24..data + 32].try_into().unwrap());
+        let data_vmsize = u64::from_le_bytes(image[data + 32..data + 40].try_into().unwrap());
+        let data_filesize = u64::from_le_bytes(image[data + 48..data + 56].try_into().unwrap());
+        let initprot = u32::from_le_bytes(image[data + 60..data + 64].try_into().unwrap());
+        let nsects = u32::from_le_bytes(image[data + 64..data + 68].try_into().unwrap());
+        assert_eq!(data_vmaddr, TEXT_BASE + text_filesize);
+        assert_eq!(data_vmsize, align_to(bss_size, PAGE_SIZE));
+        assert_eq!(data_filesize, 0, "zero-fill: no on-disk bytes");
+        assert_eq!(initprot, VM_PROT_READ | VM_PROT_WRITE);
+        assert_eq!(nsects, 1);
+
+        // __DATA,__bss section: S_ZEROFILL, no file offset, correct size.
+        let sect = data + SEGMENT_COMMAND_SIZE as usize;
+        assert_eq!(&image[sect..sect + 5], b"__bss");
+        let sect_size = u64::from_le_bytes(image[sect + 40..sect + 48].try_into().unwrap());
+        let sect_offset = u32::from_le_bytes(image[sect + 48..sect + 52].try_into().unwrap());
+        let sect_flags = u32::from_le_bytes(image[sect + 64..sect + 68].try_into().unwrap());
+        assert_eq!(sect_size, bss_size);
+        assert_eq!(sect_offset, 0);
+        assert_eq!(sect_flags, S_ZEROFILL);
+
+        // __LINKEDIT moves past __DATA in the address space.
+        let linkedit = find_segment(&image, ncmds, "__LINKEDIT").expect("__LINKEDIT present");
+        let le_vmaddr = u64::from_le_bytes(image[linkedit + 24..linkedit + 32].try_into().unwrap());
+        assert_eq!(le_vmaddr, data_vmaddr + data_vmsize);
+
+        // The zero-fill segment adds no file bytes, so the signature still
+        // begins at text_filesize and its first-page hash is valid.
+        let signature_offset = text_filesize as usize;
+        assert_eq!(
+            &image[signature_offset..signature_offset + 4],
+            &CSMAGIC_EMBEDDED_SIGNATURE.to_be_bytes()
+        );
+        let directory = &image[signature_offset + 20..];
+        let hash_offset = u32::from_be_bytes(directory[16..20].try_into().unwrap()) as usize;
+        let first_hash = &directory[hash_offset..hash_offset + SHA256_SIZE];
+        assert_eq!(first_hash, &sha256(&image[..SIGN_PAGE_SIZE]));
+    }
+
     #[test]
     fn data_fixups_resolve_page_and_offset() {
         // adrp x1, <data>; add x1, x1, #<pageoff> with the data only a
@@ -514,7 +653,7 @@ mod tests {
             add_offset: 4,
             data_offset: 0,
         }];
-        let image = write_executable(code, b"x".to_vec(), &fixups, "klassic");
+        let image = write_executable(code, b"x".to_vec(), &fixups, "klassic", 0);
         // Locate the code from the layout formula: header (32) +
         // sizeofcmds, aligned to 16.
         let sizeofcmds = u32::from_le_bytes(image[20..24].try_into().unwrap()) as u64;


### PR DESCRIPTION
## What & why

This lands the **infrastructure foundation** for giving the AArch64 (Apple Silicon, Mach-O) native backend a real garbage collector by reusing the portable ZGC that lives behind the `PortableAsm` trait (merged in #600). The AArch64 backend currently has no collector — its `__gc_*` builtins are a bump allocator that leaks. This PR is milestones M1–M4 of that epic: everything needed to *emit* the collector, all inert and behavior-preserving, so the eventual go-live PR is smaller and lands on a proven base.

Every commit here is **byte-for-byte identical to `main` for existing programs** (verified per commit) — no runtime behavior changes yet.

## Milestones in this PR

- **M1 — instruction primitives.** Add the AArch64 encodings the trait needs but the backend lacked: register-register `and`/`orr`/`eor`, flag-setting `tst`, unscaled signed-9 `ldur`/`stur` (for the GC object header's `[base-16]`/`[base-8]` accesses), and the unsigned `Hi`/`Hs` conditions. Inert; unit-tested against golden words.

- **M2 — writable `__DATA`/`__bss` segment.** The Mach-O writer gains a gated writable segment (one zero-fill `__bss` section) for the collector's ~30 mutable global cells. Because `__bss` has no on-disk bytes it adds nothing to the payload or the code signature's `codeLimit`; it is emitted only when codegen requests cells (a `bss_size` parameter), so pre-GC images are unchanged.

- **M3 — data-label + fixup mechanism.** `DataFixup` gains a `FixupSection` (Rodata vs Data) so an `adrp`/`add` pair resolves against `__const` or `__DATA,__bss`. The Assembler gains a `DataLabel`, a `reserve_data_cells` allocator, and `load_data_address` (the analog of x86-64's `data_label_with_i64s` + `mov_data_addr`). Inert.

- **M4 — `PortableAsm` impl.** Implement the trait on the AArch64 `Assembler`, so the ~24 architecture-independent `portable_asm::emit_gc_*` routines emit unchanged. Maps the portable `V0..V11` onto `{X0-X3, sp, x29, X4-X9}`, reserves `X24/X25/X26` for the colour registers and `X10` as materialization scratch. Absorbs the two x86/AArch64 convention gaps here: the frame (`bl` leaves the return address in `x30`, so the prologue saves an `x29/x30` frame record) and rbp slots (`x29` at the frame top → `[x29, #-offset]` via `stur`/`ldur`). Immediate logical/compare/bit-test forms materialize into `X10` and use the M1 register-register ops, sidestepping the AArch64 logical-immediate encoder; the bit test lowers to a flag-setting `tst` and remaps the following branch.

## Verification

The AArch64 Mach-O output cannot be *run* on the Linux x86-64 dev host and this binutils cannot disassemble arm64, so the epic's verification oracle is **[keystone](https://www.keystone-engine.org/) (assemble ground-truth) + [capstone](https://www.capstone-engine.org/) (disassemble and check)**.

- **M1/M2/M3**: unit tests assert exact instruction/layout bytes, incl. golden words from keystone and an independent `adrp`/`add` decode for the data fixup.
- **M4**: whole emitted GC routines (`grow_budget`, `bounds_error`, `drain`, `mark_roots`, `load_barrier_slow`) were disassembled with capstone and confirmed correct idiomatic AArch64 — the register mapping, sp/fp frame, negative rbp slots (`[x29,#-8]`), `ldur` header access, the bit-test remap (`b.eq` after `tst`), the colour registers (`x24`/`x25`), the syscalls, and the push/pop pairs.
- **Gating**: an aarch64 build on this branch is byte-identical to `main` after every milestone.
- `cargo fmt` / `clippy -D warnings` clean; 723 tests pass.

## What's next (not in this PR)

M5 wires the routines + cells + startup into the emitter (still dead code), M6 boxes the AArch64 object model to the collector's uniform-pointer shape, and M7 is the atomic go-live (headered `gc_alloc` + precise roots + load barrier + colour-on-store) — validated by a `--gc-stress`/`--gc-poison` differential harness on the macOS CI runners, since those semantic properties can't be checked locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
