### PR TITLE
aarch64 GC port M5: emit all 24 GC runtime routines + cells (dead but linked)

### DIFF
--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -1432,6 +1432,11 @@ impl Emitter {
                     if *elem.get_or_insert(this_elem) != this_elem {
                         return Err(unsupported(*span, "mixed list element types"));
                     }
+                    // Box a scalar element so the cons cell's head slot is
+                    // a pointer (string/list/record heads already are).
+                    if is_boxed_scalar(ty) {
+                        self.emit_box_scalar();
+                    }
                     self.asm.push(Reg::X0);
                 }
                 self.asm.mov_imm64(Reg::X0, 0); // nil
@@ -1548,6 +1553,10 @@ impl Emitter {
                             "a list element of this type",
                         ));
                     };
+                    // Box a scalar head so the cons cell holds a pointer.
+                    if is_boxed_scalar(head_ty) {
+                        self.emit_box_scalar();
+                    }
                     self.asm.push(Reg::X0);
                     let tail_ty = self.expression(&arguments[0])?;
                     if !assignable(tail_ty, ValueType::List(elem)) {
@@ -3064,13 +3073,22 @@ impl Emitter {
 
     /// Prepend a cons cell: head value on top of the machine stack,
     /// tail pointer in x0 → fresh cell pointer in x0.
+    ///
+    /// M6: a GC-shaped `POINTER_RECORD` with two pointer slots
+    /// `[head][next]`. The head on the stack is already a pointer -- a
+    /// scalar head was boxed by the caller, a string/list/record head is
+    /// a pointer already -- and `next` in x0 is a cell pointer or 0
+    /// (nil), so the collector can trace both slots uniformly. The
+    /// 16-byte header shifts the user pointer to block + 16, but the head
+    /// and next still live at `[cell + 0]`/`[cell + 8]`, so every list
+    /// read keeps the same offsets.
     fn emit_cons_cell(&mut self) {
-        self.asm.mov_imm64(Reg::X4, 16);
-        self.emit_alloc();
+        self.asm.push(Reg::X0); // preserve `next` across the alloc
+        self.emit_gc_alloc_object(2, crate::gc_layout::GC_TYPE_POINTER_RECORD); // x0 = user ptr
         self.asm.pop(Reg::X1);
-        self.asm.str_imm(Reg::X1, Reg::X5, 0);
-        self.asm.str_imm(Reg::X0, Reg::X5, 8);
-        self.asm.mov_reg(Reg::X0, Reg::X5);
+        self.asm.str_imm(Reg::X1, Reg::X0, 8); // [cell + 8] = next
+        self.asm.pop(Reg::X1);
+        self.asm.str_imm(Reg::X1, Reg::X0, 0); // [cell + 0] = head
     }
 
     /// Get/create the lazily-emitted membership-scan routine label for
@@ -3131,9 +3149,14 @@ impl Emitter {
             self.asm.branch(member, BranchKind::Link);
             let skip = self.asm.new_label();
             self.asm.branch(skip, BranchKind::CompareNonZero(Reg::X0));
-            // Absent: prepend the candidate to the accumulator.
+            // Absent: prepend the candidate to the accumulator. Box a
+            // scalar candidate so the cons cell's head slot is a pointer.
             self.asm.pop(Reg::X1);
-            self.asm.push(Reg::X1); // head for emit_cons_cell
+            self.asm.mov_reg(Reg::X0, Reg::X1);
+            if is_boxed_scalar(elem_value_type(this)) {
+                self.emit_box_scalar();
+            }
+            self.asm.push(Reg::X0); // head for emit_cons_cell
             self.asm.load_local(Reg::X0, acc);
             self.emit_cons_cell();
             self.asm.store_local(Reg::X0, acc);
@@ -3166,6 +3189,11 @@ impl Emitter {
         self.asm.pop(Reg::X3);
         self.asm.push(Reg::X3);
         self.asm.ldr_imm(Reg::X0, Reg::X3, 0);
+        // Scalar elements are boxed in the cell; unbox before printing
+        // (string elements are already the pointer).
+        if is_boxed_scalar(elem_value_type(elem)) {
+            self.emit_unbox_scalar();
+        }
         self.emit_print_elem(elem);
         self.asm.pop(Reg::X3);
         self.asm.ldr_imm(Reg::X3, Reg::X3, 8);
@@ -3188,7 +3216,8 @@ impl Emitter {
         let not_found = self.asm.new_label();
         self.asm.bind(loop_start);
         self.asm.branch(not_found, BranchKind::CompareZero(Reg::X2));
-        self.asm.ldr_imm(Reg::X3, Reg::X2, 0);
+        self.asm.ldr_imm(Reg::X3, Reg::X2, 0); // boxed element pointer
+        self.asm.ldr_imm(Reg::X3, Reg::X3, 0); // unbox to the raw scalar
         self.asm.cmp_reg(Reg::X3, Reg::X1);
         self.asm.branch(found, BranchKind::Conditional(Cond::Eq));
         self.asm.ldr_imm(Reg::X2, Reg::X2, 8);
@@ -3247,12 +3276,21 @@ impl Emitter {
         self.asm.branch(done, BranchKind::CompareZero(Reg::X0));
         self.asm.ldr_imm(Reg::X2, Reg::X0, 0); // head
         self.asm.ldr_imm(Reg::X0, Reg::X0, 8); // advance input
-        // Build [head][acc]; emit_alloc preserves x0-x5 across grow.
-        self.asm.mov_imm64(Reg::X4, 16);
-        self.emit_alloc();
-        self.asm.str_imm(Reg::X2, Reg::X5, 0); // head
-        self.asm.str_imm(Reg::X1, Reg::X5, 8); // next = acc
-        self.asm.mov_reg(Reg::X1, Reg::X5); // acc = new cell
+        // Build a GC-shaped [header][head][acc] cell. emit_alloc preserves
+        // x0-x5 across grow, so cursor (x0), acc (x1) and head (x2)
+        // survive; x3 is a free scratch. The head copied from the source
+        // cell is already boxed/a pointer, so it needs no re-boxing -- only
+        // the 16-byte header and POINTER_RECORD tag are added.
+        self.asm.mov_imm64(Reg::X4, 32);
+        self.emit_alloc(); // x5 = block base
+        self.asm.mov_imm64(Reg::X3, 32);
+        self.asm.str_imm(Reg::X3, Reg::X5, 0); // [block] = size|mark(0)
+        self.asm
+            .mov_imm64(Reg::X3, crate::gc_layout::GC_TYPE_POINTER_RECORD);
+        self.asm.str_imm(Reg::X3, Reg::X5, 8); // [block + 8] = type_tag
+        self.asm.str_imm(Reg::X2, Reg::X5, 16); // [cell + 0] = head
+        self.asm.str_imm(Reg::X1, Reg::X5, 24); // [cell + 8] = next = acc
+        self.asm.add_reg_imm(Reg::X1, Reg::X5, 16); // acc = user ptr
         self.asm.branch(loop_start, BranchKind::Unconditional);
         self.asm.bind(done);
         self.asm.mov_reg(Reg::X0, Reg::X1);
@@ -3342,6 +3380,11 @@ impl Emitter {
         self.asm.pop(Reg::X3);
         self.asm.push(Reg::X3);
         self.asm.ldr_imm(Reg::X0, Reg::X3, 0);
+        // Scalar elements are boxed in the cell; unbox before printing
+        // (string elements are already the pointer).
+        if is_boxed_scalar(elem_value_type(elem)) {
+            self.emit_unbox_scalar();
+        }
         self.emit_print_elem(elem);
         self.asm.pop(Reg::X3);
         self.asm.ldr_imm(Reg::X3, Reg::X3, 8);
@@ -3594,6 +3637,11 @@ impl Emitter {
                 self.asm.emit_exit(1);
                 self.asm.bind(non_empty);
                 self.asm.ldr_imm(Reg::X0, Reg::X0, 0);
+                // Scalar heads are boxed in the cell; unbox before use
+                // (string/list/record heads are already the pointer).
+                if is_boxed_scalar(elem_value_type(elem)) {
+                    self.emit_unbox_scalar();
+                }
                 Ok(Some(elem_value_type(elem)))
             }
             ("tail", 1) => {

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -3986,11 +3986,15 @@ pub(crate) fn emit_macho_program(
     }
 
     emitter.asm.finish();
+    // No writable data segment yet: the GC's __bss cells arrive with the
+    // data-label machinery (M3) and the GC runtime wiring (M5). Until
+    // then pass 0 so the image is byte-for-byte the pre-GC layout.
     Ok(macho::write_executable(
         emitter.asm.code,
         emitter.asm.rodata,
         &emitter.asm.fixups,
         "klassic",
+        0,
     ))
 }
 

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use klassic_span::{Diagnostic, Span};
 use klassic_syntax::{BinaryOp, Expr, StringPart};
 
-use crate::macho::{self, DataFixup};
+use crate::macho::{self, DataFixup, FixupSection};
 
 const SYS_EXIT: u16 = 1;
 const SYS_WRITE: u16 = 4;
@@ -172,6 +172,12 @@ impl Cond {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct Label(usize);
 
+/// Handle to a zero-initialized cell in the writable `__DATA,__bss`
+/// section; the value is the byte offset from the segment base. The
+/// AArch64 analog of the x86-64 backend's data label.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DataLabel(usize);
+
 enum BranchKind {
     /// `b label` — 26-bit signed word offset.
     Unconditional,
@@ -198,6 +204,9 @@ struct Assembler {
     fixups: Vec<DataFixup>,
     labels: Vec<Option<usize>>,
     branches: Vec<BranchFixup>,
+    /// Total bytes reserved in `__DATA,__bss` (the GC's zero-init cells).
+    /// Zero for pre-GC programs, so no writable segment is emitted.
+    bss_len: usize,
 }
 
 impl Assembler {
@@ -440,6 +449,39 @@ impl Assembler {
             adrp_offset,
             add_offset,
             data_offset,
+            section: FixupSection::Rodata,
+        });
+    }
+
+    /// Reserve `count` zero-initialized 8-byte cells in the writable
+    /// `__DATA,__bss` section and return a handle to the first. The GC's
+    /// mutable globals (heap pointers, phase, mark worklist, region
+    /// tables, counters, ...) live here — the AArch64 analog of the
+    /// x86-64 backend's `data_label_with_i64s(&[0; count])`. Inert until
+    /// the GC runtime wiring (M5) reserves and addresses cells.
+    #[allow(dead_code)]
+    fn reserve_data_cells(&mut self, count: usize) -> DataLabel {
+        let label = DataLabel(self.bss_len);
+        self.bss_len += count * 8;
+        label
+    }
+
+    /// `adrp xd, <page>` + `add xd, xd, #<pageoff>` addressing a cell in
+    /// `__DATA,__bss`; the immediates are zero placeholders patched by the
+    /// Mach-O writer against the segment vmaddr once the layout is final.
+    /// The GC port lowers `mov_data_addr` here.
+    #[allow(dead_code)]
+    fn load_data_address(&mut self, reg: Reg, label: DataLabel) {
+        let adrp_offset = self.code.len();
+        self.word(0x9000_0000 | reg as u32);
+        let add_offset = self.code.len();
+        let rn = reg as u32;
+        self.word(0x9100_0000 | (rn << 5) | rn);
+        self.fixups.push(DataFixup {
+            adrp_offset,
+            add_offset,
+            data_offset: label.0,
+            section: FixupSection::Data,
         });
     }
 
@@ -3986,15 +4028,17 @@ pub(crate) fn emit_macho_program(
     }
 
     emitter.asm.finish();
-    // No writable data segment yet: the GC's __bss cells arrive with the
-    // data-label machinery (M3) and the GC runtime wiring (M5). Until
-    // then pass 0 so the image is byte-for-byte the pre-GC layout.
+    // `bss_len` is 0 for every program today (no codegen reserves GC
+    // cells until M5), so no writable segment is emitted and the image
+    // stays byte-for-byte the pre-GC layout. The data-label machinery
+    // (reserve_data_cells / load_data_address) is wired to it and ready.
+    let bss_len = emitter.asm.bss_len as u64;
     Ok(macho::write_executable(
         emitter.asm.code,
         emitter.asm.rodata,
         &emitter.asm.fixups,
         "klassic",
-        0,
+        bss_len,
     ))
 }
 

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -4497,6 +4497,106 @@ struct GcState {
 }
 
 impl Emitter {
+    /// Store a register's value into a single-qword GC `__bss` cell,
+    /// using X10 as the address scratch.
+    fn emit_store_gc_cell_reg(&mut self, cell: PortDataAddr, value: Reg) {
+        let PortDataAddr::Bss(label) = cell else {
+            unreachable!("GC cells live in __bss");
+        };
+        self.asm.load_data_address(Reg::X10, label);
+        self.asm.str_imm(value, Reg::X10, 0);
+    }
+
+    /// Store a 64-bit immediate into a single-qword GC `__bss` cell
+    /// (X11 holds the value, X10 the address).
+    fn emit_store_gc_cell_imm(&mut self, cell: PortDataAddr, value: u64) {
+        self.asm.mov_imm64(Reg::X11, value);
+        self.emit_store_gc_cell_reg(cell, Reg::X11);
+    }
+
+    /// M7 (infra): bring the GC region heap online at startup -- the
+    /// AArch64 mirror of the x86-64 `emit_initialize_gc_heap`. mmaps the
+    /// whole region reservation (demand-paged) and the runtime tables
+    /// (shadow stack + mark worklist, zero-filled by mmap), then installs
+    /// region-0 metadata. Runs before the bump heap is armed; while
+    /// allocations still bump (pre go-live) these cells are written but
+    /// unread, so this only exercises the startup path.
+    fn emit_gc_init_heap(&mut self, gc: &GcState) {
+        // mmap(NULL, GC_RESERVE_BYTES, RW, MAP_ANON|PRIVATE, -1, 0).
+        self.asm.mov_imm64(Reg::X0, 0);
+        self.asm
+            .mov_imm64(Reg::X1, crate::gc_layout::GC_RESERVE_BYTES);
+        self.asm.mov_imm64(Reg::X2, PROT_READ_WRITE);
+        self.asm.mov_imm64(Reg::X3, MMAP_ANON_PRIVATE);
+        self.asm.mov_imm64(Reg::X4, u64::MAX); // fd = -1
+        self.asm.mov_imm64(Reg::X5, 0);
+        self.asm.mov_imm64(Reg::X16, u64::from(SYS_MMAP));
+        self.asm.svc_0x80();
+        self.asm
+            .emit_abort_if_syscall_failed(b"klassic gc: mmap failed\n");
+        // region_base = heap_base = heap_top = region_top[0] = base (x0).
+        self.emit_store_gc_cell_reg(gc.region_base, Reg::X0);
+        self.emit_store_gc_cell_reg(gc.heap_base, Reg::X0);
+        self.emit_store_gc_cell_reg(gc.heap_top, Reg::X0);
+        self.emit_store_gc_cell_reg(gc.region_top, Reg::X0); // element 0
+        // heap_end = base + GC_REGION_SIZE.
+        self.asm
+            .mov_imm64(Reg::X1, crate::gc_layout::GC_REGION_SIZE);
+        self.asm.add_reg(Reg::X2, Reg::X0, Reg::X1);
+        self.emit_store_gc_cell_reg(gc.heap_end, Reg::X2);
+        // free_region_head = 0; committed_count = 1; budget = initial.
+        self.emit_store_gc_cell_imm(gc.free_region_head, 0);
+        self.emit_store_gc_cell_imm(gc.committed_count, 1);
+        self.emit_store_gc_cell_imm(
+            gc.budget_regions,
+            crate::gc_layout::GC_INITIAL_BUDGET_REGIONS,
+        );
+        // mmap(NULL, GC_TABLES_BYTES, ...) for the shadow stack + worklist.
+        self.asm.mov_imm64(Reg::X0, 0);
+        self.asm
+            .mov_imm64(Reg::X1, crate::gc_layout::GC_TABLES_BYTES);
+        self.asm.mov_imm64(Reg::X2, PROT_READ_WRITE);
+        self.asm.mov_imm64(Reg::X3, MMAP_ANON_PRIVATE);
+        self.asm.mov_imm64(Reg::X4, u64::MAX);
+        self.asm.mov_imm64(Reg::X5, 0);
+        self.asm.mov_imm64(Reg::X16, u64::from(SYS_MMAP));
+        self.asm.svc_0x80();
+        self.asm
+            .emit_abort_if_syscall_failed(b"klassic gc: mmap failed\n");
+        // shadow_stack = tables base; mark_worklist = base + SHADOW_LEN*8.
+        self.emit_store_gc_cell_reg(gc.shadow_stack, Reg::X0);
+        self.asm
+            .mov_imm64(Reg::X1, (crate::gc_layout::GC_SHADOW_STACK_LEN * 8) as u64);
+        self.asm.add_reg(Reg::X0, Reg::X0, Reg::X1);
+        self.emit_store_gc_cell_reg(gc.mark_worklist, Reg::X0);
+    }
+
+    /// M7 (infra): seed the callee-saved colour registers (X24 strip mask,
+    /// X25 good colour, X26 bad-colour test mask) and the colour/mark
+    /// cells -- the AArch64 mirror of `emit_initialize_color_registers`.
+    /// Non-moving, unpoisoned scheme (evac off): good = M0, bad = M1|R.
+    /// X25/X26 cache the cells; MarkStart reloads them each cycle.
+    fn emit_gc_init_colors(&mut self, gc: &GcState) {
+        self.asm
+            .mov_imm64(Reg::X24, crate::gc_layout::GC_COLOR_STRIP);
+        self.emit_store_gc_cell_imm(gc.good_color, crate::gc_layout::GC_COLOR_M0);
+        self.emit_store_gc_cell_imm(gc.bad_mask, crate::gc_layout::GC_COLOR_BAD_MASK);
+        let PortDataAddr::Bss(good) = gc.good_color else {
+            unreachable!("GC cells live in __bss");
+        };
+        self.asm.load_data_address(Reg::X10, good);
+        self.asm.ldr_imm(Reg::X25, Reg::X10, 0);
+        let PortDataAddr::Bss(bad) = gc.bad_mask else {
+            unreachable!("GC cells live in __bss");
+        };
+        self.asm.load_data_address(Reg::X10, bad);
+        self.asm.ldr_imm(Reg::X26, Reg::X10, 0);
+        // Header-mark parity (nonzero so the first mark isn't a no-op) and
+        // the initial mark colour.
+        self.emit_store_gc_cell_imm(gc.header_mark, crate::gc_layout::GC_HMARK1);
+        self.emit_store_gc_cell_imm(gc.mark_color, crate::gc_layout::GC_COLOR_M1);
+    }
+
     /// Reserve all GC cells (single qwords + the three region arrays) in
     /// `__DATA,__bss`, intern the diagnostic strings, and create the
     /// subroutine labels.
@@ -4914,6 +5014,17 @@ pub(crate) fn emit_macho_program(
     emitter.asm.mov_reg(Reg::X22, Reg::X1);
     emitter.asm.mov_reg(Reg::X23, Reg::X2);
 
+    // M7 (infra): reserve the GC cells/labels and bring the region heap +
+    // colour registers online at startup, before the bump heap is armed.
+    // Allocations still bump below, so the collector stays inert -- this
+    // only exercises the startup mmap/seeding path (validated live on
+    // arm64 CI) ahead of the go-live flip. reserve_gc_state emits no code
+    // (it only reserves __bss cells / rodata / labels), so calling it here
+    // and emitting the routine bodies after main is unchanged.
+    let gc = emitter.reserve_gc_state();
+    emitter.emit_gc_init_heap(&gc);
+    emitter.emit_gc_init_colors(&gc);
+
     // Empty heap: the first allocation's capacity check fails and
     // mmaps the first segment.
     emitter.asm.mov_imm64(Reg::X19, 0);
@@ -4954,14 +5065,13 @@ pub(crate) fn emit_macho_program(
         emitter.emit_heap_grow_routine(label);
     }
 
-    // M5: reserve the GC's __DATA,__bss cells and emit all 24 portable
-    // ZGC runtime routines after the program's exit. Nothing calls
-    // gc_alloc yet (the bump allocator is still live), so this is dead
-    // but linked -- it exercises the __DATA segment, the data fixups, and
-    // the whole PortableAsm lowering end-to-end, and must encode validly.
-    // The go-live (M7) routes the mutator through gc_alloc and adds the
-    // startup mmap/colour seeding.
-    let gc = emitter.reserve_gc_state();
+    // M5: emit all 24 portable ZGC runtime routines after the program's
+    // exit (the cells were reserved and the region heap/colour registers
+    // seeded at startup above). Nothing calls gc_alloc yet (the bump
+    // allocator is still live), so the routines are dead but linked -- they
+    // exercise the __DATA segment, the data fixups, and the whole
+    // PortableAsm lowering end-to-end, and must encode validly. The go-live
+    // (M7) routes the mutator through gc_alloc and adds roots/barriers.
     emitter.emit_gc_runtime(&gc);
 
     emitter.asm.finish();

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -4295,6 +4295,476 @@ fn collect_functions(expr: &Expr, emitter: &mut Emitter) {
 /// Compile the whole program to a signed Mach-O arm64 executable.
 /// `lowered_enums` names the enums `desugar_enums` already lowered to
 /// `__gc_record` shape.
+/// Every data cell, diagnostic string, and subroutine label the portable
+/// ZGC needs, reserved in one pass and threaded into the `emit_gc_*`
+/// calls. Mirrors the x86-64 backend's GC field set (lib.rs) one-to-one.
+/// The single-qword cells and the three 512-entry region arrays live in
+/// `__DATA,__bss`; the diagnostic strings live in read-only `__const`.
+struct GcState {
+    heap_base: PortDataAddr,
+    heap_top: PortDataAddr,
+    heap_end: PortDataAddr,
+    free_region_head: PortDataAddr,
+    mark_worklist: PortDataAddr,
+    mark_worklist_top: PortDataAddr,
+    shadow_stack: PortDataAddr,
+    shadow_stack_top: PortDataAddr,
+    region_base: PortDataAddr,
+    committed_count: PortDataAddr,
+    budget_regions: PortDataAddr,
+    phase: PortDataAddr,
+    good_color: PortDataAddr,
+    bad_mask: PortDataAddr,
+    bytes_since_cycle: PortDataAddr,
+    bytes_since_quantum: PortDataAddr,
+    stw_fallback_pending: PortDataAddr,
+    stw_fallbacks: PortDataAddr,
+    header_mark: PortDataAddr,
+    mark_color: PortDataAddr,
+    evac_region_base: PortDataAddr,
+    evac_top: PortDataAddr,
+    evac_end: PortDataAddr,
+    reloc_scan_idx: PortDataAddr,
+    reloc_block: PortDataAddr,
+    relocated_count: PortDataAddr,
+    collect_counter: PortDataAddr,
+    alloc_count: PortDataAddr,
+    bytes_allocated: PortDataAddr,
+    pause_max_ns: PortDataAddr,
+    pause_total_ns: PortDataAddr,
+    pause_start_ns: PortDataAddr,
+    region_top: PortDataAddr,
+    region_live: PortDataAddr,
+    region_fromspace: PortDataAddr,
+    oom: (PortDataAddr, usize),
+    worklist_overflow: (PortDataAddr, usize),
+    bounds_error_text: (PortDataAddr, usize),
+    evac_exhausted: (PortDataAddr, usize),
+    evac_oversized: (PortDataAddr, usize),
+    l_alloc: Label,
+    l_collect: Label,
+    l_mark_roots: Label,
+    l_trace: Label,
+    l_sweep: Label,
+    l_clear_all_marks: Label,
+    l_stw_mark_complete: Label,
+    l_drain: Label,
+    l_evacuate: Label,
+    l_acquire_evac_region: Label,
+    l_relocate_start: Label,
+    l_relocate_quantum: Label,
+    l_relocate_finish: Label,
+    l_free_ghost_regions: Label,
+    l_relocate_fix_roots: Label,
+    l_mark_start: Label,
+    l_mark_end: Label,
+    l_mark_visit: Label,
+    l_deep_equal: Label,
+    l_load_barrier_slow: Label,
+    l_acquire_region: Label,
+    l_alloc_large: Label,
+    l_grow_budget: Label,
+    l_bounds_error: Label,
+}
+
+impl Emitter {
+    /// Reserve all GC cells (single qwords + the three region arrays) in
+    /// `__DATA,__bss`, intern the diagnostic strings, and create the
+    /// subroutine labels.
+    fn reserve_gc_state(&mut self) -> GcState {
+        const REGIONS: usize = crate::gc_layout::GC_RESERVE_REGIONS as usize;
+        let mut cell = || PortDataAddr::Bss(self.asm.reserve_data_cells(1));
+        let heap_base = cell();
+        let heap_top = cell();
+        let heap_end = cell();
+        let free_region_head = cell();
+        let mark_worklist = cell();
+        let mark_worklist_top = cell();
+        let shadow_stack = cell();
+        let shadow_stack_top = cell();
+        let region_base = cell();
+        let committed_count = cell();
+        let budget_regions = cell();
+        let phase = cell();
+        let good_color = cell();
+        let bad_mask = cell();
+        let bytes_since_cycle = cell();
+        let bytes_since_quantum = cell();
+        let stw_fallback_pending = cell();
+        let stw_fallbacks = cell();
+        let header_mark = cell();
+        let mark_color = cell();
+        let evac_region_base = cell();
+        let evac_top = cell();
+        let evac_end = cell();
+        let reloc_scan_idx = cell();
+        let reloc_block = cell();
+        let relocated_count = cell();
+        let collect_counter = cell();
+        let alloc_count = cell();
+        let bytes_allocated = cell();
+        let pause_max_ns = cell();
+        let pause_total_ns = cell();
+        let pause_start_ns = cell();
+        let region_top = PortDataAddr::Bss(self.asm.reserve_data_cells(REGIONS));
+        let region_live = PortDataAddr::Bss(self.asm.reserve_data_cells(REGIONS));
+        let region_fromspace = PortDataAddr::Bss(self.asm.reserve_data_cells(REGIONS));
+
+        let mut string = |bytes: &[u8]| {
+            (
+                PortDataAddr::Rodata(self.asm.intern_rodata(bytes)),
+                bytes.len(),
+            )
+        };
+        let oom = string(b"klassic gc: out of memory\n");
+        let worklist_overflow = string(b"klassic gc: mark worklist overflow\n");
+        let bounds_error_text = string(b"klassic gc: index out of bounds\n");
+        let evac_exhausted = string(b"klassic gc: evacuation exhausted the heap reservation\n");
+        let evac_oversized = string(b"klassic gc: evacuation object exceeds a region\n");
+
+        GcState {
+            heap_base,
+            heap_top,
+            heap_end,
+            free_region_head,
+            mark_worklist,
+            mark_worklist_top,
+            shadow_stack,
+            shadow_stack_top,
+            region_base,
+            committed_count,
+            budget_regions,
+            phase,
+            good_color,
+            bad_mask,
+            bytes_since_cycle,
+            bytes_since_quantum,
+            stw_fallback_pending,
+            stw_fallbacks,
+            header_mark,
+            mark_color,
+            evac_region_base,
+            evac_top,
+            evac_end,
+            reloc_scan_idx,
+            reloc_block,
+            relocated_count,
+            collect_counter,
+            alloc_count,
+            bytes_allocated,
+            pause_max_ns,
+            pause_total_ns,
+            pause_start_ns,
+            region_top,
+            region_live,
+            region_fromspace,
+            oom,
+            worklist_overflow,
+            bounds_error_text,
+            evac_exhausted,
+            evac_oversized,
+            l_alloc: self.asm.new_label(),
+            l_collect: self.asm.new_label(),
+            l_mark_roots: self.asm.new_label(),
+            l_trace: self.asm.new_label(),
+            l_sweep: self.asm.new_label(),
+            l_clear_all_marks: self.asm.new_label(),
+            l_stw_mark_complete: self.asm.new_label(),
+            l_drain: self.asm.new_label(),
+            l_evacuate: self.asm.new_label(),
+            l_acquire_evac_region: self.asm.new_label(),
+            l_relocate_start: self.asm.new_label(),
+            l_relocate_quantum: self.asm.new_label(),
+            l_relocate_finish: self.asm.new_label(),
+            l_free_ghost_regions: self.asm.new_label(),
+            l_relocate_fix_roots: self.asm.new_label(),
+            l_mark_start: self.asm.new_label(),
+            l_mark_end: self.asm.new_label(),
+            l_mark_visit: self.asm.new_label(),
+            l_deep_equal: self.asm.new_label(),
+            l_load_barrier_slow: self.asm.new_label(),
+            l_acquire_region: self.asm.new_label(),
+            l_alloc_large: self.asm.new_label(),
+            l_grow_budget: self.asm.new_label(),
+            l_bounds_error: self.asm.new_label(),
+        }
+    }
+
+    /// Emit all 24 portable GC runtime routines into the code buffer.
+    /// M5: evacuation is off (non-moving) and pause timing is disabled
+    /// (`plat_read_monotonic_ns` is a stub); the `--gc-log`/`--gc-stress`
+    /// flags are threaded in at go-live (M7). Emitted after the program
+    /// body and its exit, so the routines are reachable only once the
+    /// mutator calls `gc_alloc` (M7) -- dead but linked until then.
+    fn emit_gc_runtime(&mut self, gc: &GcState) {
+        use portable_asm as pa;
+        let asm = &mut self.asm;
+        let evac_off = true;
+        let poison = false;
+        let timing = false;
+        let stderr_fd = 2u64;
+        let tables = pa::RegionTables {
+            heap_base: gc.heap_base,
+            heap_top: gc.heap_top,
+            region_base: gc.region_base,
+            region_top: gc.region_top,
+            committed_count: gc.committed_count,
+            region_fromspace: gc.region_fromspace,
+        };
+        let pause = pa::PauseCells {
+            start_ns: gc.pause_start_ns,
+            total_ns: gc.pause_total_ns,
+            max_ns: gc.pause_max_ns,
+        };
+
+        pa::emit_gc_mark_visit(
+            asm,
+            gc.l_mark_visit,
+            pa::MarkWorklist {
+                header_mark: gc.header_mark,
+                worklist: gc.mark_worklist,
+                worklist_top: gc.mark_worklist_top,
+                stw_fallback_pending: gc.stw_fallback_pending,
+            },
+        );
+        pa::emit_gc_deep_equal(asm, gc.l_deep_equal);
+        pa::emit_gc_load_barrier_slow(
+            asm,
+            gc.l_load_barrier_slow,
+            gc.phase,
+            gc.region_base,
+            gc.region_fromspace,
+            gc.l_evacuate,
+            gc.l_mark_visit,
+        );
+        pa::emit_gc_alloc(
+            asm,
+            gc.l_alloc,
+            pa::AllocCells {
+                phase: gc.phase,
+                bytes_since_cycle: gc.bytes_since_cycle,
+                budget_regions: gc.budget_regions,
+                bytes_since_quantum: gc.bytes_since_quantum,
+                mark_worklist_top: gc.mark_worklist_top,
+                header_mark: gc.header_mark,
+                alloc_count: gc.alloc_count,
+                bytes_allocated: gc.bytes_allocated,
+                heap_top: gc.heap_top,
+                heap_end: gc.heap_end,
+                oom_text: gc.oom.0,
+            },
+            pa::AllocTargets {
+                mark_start: gc.l_mark_start,
+                trace: gc.l_trace,
+                mark_end: gc.l_mark_end,
+                relocate_quantum: gc.l_relocate_quantum,
+                collect: gc.l_collect,
+                grow_budget: gc.l_grow_budget,
+                acquire_region: gc.l_acquire_region,
+                alloc_large: gc.l_alloc_large,
+            },
+            pa::AllocFlags {
+                stress: false,
+                log: false,
+            },
+            gc.oom.1,
+            stderr_fd,
+        );
+        pa::emit_gc_collect(
+            asm,
+            gc.l_collect,
+            timing,
+            pause,
+            gc.phase,
+            pa::CollectTargets {
+                stw_mark_complete: gc.l_stw_mark_complete,
+                free_ghost_regions: gc.l_free_ghost_regions,
+                sweep: gc.l_sweep,
+                relocate_quantum: gc.l_relocate_quantum,
+                mark_end: gc.l_mark_end,
+            },
+        );
+        pa::emit_gc_mark_roots(
+            asm,
+            gc.l_mark_roots,
+            gc.shadow_stack,
+            gc.shadow_stack_top,
+            gc.l_mark_visit,
+        );
+        pa::emit_gc_trace(
+            asm,
+            gc.l_trace,
+            gc.mark_worklist_top,
+            gc.mark_worklist,
+            gc.l_mark_visit,
+        );
+        pa::emit_gc_sweep(
+            asm,
+            gc.l_sweep,
+            tables,
+            gc.collect_counter,
+            gc.free_region_head,
+            gc.header_mark,
+            gc.region_live,
+        );
+        pa::emit_gc_clear_all_marks(asm, gc.l_clear_all_marks, tables);
+        pa::emit_gc_stw_mark_complete(
+            asm,
+            gc.l_stw_mark_complete,
+            pa::StwMarkTargets {
+                clear_all_marks: gc.l_clear_all_marks,
+                mark_roots: gc.l_mark_roots,
+                drain: gc.l_drain,
+            },
+            gc.stw_fallback_pending,
+            gc.mark_worklist_top,
+            gc.worklist_overflow.0,
+            gc.worklist_overflow.1,
+        );
+        pa::emit_gc_drain(asm, gc.l_drain, gc.l_trace, gc.mark_worklist_top);
+        pa::emit_gc_evacuate(
+            asm,
+            gc.l_evacuate,
+            pa::EvacBumpCells {
+                evac_top: gc.evac_top,
+                evac_end: gc.evac_end,
+                relocated_count: gc.relocated_count,
+            },
+            gc.l_acquire_evac_region,
+            gc.evac_oversized.0,
+            gc.evac_oversized.1,
+            stderr_fd,
+        );
+        pa::emit_gc_acquire_evac_region(
+            asm,
+            gc.l_acquire_evac_region,
+            pa::EvacRegionCells {
+                evac_region_base: gc.evac_region_base,
+                evac_top: gc.evac_top,
+                evac_end: gc.evac_end,
+                region_base: gc.region_base,
+                region_top: gc.region_top,
+                committed_count: gc.committed_count,
+                free_region_head: gc.free_region_head,
+            },
+            gc.evac_exhausted.0,
+            gc.evac_exhausted.1,
+            stderr_fd,
+        );
+        pa::emit_gc_relocate_start(
+            asm,
+            gc.l_relocate_start,
+            pa::RelocateStartCells {
+                good_color: gc.good_color,
+                bad_mask: gc.bad_mask,
+                free_region_head: gc.free_region_head,
+                budget_regions: gc.budget_regions,
+                committed_count: gc.committed_count,
+                heap_base: gc.heap_base,
+                region_base: gc.region_base,
+                region_top: gc.region_top,
+                region_live: gc.region_live,
+                region_fromspace: gc.region_fromspace,
+                evac_region_base: gc.evac_region_base,
+                evac_top: gc.evac_top,
+                evac_end: gc.evac_end,
+                reloc_scan_idx: gc.reloc_scan_idx,
+                reloc_block: gc.reloc_block,
+                bytes_since_quantum: gc.bytes_since_quantum,
+                phase: gc.phase,
+                bytes_since_cycle: gc.bytes_since_cycle,
+            },
+            gc.l_relocate_fix_roots,
+            evac_off,
+            poison,
+        );
+        pa::emit_gc_relocate_quantum(
+            asm,
+            gc.l_relocate_quantum,
+            tables,
+            pa::RelocQuantumCells {
+                reloc_scan_idx: gc.reloc_scan_idx,
+                reloc_block: gc.reloc_block,
+                header_mark: gc.header_mark,
+            },
+            gc.l_evacuate,
+            gc.l_relocate_finish,
+        );
+        pa::emit_gc_relocate_finish(
+            asm,
+            gc.l_relocate_finish,
+            tables,
+            gc.evac_region_base,
+            gc.evac_top,
+            gc.phase,
+            gc.bytes_since_cycle,
+        );
+        pa::emit_gc_free_ghost_regions(
+            asm,
+            gc.l_free_ghost_regions,
+            tables,
+            gc.free_region_head,
+            gc.region_live,
+        );
+        pa::emit_gc_relocate_fix_roots(
+            asm,
+            gc.l_relocate_fix_roots,
+            gc.shadow_stack,
+            gc.shadow_stack_top,
+            gc.region_base,
+            gc.region_fromspace,
+            gc.l_evacuate,
+        );
+        pa::emit_gc_mark_start(
+            asm,
+            gc.l_mark_start,
+            timing,
+            pause,
+            pa::MarkStartCells {
+                header_mark: gc.header_mark,
+                good_color: gc.good_color,
+                bad_mask: gc.bad_mask,
+                mark_color: gc.mark_color,
+                worklist_top: gc.mark_worklist_top,
+                phase: gc.phase,
+            },
+            gc.l_mark_roots,
+            pa::MarkColorMode { evac_off, poison },
+        );
+        pa::emit_gc_mark_end(
+            asm,
+            gc.l_mark_end,
+            timing,
+            pause,
+            pa::MarkEndTargets {
+                drain: gc.l_drain,
+                stw_mark_complete: gc.l_stw_mark_complete,
+                free_ghost_regions: gc.l_free_ghost_regions,
+                sweep: gc.l_sweep,
+                relocate_start: gc.l_relocate_start,
+            },
+            gc.stw_fallback_pending,
+            gc.stw_fallbacks,
+        );
+        pa::emit_gc_acquire_region(
+            asm,
+            gc.l_acquire_region,
+            tables,
+            gc.free_region_head,
+            gc.budget_regions,
+            gc.heap_end,
+        );
+        pa::emit_gc_alloc_large(asm, gc.l_alloc_large, tables, gc.budget_regions);
+        pa::emit_gc_grow_budget(asm, gc.l_grow_budget, gc.committed_count, gc.budget_regions);
+        pa::emit_gc_bounds_error(
+            asm,
+            gc.l_bounds_error,
+            gc.bounds_error_text.0,
+            gc.bounds_error_text.1,
+        );
+    }
+}
+
 pub(crate) fn emit_macho_program(
     expr: &Expr,
     lowered_enums: std::collections::HashSet<String>,
@@ -4354,6 +4824,16 @@ pub(crate) fn emit_macho_program(
     if let Some(label) = emitter.heap_grow_label {
         emitter.emit_heap_grow_routine(label);
     }
+
+    // M5: reserve the GC's __DATA,__bss cells and emit all 24 portable
+    // ZGC runtime routines after the program's exit. Nothing calls
+    // gc_alloc yet (the bump allocator is still live), so this is dead
+    // but linked -- it exercises the __DATA segment, the data fixups, and
+    // the whole PortableAsm lowering end-to-end, and must encode validly.
+    // The go-live (M7) routes the mutator through gc_alloc and adds the
+    // startup mmap/colour seeding.
+    let gc = emitter.reserve_gc_state();
+    emitter.emit_gc_runtime(&gc);
 
     emitter.asm.finish();
     // `bss_len` is 0 for every program today (no codegen reserves GC

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -1230,6 +1230,14 @@ struct RecordInfo {
 }
 
 /// The value type of one list element of element type `elem`.
+/// A scalar value held directly in a GP register (not a heap pointer).
+/// The GC's uniform pointer representation requires these to be boxed
+/// into a single-slot RAW_BYTES object when stored in a POINTER_RECORD
+/// slot (a record field or a cons-cell value), and unboxed on read.
+fn is_boxed_scalar(ty: ValueType) -> bool {
+    matches!(ty, ValueType::Int | ValueType::Double | ValueType::Bool)
+}
+
 fn elem_value_type(elem: ListElem) -> ValueType {
     match elem {
         ListElem::Int => ValueType::Int,
@@ -1465,6 +1473,9 @@ impl Emitter {
                     if !assignable(ty, *expected) {
                         return Err(unsupported(argument.span(), "a record field of this type"));
                     }
+                    if is_boxed_scalar(ty) {
+                        self.emit_box_scalar();
+                    }
                     self.asm.push(Reg::X0);
                 }
                 self.emit_record_object(arguments.len());
@@ -1480,6 +1491,9 @@ impl Emitter {
                         return Err(unsupported(value.span(), "a record field of this type"));
                     }
                     typed.push((field_name.clone(), ty));
+                    if is_boxed_scalar(ty) {
+                        self.emit_box_scalar();
+                    }
                     self.asm.push(Reg::X0);
                 }
                 let count = fields.len();
@@ -1506,6 +1520,9 @@ impl Emitter {
                 };
                 let ty = info.fields[position].1;
                 self.asm.ldr_imm(Reg::X0, Reg::X0, (position * 8) as u32);
+                if is_boxed_scalar(ty) {
+                    self.emit_unbox_scalar();
+                }
                 Ok(ty)
             }
             Expr::Call {
@@ -2132,6 +2149,49 @@ impl Emitter {
         self.asm.bind(fits);
         self.asm.mov_reg(Reg::X5, Reg::X19);
         self.asm.add_reg(Reg::X19, Reg::X19, Reg::X4);
+    }
+
+    /// Allocate a GC-shaped heap object: a 16-byte header
+    /// `[size|mark][type_tag]` followed by `words` 8-byte payload slots.
+    /// Bumps the allocator, writes the header, and leaves the *user*
+    /// pointer (block + 16) in x0 -- so every existing `[x0 + off]`
+    /// payload access is unchanged. `size` is the 16-aligned block size;
+    /// its low 4 bits are free for the collector's mark/forward bits (0
+    /// here). The tag distinguishes RAW_BYTES (no inner pointers) from
+    /// POINTER_RECORD (every payload slot a heap pointer), so the
+    /// collector -- once live (M7) -- traces only the latter.
+    ///
+    /// M6: objects are laid out GC-shaped while the bump allocator is
+    /// still live and the collector is still dead, so this changes only
+    /// the object representation, not behavior -- the CI eval-differential
+    /// confirms each conversion is semantics-preserving.
+    fn emit_gc_alloc_object(&mut self, words: usize, tag: u64) {
+        let block = (16 + words * 8).div_ceil(16) * 16;
+        self.asm.mov_imm64(Reg::X4, block as u64);
+        self.emit_alloc(); // block base in x5
+        self.asm.mov_imm64(Reg::X1, block as u64);
+        self.asm.str_imm(Reg::X1, Reg::X5, 0); // [block] = size|mark(0)
+        self.asm.mov_imm64(Reg::X1, tag);
+        self.asm.str_imm(Reg::X1, Reg::X5, 8); // [block+8] = type_tag
+        self.asm.add_reg_imm(Reg::X0, Reg::X5, 16); // x0 = user pointer
+    }
+
+    /// Box a scalar (in x0) into its own single-slot `RAW_BYTES` object,
+    /// leaving the box's user pointer in x0. Every heap slot of a
+    /// `POINTER_RECORD` must be a pointer, so scalar record fields and
+    /// list elements are boxed on write and unboxed on read (the uniform
+    /// representation the shared enum lowering already uses).
+    fn emit_box_scalar(&mut self) {
+        self.asm.push(Reg::X0); // preserve the scalar across the alloc
+        self.emit_gc_alloc_object(1, crate::gc_layout::GC_TYPE_RAW_BYTES);
+        self.asm.pop(Reg::X1);
+        self.asm.str_imm(Reg::X1, Reg::X0, 0); // [box] = scalar
+    }
+
+    /// Unbox a scalar: load it from the single-slot box whose user
+    /// pointer is in x0.
+    fn emit_unbox_scalar(&mut self) {
+        self.asm.ldr_imm(Reg::X0, Reg::X0, 0);
     }
 
     /// Copy `[count]` bytes between the byte pointers in `src`/`dst`;
@@ -2990,13 +3050,16 @@ impl Emitter {
     /// Build a record object from `count` field values pushed onto
     /// the machine stack in declaration order → object pointer in x0.
     fn emit_record_object(&mut self, count: usize) {
-        self.asm.mov_imm64(Reg::X4, (count * 8) as u64);
-        self.emit_alloc();
+        // M6: a GC-shaped POINTER_RECORD -- every field is a heap pointer
+        // (scalar fields were boxed by the caller as they were evaluated),
+        // so the collector can trace the payload uniformly. The 16-byte
+        // header shifts the user pointer to block + 16, but fields still
+        // live at [user_ptr + position*8], so field access is unchanged.
+        self.emit_gc_alloc_object(count, crate::gc_layout::GC_TYPE_POINTER_RECORD); // x0 = user ptr
         for position in (0..count).rev() {
             self.asm.pop(Reg::X1);
-            self.asm.str_imm(Reg::X1, Reg::X5, (position * 8) as u32);
+            self.asm.str_imm(Reg::X1, Reg::X0, (position * 8) as u32);
         }
-        self.asm.mov_reg(Reg::X0, Reg::X5);
     }
 
     /// Prepend a cons cell: head value on top of the machine stack,
@@ -3253,6 +3316,11 @@ impl Emitter {
             self.asm.pop(Reg::X0);
             self.asm.push(Reg::X0);
             self.asm.ldr_imm(Reg::X0, Reg::X0, (position * 8) as u32);
+            // Scalar fields are boxed in the POINTER_RECORD; unbox before
+            // printing (string fields are already the pointer).
+            if is_boxed_scalar(*ty) {
+                self.emit_unbox_scalar();
+            }
             self.emit_print_elem(list_elem_of(*ty).expect("checked above"));
         }
         self.asm.pop(Reg::X0); // discard the saved object

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -136,13 +136,22 @@ const FP: u32 = 29;
 enum Cond {
     Eq = 0,
     Ne = 1,
+    /// Unsigned "higher or same" (carry set). Also the GC port's
+    /// `AboveOrEqual`. Same encoding as ARM `CS`. Inert until the
+    /// PortableAsm condition mapping (M4) constructs it.
+    #[allow(dead_code)]
+    Hs = 2,
     /// Carry clear. Darwin's `svc #0x80` convention signals a
     /// *successful* syscall this way (carry set = failure, x0 holds
     /// the positive errno) — the mirror image of Linux's
-    /// negative-rax convention.
+    /// negative-rax convention. Also the GC port's unsigned `Below`.
     Cc = 3,
     /// After `fcmp`: strictly less, unordered fails — the float `<`.
     Mi = 4,
+    /// Unsigned "higher" (strictly greater). The GC port's `Above`.
+    /// Inert until the PortableAsm condition mapping (M4).
+    #[allow(dead_code)]
+    Hi = 8,
     /// After `fcmp`: less-or-equal, unordered fails — the float `<=`.
     Ls = 9,
     Ge = 10,
@@ -304,6 +313,39 @@ impl Assembler {
         self.word(0xeb00_001f | ((rhs as u32) << 16) | ((lhs as u32) << 5));
     }
 
+    // The logical-register and unscaled load/store primitives below are
+    // added for the AArch64 GC port and stay inert (dead code) until the
+    // PortableAsm impl (M4) lowers `and/or/xor/test_reg_reg`,
+    // `load/store_ptr_disp32`, and `bt_reg_imm8` onto them.
+
+    /// `and xd, xn, xm` (logical AND, shifted register, shift 0).
+    #[allow(dead_code)]
+    fn and_reg(&mut self, dst: Reg, lhs: Reg, rhs: Reg) {
+        self.word(0x8a00_0000 | ((rhs as u32) << 16) | ((lhs as u32) << 5) | dst as u32);
+    }
+
+    /// `orr xd, xn, xm` (logical OR). `mov xd, xm` is the `xn = xzr` case.
+    #[allow(dead_code)]
+    fn orr_reg(&mut self, dst: Reg, lhs: Reg, rhs: Reg) {
+        self.word(0xaa00_0000 | ((rhs as u32) << 16) | ((lhs as u32) << 5) | dst as u32);
+    }
+
+    /// `eor xd, xn, xm` (logical XOR).
+    #[allow(dead_code)]
+    fn eor_reg(&mut self, dst: Reg, lhs: Reg, rhs: Reg) {
+        self.word(0xca00_0000 | ((rhs as u32) << 16) | ((lhs as u32) << 5) | dst as u32);
+    }
+
+    /// `tst xn, xm` (ands xzr, xn, xm) — flag-setting AND that discards
+    /// its result, setting Z = ((xn & xm) == 0). The GC port lowers
+    /// `test_reg_reg` here, and its bit-test to `tst xn, scratch` with a
+    /// materialized `1 << bit` mask (avoiding the logical-immediate
+    /// encoder), then remaps the following conditional branch.
+    #[allow(dead_code)]
+    fn tst_reg(&mut self, lhs: Reg, rhs: Reg) {
+        self.word(0xea00_001f | ((rhs as u32) << 16) | ((lhs as u32) << 5));
+    }
+
     /// `cset xd, cond`
     fn cset(&mut self, dst: Reg, cond: Cond) {
         self.word(0x9a9f_07e0 | (cond.inverted_bits() << 12) | dst as u32);
@@ -359,6 +401,25 @@ impl Assembler {
     fn load_local(&mut self, reg: Reg, offset: u32) {
         debug_assert!(offset.is_multiple_of(8) && offset / 8 < 4096);
         self.word(0xf940_0000 | ((offset / 8) << 10) | (FP << 5) | reg as u32);
+    }
+
+    /// `ldur xt, [xn, #simm9]` — unscaled load, signed 9-bit byte offset
+    /// in `-256..=255`. The GC port needs this for the object header's
+    /// `[base-16]` (word0) / `[base-8]` (type tag) accesses, which the
+    /// scaled `ldr` immediate form cannot express (it is non-negative).
+    #[allow(dead_code)]
+    fn ldur(&mut self, reg: Reg, base: Reg, offset: i32) {
+        debug_assert!((-256..=255).contains(&offset));
+        let imm9 = (offset as u32) & 0x1ff;
+        self.word(0xf840_0000 | (imm9 << 12) | ((base as u32) << 5) | reg as u32);
+    }
+
+    /// `stur xt, [xn, #simm9]` — unscaled store, signed 9-bit byte offset.
+    #[allow(dead_code)]
+    fn stur(&mut self, reg: Reg, base: Reg, offset: i32) {
+        debug_assert!((-256..=255).contains(&offset));
+        let imm9 = (offset as u32) & 0x1ff;
+        self.word(0xf800_0000 | (imm9 << 12) | ((base as u32) << 5) | reg as u32);
     }
 
     /// `strb wt, [xn, #-1]!`
@@ -3982,6 +4043,51 @@ mod tests {
                 0xf940_07a2, // ldr x2, [x29, #8]
             ]
         );
+    }
+
+    #[test]
+    fn encodes_gc_port_instructions() {
+        // Golden words generated with keystone-engine (ARM64) and
+        // round-tripped through capstone; see the aarch64 GC port plan.
+        // These primitives are inert until the PortableAsm impl (M4)
+        // references them.
+        let mut asm = Assembler::default();
+        asm.and_reg(Reg::X0, Reg::X1, Reg::X2);
+        asm.orr_reg(Reg::X0, Reg::X1, Reg::X2);
+        asm.eor_reg(Reg::X0, Reg::X1, Reg::X2);
+        asm.tst_reg(Reg::X0, Reg::X1);
+        asm.ldur(Reg::X0, Reg::X7, -16);
+        asm.ldur(Reg::X0, Reg::X7, -8);
+        asm.stur(Reg::X11, Reg::X10, -16);
+        asm.ldur(Reg::X0, Reg::X7, 255);
+        assert_eq!(
+            words(&asm),
+            vec![
+                0x8a02_0020, // and x0, x1, x2
+                0xaa02_0020, // orr x0, x1, x2
+                0xca02_0020, // eor x0, x1, x2
+                0xea01_001f, // tst x0, x1  (ands xzr, x0, x1)
+                0xf85f_00e0, // ldur x0, [x7, #-16]
+                0xf85f_80e0, // ldur x0, [x7, #-8]
+                0xf81f_014b, // stur x11, [x10, #-16]
+                0xf84f_f0e0, // ldur x0, [x7, #255]
+            ]
+        );
+    }
+
+    #[test]
+    fn encodes_unsigned_conditional_branches() {
+        // b.hi (Above) = cond 8, b.hs/b.cs (AboveOrEqual) = cond 2.
+        let mut asm = Assembler::default();
+        let target = asm.new_label();
+        asm.branch(target, BranchKind::Conditional(Cond::Hi));
+        asm.branch(target, BranchKind::Conditional(Cond::Hs));
+        asm.bind(target);
+        asm.finish();
+        let w = words(&asm);
+        // b.cond encodes cond in the low 4 bits; offset patched to +N words.
+        assert_eq!(w[0] & 0xff00_001f, 0x5400_0008); // b.hi
+        assert_eq!(w[1] & 0xff00_001f, 0x5400_0002); // b.hs
     }
 
     #[test]

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -1762,10 +1762,7 @@ impl Emitter {
 
         self.asm.push(Reg::X5); // scratch buffer ptr
         self.asm.push(Reg::X2); // bytes_read
-        self.asm.add_reg_imm(Reg::X4, Reg::X2, 15);
-        self.asm.lsr_imm(Reg::X4, Reg::X4, 3);
-        self.asm.lsl_imm(Reg::X4, Reg::X4, 3);
-        self.emit_alloc(); // x5 = result object
+        self.emit_alloc_raw_string(Reg::X2); // x5 = result object
         self.asm.pop(Reg::X2); // bytes_read
         self.asm.pop(Reg::X6); // scratch buffer ptr
 
@@ -2203,6 +2200,33 @@ impl Emitter {
         self.asm.ldr_imm(Reg::X0, Reg::X0, 0);
     }
 
+    /// Allocate a GC-shaped heap string whose payload is `[len][bytes...]`,
+    /// with the character count in `len` (a caller register that is not x4,
+    /// x5 or x6). Reserves a 16-byte header `[size|mark][RAW_BYTES]` in
+    /// front and leaves the *user* pointer (block + 16) in x5, so callers
+    /// keep writing the length at `[x5 + 0]` and the bytes at `[x5 + 8]`
+    /// exactly as before -- the only visible change is the header the
+    /// collector reads once it goes live (M7). A string carries no inner
+    /// pointers, hence RAW_BYTES. `len` is preserved across the call
+    /// (emit_alloc keeps x0-x5 over a heap grow, and this only writes x4/
+    /// x5/x6).
+    fn emit_alloc_raw_string(&mut self, len: Reg) {
+        // payload = align8(len + 8): the 8-byte length field plus the bytes.
+        self.asm.add_reg_imm(Reg::X4, len, 15);
+        self.asm.lsr_imm(Reg::X4, Reg::X4, 3);
+        self.asm.lsl_imm(Reg::X4, Reg::X4, 3);
+        // block = align16(payload + 16 header).
+        self.asm.add_reg_imm(Reg::X4, Reg::X4, 16 + 15);
+        self.asm.lsr_imm(Reg::X4, Reg::X4, 4);
+        self.asm.lsl_imm(Reg::X4, Reg::X4, 4);
+        self.emit_alloc(); // x5 = block base, x4 = block size preserved
+        self.asm.str_imm(Reg::X4, Reg::X5, 0); // [block] = size|mark(0)
+        self.asm
+            .mov_imm64(Reg::X6, crate::gc_layout::GC_TYPE_RAW_BYTES);
+        self.asm.str_imm(Reg::X6, Reg::X5, 8); // [block + 8] = type_tag
+        self.asm.add_reg_imm(Reg::X5, Reg::X5, 16); // x5 = user pointer
+    }
+
     /// Copy `[count]` bytes between the byte pointers in `src`/`dst`;
     /// `count` reaches zero, `src`/`dst` advance, `scratch` clobbered.
     fn emit_copy_bytes(&mut self, count: Reg, src: Reg, dst: Reg, scratch: Reg) {
@@ -2224,10 +2248,7 @@ impl Emitter {
         self.asm.ldr_imm(Reg::X3, Reg::X1, 0);
         self.asm.add_reg(Reg::X2, Reg::X2, Reg::X3);
         // size = align8(total + 8 header)
-        self.asm.add_reg_imm(Reg::X4, Reg::X2, 15);
-        self.asm.lsr_imm(Reg::X4, Reg::X4, 3);
-        self.asm.lsl_imm(Reg::X4, Reg::X4, 3);
-        self.emit_alloc();
+        self.emit_alloc_raw_string(Reg::X2);
         self.asm.str_imm(Reg::X2, Reg::X5, 0);
         self.asm.add_reg_imm(Reg::X7, Reg::X5, 8);
         self.asm.ldr_imm(Reg::X2, Reg::X0, 0);
@@ -2334,10 +2355,7 @@ impl Emitter {
     fn emit_str_ascii_case(&mut self, to_upper: bool) {
         self.asm.ldr_imm(Reg::X2, Reg::X0, 0);
         self.asm.add_reg_imm(Reg::X3, Reg::X0, 8);
-        self.asm.add_reg_imm(Reg::X4, Reg::X2, 15);
-        self.asm.lsr_imm(Reg::X4, Reg::X4, 3);
-        self.asm.lsl_imm(Reg::X4, Reg::X4, 3);
-        self.emit_alloc();
+        self.emit_alloc_raw_string(Reg::X2);
         self.asm.str_imm(Reg::X2, Reg::X5, 0);
         self.asm.add_reg_imm(Reg::X6, Reg::X5, 8);
         self.asm.mov_reg(Reg::X7, Reg::X2);
@@ -2375,10 +2393,7 @@ impl Emitter {
     fn emit_str_reverse(&mut self) {
         self.asm.ldr_imm(Reg::X2, Reg::X0, 0);
         self.asm.add_reg_imm(Reg::X3, Reg::X0, 8);
-        self.asm.add_reg_imm(Reg::X4, Reg::X2, 15);
-        self.asm.lsr_imm(Reg::X4, Reg::X4, 3);
-        self.asm.lsl_imm(Reg::X4, Reg::X4, 3);
-        self.emit_alloc();
+        self.emit_alloc_raw_string(Reg::X2);
         self.asm.str_imm(Reg::X2, Reg::X5, 0);
         self.asm.add_reg_imm(Reg::X6, Reg::X5, 8);
         self.asm.mov_reg(Reg::X8, Reg::X2);
@@ -2474,10 +2489,7 @@ impl Emitter {
         // and lost it to a heap-grow mmap when the bump allocator's
         // segment was full).
         self.asm.push(Reg::X9);
-        self.asm.add_reg_imm(Reg::X4, Reg::X2, 15);
-        self.asm.lsr_imm(Reg::X4, Reg::X4, 3);
-        self.asm.lsl_imm(Reg::X4, Reg::X4, 3);
-        self.emit_alloc();
+        self.emit_alloc_raw_string(Reg::X2);
         self.asm.pop(Reg::X9);
         self.asm.add_reg(Reg::X6, Reg::X3, Reg::X9);
         self.asm.str_imm(Reg::X2, Reg::X5, 0);
@@ -2525,10 +2537,7 @@ impl Emitter {
         // emit_str_trim fix for why this matters once a heap-grow
         // mmap actually fires).
         self.asm.push(Reg::X9);
-        self.asm.add_reg_imm(Reg::X4, Reg::X2, 15);
-        self.asm.lsr_imm(Reg::X4, Reg::X4, 3);
-        self.asm.lsl_imm(Reg::X4, Reg::X4, 3);
-        self.emit_alloc();
+        self.emit_alloc_raw_string(Reg::X2);
         self.asm.pop(Reg::X9);
 
         self.asm.str_imm(Reg::X2, Reg::X5, 0);
@@ -2660,10 +2669,7 @@ impl Emitter {
 
         self.asm.push(Reg::X6);
         self.asm.push(Reg::X0); // total_content_len
-        self.asm.add_reg_imm(Reg::X4, Reg::X0, 15);
-        self.asm.lsr_imm(Reg::X4, Reg::X4, 3);
-        self.asm.lsl_imm(Reg::X4, Reg::X4, 3);
-        self.emit_alloc(); // x5 = result object
+        self.emit_alloc_raw_string(Reg::X0); // x5 = result object user pointer
         self.asm.pop(Reg::X12); // total_content_len
         self.asm.pop(Reg::X6); // scratch struct ptr
 
@@ -2736,10 +2742,7 @@ impl Emitter {
         self.asm.push(Reg::X12);
         self.asm.push(Reg::X2); // len
         self.asm.push(start);
-        self.asm.add_reg_imm(Reg::X4, Reg::X2, 15);
-        self.asm.lsr_imm(Reg::X4, Reg::X4, 3);
-        self.asm.lsl_imm(Reg::X4, Reg::X4, 3);
-        self.emit_alloc(); // x5 = new segment string object
+        self.emit_alloc_raw_string(Reg::X2); // x5 = new segment string object
         self.asm.pop(Reg::X0); // start offset
         self.asm.pop(Reg::X2); // len
         self.asm.pop(Reg::X12);
@@ -3014,10 +3017,7 @@ impl Emitter {
         self.emit_skip_chars();
         // Slice byte length, then allocate and copy.
         self.asm.sub_reg(Reg::X2, Reg::X3, Reg::X0);
-        self.asm.add_reg_imm(Reg::X4, Reg::X2, 15);
-        self.asm.lsr_imm(Reg::X4, Reg::X4, 3);
-        self.asm.lsl_imm(Reg::X4, Reg::X4, 3);
-        self.emit_alloc();
+        self.emit_alloc_raw_string(Reg::X2);
         self.asm.str_imm(Reg::X2, Reg::X5, 0);
         self.asm.add_reg_imm(Reg::X7, Reg::X5, 8);
         self.emit_copy_bytes(Reg::X2, Reg::X0, Reg::X7, Reg::X3);
@@ -3030,10 +3030,7 @@ impl Emitter {
         self.asm.emit_int_digits(false);
         self.asm.add_reg_sp_imm(Reg::X2, 32);
         self.asm.sub_reg(Reg::X2, Reg::X2, Reg::X1);
-        self.asm.add_reg_imm(Reg::X4, Reg::X2, 15);
-        self.asm.lsr_imm(Reg::X4, Reg::X4, 3);
-        self.asm.lsl_imm(Reg::X4, Reg::X4, 3);
-        self.emit_alloc();
+        self.emit_alloc_raw_string(Reg::X2);
         self.asm.str_imm(Reg::X2, Reg::X5, 0);
         self.asm.add_reg_imm(Reg::X7, Reg::X5, 8);
         self.emit_copy_bytes(Reg::X2, Reg::X1, Reg::X7, Reg::X3);

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -20,6 +20,7 @@ use klassic_span::{Diagnostic, Span};
 use klassic_syntax::{BinaryOp, Expr, StringPart};
 
 use crate::macho::{self, DataFixup, FixupSection};
+use crate::portable_asm;
 
 const SYS_EXIT: u16 = 1;
 const SYS_WRITE: u16 = 4;
@@ -112,6 +113,21 @@ enum Reg {
     X22 = 22,
     /// Callee-saved: `envp`, captured from dyld's `LC_MAIN` entry.
     X23 = 23,
+    /// Callee-saved: GC load-barrier colour-strip mask (`ColorStrip`).
+    /// Seeded once at startup; the portable collector keeps it live.
+    #[allow(dead_code)]
+    X24 = 24,
+    /// Callee-saved: GC current good colour (`GoodColor`).
+    #[allow(dead_code)]
+    X25 = 25,
+    /// Callee-saved: GC bad-colour test mask (`BadMask`).
+    #[allow(dead_code)]
+    X26 = 26,
+    /// The frame pointer, as a base register for the GC's rbp-relative
+    /// frame slots (`[x29, #-offset]`). The rest of the backend addresses
+    /// the frame through the bare `FP` const and `mov_fp_sp`.
+    #[allow(dead_code)]
+    X29 = 29,
 }
 
 /// AAPCS64 integer argument registers, in order.
@@ -207,6 +223,12 @@ struct Assembler {
     /// Total bytes reserved in `__DATA,__bss` (the GC's zero-init cells).
     /// Zero for pre-GC programs, so no writable segment is emitted.
     bss_len: usize,
+    /// Set by the PortableAsm `bt_reg_imm8` lowering (which becomes a
+    /// flag-setting `tst reg, #(1<<bit)` → Z = (bit == 0)); the next
+    /// `jcc_label` consumes it to remap the x86 carry-based condition to
+    /// the AArch64 zero-based one. The GC always emits the branch
+    /// immediately after the bit test.
+    bt_pending: bool,
 }
 
 impl Assembler {
@@ -809,6 +831,312 @@ impl Assembler {
     /// `ret`
     fn ret(&mut self) {
         self.word(0xd65f_03c0);
+    }
+}
+
+/// Address of a datum the portable GC codegen references through
+/// `mov_data_addr`: a byte in read-only `__TEXT,__const` (constants,
+/// diagnostic strings) or a cell in writable `__DATA,__bss` (the
+/// collector's mutable globals). The AArch64 `PortableAsm::DataLabel`.
+#[derive(Clone, Copy)]
+#[allow(dead_code)]
+enum PortDataAddr {
+    Rodata(usize),
+    Bss(DataLabel),
+}
+
+/// Scratch register for immediate materialization and large-displacement
+/// forms. It sits outside the `V0..V11` mapping, so the portable
+/// collector never holds a live value in it.
+const PORT_SCRATCH: Reg = Reg::X10;
+
+/// Map a portable register to its AArch64 home. `V4`/`V5` (the x86 rsp/
+/// rbp roles) are the stack and frame pointers; the frame-shaped methods
+/// handle them inline and never route them through here.
+fn port_reg(r: portable_asm::Reg) -> Reg {
+    use portable_asm::Reg as P;
+    match r {
+        P::V0 => Reg::X0,
+        P::V1 => Reg::X1,
+        P::V2 => Reg::X2,
+        P::V3 => Reg::X3,
+        P::V6 => Reg::X4,
+        P::V7 => Reg::X5,
+        P::V8 => Reg::X6,
+        P::V9 => Reg::X7,
+        P::V10 => Reg::X8,
+        P::V11 => Reg::X9,
+        P::ColorStrip => Reg::X24,
+        P::GoodColor => Reg::X25,
+        P::BadMask => Reg::X26,
+        P::V4 | P::V5 => {
+            unreachable!("V4/V5 (sp/fp) are handled by the frame-shaped methods")
+        }
+    }
+}
+
+fn port_cond(c: portable_asm::Condition) -> Cond {
+    use portable_asm::Condition as P;
+    match c {
+        P::Equal => Cond::Eq,
+        P::NotEqual => Cond::Ne,
+        P::Below => Cond::Cc,
+        P::Above => Cond::Hi,
+        P::AboveOrEqual => Cond::Hs,
+        P::Less => Cond::Lt,
+        P::LessEqual => Cond::Le,
+        P::Greater => Cond::Gt,
+        P::GreaterEqual => Cond::Ge,
+        P::NoOverflow | P::Parity => {
+            unreachable!("condition not emitted by any GC runtime routine")
+        }
+    }
+}
+
+/// AArch64 realization of the portable ZGC emitter. Every method lowers
+/// one x86-flavored `PortableAsm` operation to AArch64, so the ~24
+/// architecture-independent `portable_asm::emit_gc_*` routines emit into
+/// this `Assembler` unchanged. Two conventions differ from x86 and are
+/// absorbed here: the frame (x86 `push rbp` leaves the return address on
+/// the stack, but AArch64 `bl` leaves it in x30, so the prologue saves a
+/// full frame record x29/x30), and rbp-relative slots (x29 sits at the
+/// frame top, so a slot is `[x29, #-offset]`).
+impl portable_asm::PortableAsm for Assembler {
+    type TextLabel = Label;
+    type DataLabel = PortDataAddr;
+
+    fn create_text_label(&mut self) -> Label {
+        self.new_label()
+    }
+    fn bind_text_label(&mut self, label: Label) {
+        self.bind(label);
+    }
+    fn jmp_label(&mut self, label: Label) {
+        self.branch(label, BranchKind::Unconditional);
+    }
+    fn jcc_label(&mut self, cond: portable_asm::Condition, label: Label) {
+        use portable_asm::Condition as P;
+        let cond = if self.bt_pending {
+            self.bt_pending = false;
+            // The bit test lowered to `tst reg, #(1<<bit)`, setting
+            // Z = (bit == 0). x86 `Below` (bit set) becomes `Ne`;
+            // `AboveOrEqual` (bit clear) becomes `Eq`.
+            match cond {
+                P::Below => Cond::Ne,
+                P::AboveOrEqual => Cond::Eq,
+                other => port_cond(other),
+            }
+        } else {
+            port_cond(cond)
+        };
+        self.branch(label, BranchKind::Conditional(cond));
+    }
+    fn call_label(&mut self, label: Label) {
+        self.branch(label, BranchKind::Link);
+    }
+    fn ret(&mut self) {
+        Assembler::ret(self);
+    }
+    fn leave(&mut self) {
+        self.word(0x9100_03bf); // mov sp, x29 (add sp, x29, #0)
+        self.pop_frame_record(); // ldp x29, x30, [sp], #16
+    }
+
+    fn push_reg(&mut self, r: portable_asm::Reg) {
+        match r {
+            portable_asm::Reg::V5 => self.push_frame_record(), // save fp+lr
+            other => self.push(port_reg(other)),
+        }
+    }
+    fn pop_reg(&mut self, r: portable_asm::Reg) {
+        match r {
+            portable_asm::Reg::V5 => self.pop_frame_record(),
+            other => self.pop(port_reg(other)),
+        }
+    }
+    fn mov_reg_reg(&mut self, dst: portable_asm::Reg, src: portable_asm::Reg) {
+        use portable_asm::Reg as P;
+        match (dst, src) {
+            (P::V5, P::V4) => self.mov_fp_sp(), // mov x29, sp
+            _ => self.mov_reg(port_reg(dst), port_reg(src)),
+        }
+    }
+    fn mov_imm64(&mut self, dst: portable_asm::Reg, imm: u64) {
+        Assembler::mov_imm64(self, port_reg(dst), imm);
+    }
+    fn mov_data_addr(&mut self, dst: portable_asm::Reg, label: PortDataAddr) {
+        let reg = port_reg(dst);
+        match label {
+            PortDataAddr::Rodata(off) => self.load_rodata_address(reg, off),
+            PortDataAddr::Bss(dl) => self.load_data_address(reg, dl),
+        }
+    }
+
+    fn load_ptr_disp32(&mut self, dst: portable_asm::Reg, base: portable_asm::Reg, disp: i32) {
+        let (d, b) = (port_reg(dst), port_reg(base));
+        if disp >= 0 && disp % 8 == 0 && disp / 8 < 4096 {
+            self.ldr_imm(d, b, disp as u32);
+        } else if (-256..=255).contains(&disp) {
+            self.ldur(d, b, disp);
+        } else {
+            Assembler::mov_imm64(self, PORT_SCRATCH, disp as i64 as u64);
+            self.ldr_reg_offset(d, b, PORT_SCRATCH);
+        }
+    }
+    fn store_ptr_disp32(&mut self, base: portable_asm::Reg, disp: i32, src: portable_asm::Reg) {
+        let (s, b) = (port_reg(src), port_reg(base));
+        if disp >= 0 && disp % 8 == 0 && disp / 8 < 4096 {
+            self.str_imm(s, b, disp as u32);
+        } else if (-256..=255).contains(&disp) {
+            self.stur(s, b, disp);
+        } else {
+            Assembler::mov_imm64(self, PORT_SCRATCH, disp as i64 as u64);
+            self.str_reg_offset(s, b, PORT_SCRATCH);
+        }
+    }
+    fn load_rbp_slot(&mut self, dst: portable_asm::Reg, offset: i32) {
+        // x86 `[rbp - offset]`; x29 sits at the frame top, so `[x29, -off]`.
+        self.ldur(port_reg(dst), Reg::X29, -offset);
+    }
+    fn store_rbp_slot(&mut self, offset: i32, src: portable_asm::Reg) {
+        self.stur(port_reg(src), Reg::X29, -offset);
+    }
+
+    fn add_reg_reg(&mut self, dst: portable_asm::Reg, src: portable_asm::Reg) {
+        let (d, s) = (port_reg(dst), port_reg(src));
+        self.add_reg(d, d, s);
+    }
+    fn sub_reg_reg(&mut self, dst: portable_asm::Reg, src: portable_asm::Reg) {
+        let (d, s) = (port_reg(dst), port_reg(src));
+        self.sub_reg(d, d, s);
+    }
+    fn and_reg_reg(&mut self, dst: portable_asm::Reg, src: portable_asm::Reg) {
+        let (d, s) = (port_reg(dst), port_reg(src));
+        self.and_reg(d, d, s);
+    }
+    fn or_reg_reg(&mut self, dst: portable_asm::Reg, src: portable_asm::Reg) {
+        let (d, s) = (port_reg(dst), port_reg(src));
+        self.orr_reg(d, d, s);
+    }
+    fn xor_reg_reg(&mut self, dst: portable_asm::Reg, src: portable_asm::Reg) {
+        let (d, s) = (port_reg(dst), port_reg(src));
+        self.eor_reg(d, d, s);
+    }
+    fn cmp_reg_reg(&mut self, a: portable_asm::Reg, b: portable_asm::Reg) {
+        self.cmp_reg(port_reg(a), port_reg(b));
+    }
+    fn test_reg_reg(&mut self, a: portable_asm::Reg, b: portable_asm::Reg) {
+        self.tst_reg(port_reg(a), port_reg(b));
+    }
+
+    fn add_reg_imm32(&mut self, dst: portable_asm::Reg, imm: i32) {
+        if dst == portable_asm::Reg::V4 {
+            debug_assert!((0..4096).contains(&imm));
+            self.add_sp_imm(imm as u32);
+        } else {
+            let d = port_reg(dst);
+            if (0..4096).contains(&imm) {
+                self.add_reg_imm(d, d, imm as u32);
+            } else if (-4095..0).contains(&imm) {
+                self.sub_reg_imm(d, d, (-imm) as u32);
+            } else {
+                Assembler::mov_imm64(self, PORT_SCRATCH, imm as i64 as u64);
+                self.add_reg(d, d, PORT_SCRATCH);
+            }
+        }
+    }
+    fn sub_reg_imm8(&mut self, r: portable_asm::Reg, imm: i8) {
+        if r == portable_asm::Reg::V4 {
+            self.sub_sp_imm(imm as u32);
+        } else {
+            let d = port_reg(r);
+            self.sub_reg_imm(d, d, imm as u32);
+        }
+    }
+    fn sub_reg_imm32(&mut self, r: portable_asm::Reg, imm: i32) {
+        let d = port_reg(r);
+        if (0..4096).contains(&imm) {
+            self.sub_reg_imm(d, d, imm as u32);
+        } else {
+            Assembler::mov_imm64(self, PORT_SCRATCH, imm as i64 as u64);
+            self.sub_reg(d, d, PORT_SCRATCH);
+        }
+    }
+    fn and_reg_imm32(&mut self, r: portable_asm::Reg, imm: i32) {
+        // Materialize the mask and AND register-register, sidestepping the
+        // AArch64 logical-immediate (N:immr:imms) encoder.
+        let d = port_reg(r);
+        Assembler::mov_imm64(self, PORT_SCRATCH, imm as i64 as u64);
+        self.and_reg(d, d, PORT_SCRATCH);
+    }
+    fn cmp_reg_imm8(&mut self, r: portable_asm::Reg, imm: i8) {
+        let d = port_reg(r);
+        if imm >= 0 {
+            self.cmp_imm(d, imm as u32);
+        } else {
+            Assembler::mov_imm64(self, PORT_SCRATCH, imm as i64 as u64);
+            self.cmp_reg(d, PORT_SCRATCH);
+        }
+    }
+    fn cmp_reg_imm32(&mut self, r: portable_asm::Reg, imm: i32) {
+        let d = port_reg(r);
+        if (0..4096).contains(&imm) {
+            self.cmp_imm(d, imm as u32);
+        } else {
+            Assembler::mov_imm64(self, PORT_SCRATCH, imm as i64 as u64);
+            self.cmp_reg(d, PORT_SCRATCH);
+        }
+    }
+    fn shl_reg_imm8(&mut self, r: portable_asm::Reg, imm: u8) {
+        let d = port_reg(r);
+        self.lsl_imm(d, d, u32::from(imm));
+    }
+    fn shr_reg_imm8(&mut self, r: portable_asm::Reg, imm: u8) {
+        let d = port_reg(r);
+        self.lsr_imm(d, d, u32::from(imm));
+    }
+    fn bt_reg_imm8(&mut self, r: portable_asm::Reg, bit: u8) {
+        // Flag-setting `tst reg, #(1<<bit)` via a materialized mask;
+        // `jcc_label` remaps the following branch (see `bt_pending`).
+        Assembler::mov_imm64(self, PORT_SCRATCH, 1u64 << bit);
+        self.tst_reg(port_reg(r), PORT_SCRATCH);
+        self.bt_pending = true;
+    }
+    fn rep_movsb(&mut self) {
+        // Copy V1 (rcx=x1) bytes from [V6 (rsi=x4)] to [V7 (rdi=x5)].
+        let (count, src, dst) = (Reg::X1, Reg::X4, Reg::X5);
+        let copy_loop = self.new_label();
+        let done = self.new_label();
+        self.bind(copy_loop);
+        self.branch(done, BranchKind::CompareZero(count));
+        self.ldrb_post_increment(PORT_SCRATCH, src);
+        self.strb_post_increment(PORT_SCRATCH, dst);
+        self.sub_reg_imm(count, count, 1);
+        self.branch(copy_loop, BranchKind::Unconditional);
+        self.bind(done);
+    }
+
+    fn plat_write_data(&mut self, fd: u64, data: PortDataAddr, len: usize) {
+        Assembler::mov_imm64(self, Reg::X0, fd);
+        match data {
+            PortDataAddr::Rodata(off) => self.load_rodata_address(Reg::X1, off),
+            PortDataAddr::Bss(dl) => self.load_data_address(Reg::X1, dl),
+        }
+        Assembler::mov_imm64(self, Reg::X2, len as u64);
+        Assembler::mov_imm64(self, Reg::X16, u64::from(SYS_WRITE));
+        self.svc_0x80();
+    }
+    fn plat_exit(&mut self, code: u64) {
+        Assembler::mov_imm64(self, Reg::X0, code);
+        Assembler::mov_imm64(self, Reg::X16, u64::from(SYS_EXIT));
+        self.svc_0x80();
+    }
+    fn plat_read_monotonic_ns(&mut self) {
+        // Minimal: report 0 ns (like the x86 Windows path, whose pauses
+        // also read 0). The GC wiring keeps `--gc-log` timing disabled on
+        // AArch64, so this is never emitted; a real monotonic clock can
+        // replace it later.
+        Assembler::mov_imm64(self, Reg::X0, 0);
     }
 }
 
@@ -4136,6 +4464,66 @@ mod tests {
         // b.cond encodes cond in the low 4 bits; offset patched to +N words.
         assert_eq!(w[0] & 0xff00_001f, 0x5400_0008); // b.hi
         assert_eq!(w[1] & 0xff00_001f, 0x5400_0002); // b.hs
+    }
+
+    #[test]
+    fn portable_gc_routines_emit_valid_aarch64() {
+        // Emit whole architecture-independent GC routines through the
+        // AArch64 PortableAsm impl and sanity-check the byte stream. Set
+        // KLASSIC_AA_DUMP to a path to dump the code for capstone disasm.
+        let mut asm = Assembler::default();
+
+        let cc = PortDataAddr::Bss(asm.reserve_data_cells(1));
+        let br = PortDataAddr::Bss(asm.reserve_data_cells(1));
+        let grow = asm.new_label();
+        crate::portable_asm::emit_gc_grow_budget(&mut asm, grow, cc, br);
+
+        let bounds = asm.new_label();
+        crate::portable_asm::emit_gc_bounds_error(&mut asm, bounds, PortDataAddr::Rodata(0), 32);
+
+        let worklist_top = PortDataAddr::Bss(asm.reserve_data_cells(1));
+        let drain = asm.new_label();
+        let trace = asm.new_label();
+        asm.bind(trace); // a stand-in body so `finish` can resolve the call
+        asm.ret();
+        crate::portable_asm::emit_gc_drain(&mut asm, drain, trace, worklist_top);
+
+        // mark_roots exercises the rbp-relative frame slots ([x29,#-N]).
+        let shadow = PortDataAddr::Bss(asm.reserve_data_cells(1));
+        let shadow_top = PortDataAddr::Bss(asm.reserve_data_cells(1));
+        let mark_visit = asm.new_label();
+        asm.bind(mark_visit);
+        asm.ret();
+        let mark_roots = asm.new_label();
+        crate::portable_asm::emit_gc_mark_roots(
+            &mut asm, mark_roots, shadow, shadow_top, mark_visit,
+        );
+
+        // load_barrier_slow exercises the bit-test remap and the reserved
+        // colour registers (x24/x25/x26) and the [base-16] header access.
+        let phase = PortDataAddr::Bss(asm.reserve_data_cells(1));
+        let region_base = PortDataAddr::Bss(asm.reserve_data_cells(1));
+        let region_fromspace = PortDataAddr::Bss(asm.reserve_data_cells(1));
+        let evacuate = asm.new_label();
+        asm.bind(evacuate);
+        asm.ret();
+        let lbs = asm.new_label();
+        crate::portable_asm::emit_gc_load_barrier_slow(
+            &mut asm,
+            lbs,
+            phase,
+            region_base,
+            region_fromspace,
+            evacuate,
+            mark_visit,
+        );
+
+        asm.finish();
+        assert!(!asm.code.is_empty());
+        assert_eq!(asm.code.len() % 4, 0, "every instruction is a 32-bit word");
+        if let Ok(path) = std::env::var("KLASSIC_AA_DUMP") {
+            std::fs::write(path, &asm.code).unwrap();
+        }
     }
 
     #[test]

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -3719,16 +3719,32 @@ impl Emitter {
                 if self.expression(&arguments[0])? != ValueType::Int {
                     return Err(unsupported(span, &format!("{name} with a non-Int size")));
                 }
-                if name == "__gc_record" {
-                    // n pointer slots → n * 8 bytes.
+                // M6: a GC-shaped object with a 16-byte header. The enum
+                // lowering boxes every scalar/bool/double field and the
+                // discriminant, so a `__gc_record`'s n slots are all heap
+                // pointers (POINTER_RECORD, size = 1 + field_count >= 1); a
+                // `__gc_alloc` cell is raw bytes (RAW_BYTES). Both return the
+                // user pointer (block + 16), so the `__gc_write`/`__gc_read`
+                // payload offsets are unchanged.
+                let tag = if name == "__gc_record" {
+                    // n pointer slots -> n * 8 bytes.
                     self.asm.lsl_imm(Reg::X4, Reg::X0, 3);
+                    crate::gc_layout::GC_TYPE_POINTER_RECORD
                 } else {
                     self.asm.add_reg_imm(Reg::X4, Reg::X0, 7);
                     self.asm.lsr_imm(Reg::X4, Reg::X4, 3);
                     self.asm.lsl_imm(Reg::X4, Reg::X4, 3);
-                }
-                self.emit_alloc();
-                self.asm.mov_reg(Reg::X0, Reg::X5);
+                    crate::gc_layout::GC_TYPE_RAW_BYTES
+                };
+                // block = align16(payload + 16 header).
+                self.asm.add_reg_imm(Reg::X4, Reg::X4, 16 + 15);
+                self.asm.lsr_imm(Reg::X4, Reg::X4, 4);
+                self.asm.lsl_imm(Reg::X4, Reg::X4, 4);
+                self.emit_alloc(); // x5 = block base, x4 = block size preserved
+                self.asm.str_imm(Reg::X4, Reg::X5, 0); // [block] = size|mark(0)
+                self.asm.mov_imm64(Reg::X6, tag);
+                self.asm.str_imm(Reg::X6, Reg::X5, 8); // [block + 8] = type_tag
+                self.asm.add_reg_imm(Reg::X0, Reg::X5, 16); // x0 = user pointer
                 Ok(Some(ValueType::Ptr))
             }
             ("__gc_write", 3) => {

--- a/crates/klassic-native/src/macho.rs
+++ b/crates/klassic-native/src/macho.rs
@@ -13,13 +13,23 @@
 //! — and no external `codesign` / `cc` / `ld` is involved, keeping
 //! the no-toolchain policy of the direct backends.
 
-/// An `adrp`+`add` pair in `code` that must be patched to address a
-/// byte in `rodata` once the final image layout is known.
+/// Which segment a `DataFixup` addresses: the read-only `__TEXT,__const`
+/// (constants, strings) or the writable `__DATA,__bss` (the GC's cells).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FixupSection {
+    Rodata,
+    Data,
+}
+
+/// An `adrp`+`add` pair in `code` that must be patched to address a byte
+/// in `section` (at `data_offset` within it) once the final image layout
+/// is known.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct DataFixup {
     pub adrp_offset: usize,
     pub add_offset: usize,
     pub data_offset: usize,
+    pub section: FixupSection,
 }
 
 const PAGE_SIZE: u64 = 16384;
@@ -154,7 +164,13 @@ pub(crate) fn write_executable(
     };
 
     for fixup in fixups {
-        patch_data_fixup(&mut code, code_offset, rodata_offset, fixup);
+        let section_base = match fixup.section {
+            FixupSection::Rodata => TEXT_BASE + rodata_offset,
+            // __DATA maps right after __TEXT; the zero-fill __bss shares
+            // the segment's vmaddr (its file offset is meaningless).
+            FixupSection::Data => data_vmaddr,
+        };
+        patch_data_fixup(&mut code, code_offset, section_base, fixup);
     }
 
     let identifier_bytes = identifier.as_bytes();
@@ -339,9 +355,9 @@ pub(crate) fn write_executable(
     out.bytes
 }
 
-fn patch_data_fixup(code: &mut [u8], code_offset: u64, rodata_offset: u64, fixup: &DataFixup) {
+fn patch_data_fixup(code: &mut [u8], code_offset: u64, section_base: u64, fixup: &DataFixup) {
     let place = TEXT_BASE + code_offset + fixup.adrp_offset as u64;
-    let target = TEXT_BASE + rodata_offset + fixup.data_offset as u64;
+    let target = section_base + fixup.data_offset as u64;
     let page_delta = ((target >> 12) as i64 - (place >> 12) as i64) as u64;
     let immlo = (page_delta & 0x3) as u32;
     let immhi = ((page_delta >> 2) & 0x7_ffff) as u32;
@@ -652,6 +668,7 @@ mod tests {
             adrp_offset: 0,
             add_offset: 4,
             data_offset: 0,
+            section: FixupSection::Rodata,
         }];
         let image = write_executable(code, b"x".to_vec(), &fixups, "klassic", 0);
         // Locate the code from the layout formula: header (32) +
@@ -663,5 +680,50 @@ mod tests {
         let add = u32::from_le_bytes(image[code_offset + 4..code_offset + 8].try_into().unwrap());
         let rodata_offset = align_to(code_offset as u64 + 8, 8) as u32;
         assert_eq!(add, 0x9100_0021 | (rodata_offset << 10));
+    }
+
+    /// Decode an `adrp xd, <page>` + `add xd, xd, #<off>` pair back to the
+    /// absolute address it computes, independent of the writer's formula.
+    fn decode_adrp_add(image: &[u8], adrp_at: usize) -> u64 {
+        let adrp = u32::from_le_bytes(image[adrp_at..adrp_at + 4].try_into().unwrap());
+        let add = u32::from_le_bytes(image[adrp_at + 4..adrp_at + 8].try_into().unwrap());
+        let immlo = ((adrp >> 29) & 0x3) as u64;
+        let immhi = ((adrp >> 5) & 0x7_ffff) as u64;
+        let mut page_delta = (immhi << 2) | immlo; // 21-bit signed
+        if page_delta & (1 << 20) != 0 {
+            page_delta |= !0 << 21; // sign-extend
+        }
+        let place = TEXT_BASE + adrp_at as u64;
+        let target_page = (place & !0xfff).wrapping_add(page_delta.wrapping_shl(12));
+        let imm12 = ((add >> 10) & 0xfff) as u64;
+        target_page + imm12
+    }
+
+    #[test]
+    fn data_section_fixups_resolve_against_data_segment() {
+        // adrp/add addressing the second GC cell (byte offset 8) in
+        // __DATA,__bss. Its target is a full segment away from the code,
+        // so the adrp page delta is non-zero (unlike the rodata case).
+        let code = vec![
+            0x01, 0x00, 0x00, 0x90, // adrp x1, 0 (placeholder)
+            0x21, 0x00, 0x00, 0x91, // add x1, x1, #0 (placeholder)
+        ];
+        let fixups = [DataFixup {
+            adrp_offset: 0,
+            add_offset: 4,
+            data_offset: 8,
+            section: FixupSection::Data,
+        }];
+        let image = write_executable(code, b"x".to_vec(), &fixups, "klassic", 16);
+
+        let ncmds = u32::from_le_bytes(image[16..20].try_into().unwrap());
+        let text = find_segment(&image, ncmds, "__TEXT").unwrap();
+        let text_filesize = u64::from_le_bytes(image[text + 32..text + 40].try_into().unwrap());
+        let data_vmaddr = TEXT_BASE + text_filesize;
+
+        let sizeofcmds = u32::from_le_bytes(image[20..24].try_into().unwrap()) as u64;
+        let code_offset = align_to(32 + sizeofcmds, 16) as usize;
+        let resolved = decode_adrp_add(&image, code_offset);
+        assert_eq!(resolved, data_vmaddr + 8);
     }
 }

--- a/crates/klassic-native/src/macho.rs
+++ b/crates/klassic-native/src/macho.rs
@@ -42,7 +42,14 @@ const LC_BUILD_VERSION: u32 = 0x32;
 const LC_CODE_SIGNATURE: u32 = 0x1d;
 
 const VM_PROT_READ: u32 = 0x1;
+const VM_PROT_WRITE: u32 = 0x2;
 const VM_PROT_EXECUTE: u32 = 0x4;
+
+/// `S_ZEROFILL` section type: no file backing, zeroed at map time. The
+/// GC's mutable global cells live in a `__DATA,__bss` section of this
+/// type, so they add no on-disk bytes and fall outside the code
+/// signature's `codeLimit`.
+const S_ZEROFILL: u32 = 0x1;
 
 const SEGMENT_COMMAND_SIZE: u32 = 72;
 const SECTION_SIZE: u32 = 80;
@@ -104,9 +111,23 @@ pub(crate) fn write_executable(
     rodata: Vec<u8>,
     fixups: &[DataFixup],
     identifier: &str,
+    bss_size: u64,
 ) -> Vec<u8> {
+    // A writable `__DATA` segment (one zero-fill `__bss` section) is
+    // emitted only when the codegen requested mutable global cells (the
+    // GC's). It carries no on-disk bytes, so it shifts nothing in the
+    // payload or the signature — only the two extra load commands grow
+    // `sizeofcmds`, which cascades through the file offsets. When
+    // `bss_size == 0` the layout is byte-for-byte the pre-GC image.
+    let has_data = bss_size > 0;
+    let data_cmd_size = if has_data {
+        SEGMENT_COMMAND_SIZE + SECTION_SIZE
+    } else {
+        0
+    };
     let sizeofcmds = SEGMENT_COMMAND_SIZE          // __PAGEZERO
         + SEGMENT_COMMAND_SIZE + 2 * SECTION_SIZE  // __TEXT (__text, __const)
+        + data_cmd_size                            // __DATA (__bss), if any
         + SEGMENT_COMMAND_SIZE                     // __LINKEDIT
         + LOAD_DYLINKER_COMMAND_SIZE
         + MAIN_COMMAND_SIZE
@@ -114,12 +135,23 @@ pub(crate) fn write_executable(
         + DYSYMTAB_COMMAND_SIZE
         + BUILD_VERSION_COMMAND_SIZE
         + CODE_SIGNATURE_COMMAND_SIZE;
-    let ncmds = 9u32;
+    let ncmds = if has_data { 10u32 } else { 9u32 };
     let header_end = 32 + u64::from(sizeofcmds);
     let code_offset = align_to(header_end, 16);
     let rodata_offset = align_to(code_offset + code.len() as u64, 8);
     let text_filesize = align_to(rodata_offset + rodata.len() as u64, PAGE_SIZE);
+    // The zero-fill __bss adds no file bytes, so the signature still
+    // begins at the end of __TEXT regardless of the data segment.
     let signature_offset = text_filesize;
+    // __DATA maps in VM immediately after __TEXT; __LINKEDIT then moves
+    // past __DATA's (page-rounded) vm size.
+    let data_vmaddr = TEXT_BASE + text_filesize;
+    let data_vmsize = align_to(bss_size, PAGE_SIZE);
+    let linkedit_vmaddr = if has_data {
+        data_vmaddr + data_vmsize
+    } else {
+        TEXT_BASE + text_filesize
+    };
 
     for fixup in fixups {
         patch_data_fixup(&mut code, code_offset, rodata_offset, fixup);
@@ -200,11 +232,42 @@ pub(crate) fn write_executable(
     out.u32(0);
     out.u32(0);
 
+    // __DATA: the GC's writable globals. One zero-fill __bss section, so
+    // the segment has no on-disk bytes (fileoff points just past __TEXT,
+    // filesize 0) and dyld zeroes the whole vm range at map time.
+    if has_data {
+        out.u32(LC_SEGMENT_64);
+        out.u32(SEGMENT_COMMAND_SIZE + SECTION_SIZE);
+        out.name16("__DATA");
+        out.u64(data_vmaddr);
+        out.u64(data_vmsize);
+        out.u64(text_filesize); // fileoff (filesize 0, so unmapped from file)
+        out.u64(0); // filesize
+        out.u32(VM_PROT_READ | VM_PROT_WRITE);
+        out.u32(VM_PROT_READ | VM_PROT_WRITE);
+        out.u32(1); // nsects
+        out.u32(0);
+
+        // __DATA,__bss
+        out.name16("__bss");
+        out.name16("__DATA");
+        out.u64(data_vmaddr);
+        out.u64(bss_size);
+        out.u32(0); // offset: S_ZEROFILL has no file backing
+        out.u32(3); // 2^3 alignment
+        out.u32(0);
+        out.u32(0);
+        out.u32(S_ZEROFILL);
+        out.u32(0);
+        out.u32(0);
+        out.u32(0);
+    }
+
     // __LINKEDIT: holds exactly the code signature.
     out.u32(LC_SEGMENT_64);
     out.u32(SEGMENT_COMMAND_SIZE);
     out.name16("__LINKEDIT");
-    out.u64(TEXT_BASE + text_filesize);
+    out.u64(linkedit_vmaddr);
     out.u64(align_to(signature_size, PAGE_SIZE));
     out.u64(signature_offset);
     out.u64(signature_size);
@@ -466,7 +529,7 @@ mod tests {
     fn executable_layout_is_structurally_sound() {
         let code = vec![0xd2, 0x80, 0x00, 0x40]; // mov x0, #2
         let rodata = b"hi\n".to_vec();
-        let image = write_executable(code, rodata, &[], "klassic");
+        let image = write_executable(code, rodata, &[], "klassic", 0);
 
         assert_eq!(&image[0..4], &MH_MAGIC_64.to_le_bytes());
         assert_eq!(&image[4..8], &CPU_TYPE_ARM64.to_le_bytes());
@@ -500,6 +563,82 @@ mod tests {
         assert_eq!(first_hash, &sha256(&image[..SIGN_PAGE_SIZE]));
     }
 
+    /// Walk the load commands and return the file offset of the
+    /// `LC_SEGMENT_64` whose segname matches, or `None`.
+    fn find_segment(image: &[u8], ncmds: u32, segname: &str) -> Option<usize> {
+        let mut off = 32usize;
+        for _ in 0..ncmds {
+            let cmd = u32::from_le_bytes(image[off..off + 4].try_into().unwrap());
+            let cmdsize = u32::from_le_bytes(image[off + 4..off + 8].try_into().unwrap()) as usize;
+            if cmd == LC_SEGMENT_64 {
+                let name_end = image[off + 8..off + 24]
+                    .iter()
+                    .position(|&b| b == 0)
+                    .unwrap_or(16);
+                if &image[off + 8..off + 8 + name_end] == segname.as_bytes() {
+                    return Some(off);
+                }
+            }
+            off += cmdsize;
+        }
+        None
+    }
+
+    #[test]
+    fn writable_data_segment_is_gated_and_structurally_sound() {
+        let code = vec![0xd2, 0x80, 0x00, 0x40]; // mov x0, #2
+        let bss_size = 30 * 8; // ~30 zero-init GC cells
+        let image = write_executable(code, b"hi\n".to_vec(), &[], "klassic", bss_size);
+
+        // The data segment bumps the command count.
+        let ncmds = u32::from_le_bytes(image[16..20].try_into().unwrap());
+        assert_eq!(ncmds, 10);
+
+        // __TEXT gives us its (page-aligned) vmsize = text_filesize.
+        let text = find_segment(&image, ncmds, "__TEXT").expect("__TEXT present");
+        let text_filesize = u64::from_le_bytes(image[text + 32..text + 40].try_into().unwrap());
+
+        // __DATA: writable, one section, mapped right after __TEXT.
+        let data = find_segment(&image, ncmds, "__DATA").expect("__DATA present");
+        let data_vmaddr = u64::from_le_bytes(image[data + 24..data + 32].try_into().unwrap());
+        let data_vmsize = u64::from_le_bytes(image[data + 32..data + 40].try_into().unwrap());
+        let data_filesize = u64::from_le_bytes(image[data + 48..data + 56].try_into().unwrap());
+        let initprot = u32::from_le_bytes(image[data + 60..data + 64].try_into().unwrap());
+        let nsects = u32::from_le_bytes(image[data + 64..data + 68].try_into().unwrap());
+        assert_eq!(data_vmaddr, TEXT_BASE + text_filesize);
+        assert_eq!(data_vmsize, align_to(bss_size, PAGE_SIZE));
+        assert_eq!(data_filesize, 0, "zero-fill: no on-disk bytes");
+        assert_eq!(initprot, VM_PROT_READ | VM_PROT_WRITE);
+        assert_eq!(nsects, 1);
+
+        // __DATA,__bss section: S_ZEROFILL, no file offset, correct size.
+        let sect = data + SEGMENT_COMMAND_SIZE as usize;
+        assert_eq!(&image[sect..sect + 5], b"__bss");
+        let sect_size = u64::from_le_bytes(image[sect + 40..sect + 48].try_into().unwrap());
+        let sect_offset = u32::from_le_bytes(image[sect + 48..sect + 52].try_into().unwrap());
+        let sect_flags = u32::from_le_bytes(image[sect + 64..sect + 68].try_into().unwrap());
+        assert_eq!(sect_size, bss_size);
+        assert_eq!(sect_offset, 0);
+        assert_eq!(sect_flags, S_ZEROFILL);
+
+        // __LINKEDIT moves past __DATA in the address space.
+        let linkedit = find_segment(&image, ncmds, "__LINKEDIT").expect("__LINKEDIT present");
+        let le_vmaddr = u64::from_le_bytes(image[linkedit + 24..linkedit + 32].try_into().unwrap());
+        assert_eq!(le_vmaddr, data_vmaddr + data_vmsize);
+
+        // The zero-fill segment adds no file bytes, so the signature still
+        // begins at text_filesize and its first-page hash is valid.
+        let signature_offset = text_filesize as usize;
+        assert_eq!(
+            &image[signature_offset..signature_offset + 4],
+            &CSMAGIC_EMBEDDED_SIGNATURE.to_be_bytes()
+        );
+        let directory = &image[signature_offset + 20..];
+        let hash_offset = u32::from_be_bytes(directory[16..20].try_into().unwrap()) as usize;
+        let first_hash = &directory[hash_offset..hash_offset + SHA256_SIZE];
+        assert_eq!(first_hash, &sha256(&image[..SIGN_PAGE_SIZE]));
+    }
+
     #[test]
     fn data_fixups_resolve_page_and_offset() {
         // adrp x1, <data>; add x1, x1, #<pageoff> with the data only a
@@ -514,7 +653,7 @@ mod tests {
             add_offset: 4,
             data_offset: 0,
         }];
-        let image = write_executable(code, b"x".to_vec(), &fixups, "klassic");
+        let image = write_executable(code, b"x".to_vec(), &fixups, "klassic", 0);
         // Locate the code from the layout formula: header (32) +
         // sizeofcmds, aligned to 16.
         let sizeofcmds = u32::from_le_bytes(image[20..24].try_into().unwrap()) as u64;


### PR DESCRIPTION
## What & why

Milestone **M5** of giving the AArch64 backend a real GC (foundation M1–M4 landed in #601). This emits the entire portable ZGC into every AArch64 image — **dead but linked** — driving the whole pipeline (the `__DATA` segment, the data-label fixups, and the `PortableAsm` lowering) end-to-end for the first time.

## What it does

- A `GcState` reserves the collector's ~35 mutable global cells in `__DATA,__bss` (32 single qwords plus the three 512-entry region arrays), interns its diagnostic strings in `__const`, and creates the 24 subroutine labels — mirroring the x86-64 field set one-to-one.
- `emit_gc_runtime` emits all 24 `portable_asm::emit_gc_*` routines (in x86-64 dispatch order) into the code buffer, after the program's exit, so they are reachable only once the mutator calls `gc_alloc` — which it does not yet (the bump allocator is still live). Evacuation is off (non-moving), pause timing is disabled (the monotonic-clock primitive stubs to 0), and the `--gc-log`/`--gc-stress` flags plus the startup mmap/colour seeding arrive at go-live (M7).

## Verification

AArch64 Mach-O cannot be run or disassembled by this Linux host's binutils, so the oracle remains capstone.

- An AArch64 image now carries a `__DATA` segment (`ncmds` 10, `vmsize` 0x4000, zero-fill) with `__LINKEDIT` shifted past it; its `__text` grows 2332 → 8176 bytes.
- **capstone disassembles every one of the 2044 instructions to valid AArch64** (2044 × 4 = 8176, no gaps), and the `adrp`/`add` pairs resolve to real `__DATA,__bss` cells (e.g. `adrp x8, #0x3000; add x8, x8, #0x48`) — proving the segment (M2), the fixups (M3), the lowering (M4), and this wiring all work together.
- `cargo fmt` / `clippy -D warnings` clean; 723 tests pass.

## Next

M6 boxes the AArch64 object model (records/lists) to the collector's uniform-pointer shape — a larger semantic change verifiable only on the macOS CI eval-differential — and M7 is the atomic go-live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
