### PR TITLE
Collections, values, strings, and math on every target

### DIFF
--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -1247,6 +1247,9 @@ enum ListElem {
     /// An element that is one of this backend's own enums, which is a pointer
     /// like a string is -- `JArr(items: List<Json>)` is a list of them.
     Enum(u32),
+    /// An element that is a record, which is a pointer too. A list of them is
+    /// what `toPairs()` hands back.
+    Record(u32),
     /// An element that is itself a list: `depth` levels of list over `base`.
     /// `List<List<Int>>`'s element is `Nested { depth: 1, base: Int }` and
     /// `List<List<List<Int>>>`'s is `depth: 2`.
@@ -1288,7 +1291,7 @@ impl ListElem {
             ListElem::Int => Some(ScalarElem::Int),
             ListElem::Bool => Some(ScalarElem::Bool),
             ListElem::Str => Some(ScalarElem::Str),
-            ListElem::Enum(_) | ListElem::Nested { .. } => None,
+            ListElem::Enum(_) | ListElem::Record(_) | ListElem::Nested { .. } => None,
         }
     }
 
@@ -1462,6 +1465,7 @@ fn elem_value_type(elem: ListElem) -> ValueType {
         ListElem::Bool => ValueType::Bool,
         ListElem::Str => ValueType::Str,
         ListElem::Enum(shape) => ValueType::Enum(shape),
+        ListElem::Record(index) => ValueType::Record(index),
         ListElem::Nested { .. } => ValueType::List(
             elem.nested_inner()
                 .expect("a nested element is a list of its inner element"),
@@ -1616,6 +1620,7 @@ fn list_elem_of(ty: ValueType) -> Option<ListElem> {
         ValueType::Bool => Some(ListElem::Bool),
         ValueType::Str => Some(ListElem::Str),
         ValueType::Enum(shape) => Some(ListElem::Enum(shape)),
+        ValueType::Record(index) => Some(ListElem::Record(index)),
         // A list of lists: one more level over whatever the inner list holds.
         ValueType::List(inner) => Some(match inner.as_scalar() {
             Some(base) => ListElem::Nested { depth: 1, base },
@@ -1706,6 +1711,9 @@ struct Emitter {
     /// Nominal record declarations plus interned structural shapes;
     /// `ValueType::Record` carries an index into this table.
     records: Vec<RecordInfo>,
+    /// The records whose rendering is currently being emitted, so a record
+    /// that holds itself is rejected instead of printed forever.
+    printing_records: Vec<u32>,
     /// Lazily emitted set helpers (called via `bl`): scalar / string
     /// membership scans and a cons-list reverse.
     member_scalar_label: Option<Label>,
@@ -3802,6 +3810,33 @@ impl Emitter {
                     self.emit_heap_string_copy();
                     rhs_ty = ValueType::Str;
                 }
+                // A value that may not be there appends as the word `null`
+                // when it is not, and as itself when it is -- which is what
+                // reading a map entry's value into a message does.
+                ValueType::Nullable(elem) => {
+                    let null_label = self.asm.new_label();
+                    let end_label = self.asm.new_label();
+                    self.asm
+                        .branch(null_label, BranchKind::CompareZero(Reg::X0));
+                    if is_boxed_scalar(elem_value_type(elem)) {
+                        self.emit_unbox_scalar();
+                    }
+                    match elem {
+                        ListElem::Int => self.emit_int_to_str(),
+                        ListElem::Bool => self.emit_bool_to_str(),
+                        ListElem::Str => self.emit_heap_string_copy(),
+                        _ => {
+                            return Err(unsupported(rhs.span(), "appending a value of this type"));
+                        }
+                    }
+                    self.asm.branch(end_label, BranchKind::Unconditional);
+                    self.asm.bind(null_label);
+                    let offset = self.asm.intern_string_object("null");
+                    self.asm.load_rodata_address(Reg::X0, offset);
+                    self.emit_heap_string_copy();
+                    self.asm.bind(end_label);
+                    rhs_ty = ValueType::Str;
+                }
                 _ => return Err(unsupported(rhs.span(), "appending a value of this type")),
             }
         }
@@ -5601,6 +5636,19 @@ impl Emitter {
         self.asm.mov_reg(Reg::X0, Reg::X2);
     }
 
+    /// Prepend a fresh `[key][value]` entry, taken from those two slots, to
+    /// the chain in `acc`.
+    fn emit_put_entry(&mut self, key_slot: u32, value_slot: u32, acc: u32) {
+        self.asm.load_local(Reg::X0, key_slot);
+        self.push_rooted(Reg::X0);
+        self.asm.load_local(Reg::X0, value_slot);
+        self.emit_cons_cell(); // entry = [key][value]
+        self.push_rooted(Reg::X0);
+        self.asm.load_local(Reg::X0, acc);
+        self.emit_cons_cell(); // chain cell = [entry][rest]
+        self.asm.store_local(Reg::X0, acc);
+    }
+
     /// The entry whose key equals the one in x1, or 0 when there is none:
     /// x0 = map chain, x1 = key (a boxed scalar or a string pointer)
     /// -> x0 = entry pointer or 0.
@@ -5853,6 +5901,9 @@ impl Emitter {
             ListElem::Enum(_) => {
                 return Err(unsupported(span, "printing an enum element"));
             }
+            ListElem::Record(index) => {
+                self.emit_print_record_inline(index, span)?;
+            }
             // A nested element is a list: build its text with the same
             // renderer and write that. The recursion is at codegen time and
             // terminates because the depth decreases.
@@ -5903,11 +5954,31 @@ impl Emitter {
     /// `#Name(v1, v2)` for nominal records, `#(v1, v2)` for
     /// structural shapes. Scalar and string fields only for now.
     fn emit_println_record(&mut self, index: u32, span: Span) -> Result<(), Diagnostic> {
+        self.emit_print_record_inline(index, span)?;
+        self.asm.emit_write_rodata(STDOUT_FD, b"\n");
+        Ok(())
+    }
+
+    /// The same rendering without the newline, which is what a record nested
+    /// inside a list or another record needs. A record that (transitively)
+    /// holds itself would print forever, so the stack of records being
+    /// rendered is checked rather than recursed into.
+    fn emit_print_record_inline(&mut self, index: u32, span: Span) -> Result<(), Diagnostic> {
+        if self.printing_records.contains(&index) {
+            return Err(unsupported(span, "printing a record that holds itself"));
+        }
+        self.printing_records.push(index);
+        let result = self.emit_print_record_fields(index, span);
+        self.printing_records.pop();
+        result
+    }
+
+    fn emit_print_record_fields(&mut self, index: u32, span: Span) -> Result<(), Diagnostic> {
         let info = &self.records[index as usize];
         let opener = format!("#{}(", info.name);
         let fields = info.fields.clone();
         for (_, ty) in &fields {
-            if list_elem_of(*ty).is_none() {
+            if list_elem_of(*ty).is_none() && !matches!(ty, ValueType::Nullable(_)) {
                 return Err(unsupported(span, "printing a record with this field type"));
             }
         }
@@ -5920,6 +5991,24 @@ impl Emitter {
             self.asm.pop(Reg::X0);
             self.asm.push(Reg::X0);
             self.emit_gc_load_ptr(Reg::X0, (position * 8) as u32); // barriered
+            // A field that may not be there -- `Map#get`'s answer is the one
+            // every map entry carries -- prints the word `null` when it is
+            // not, which is what the evaluator prints.
+            if let ValueType::Nullable(elem) = *ty {
+                let null_label = self.asm.new_label();
+                let end_label = self.asm.new_label();
+                self.asm
+                    .branch(null_label, BranchKind::CompareZero(Reg::X0));
+                if is_boxed_scalar(elem_value_type(elem)) {
+                    self.emit_unbox_scalar();
+                }
+                self.emit_print_elem(elem, span)?;
+                self.asm.branch(end_label, BranchKind::Unconditional);
+                self.asm.bind(null_label);
+                self.asm.emit_write_rodata(STDOUT_FD, b"null");
+                self.asm.bind(end_label);
+                continue;
+            }
             // Scalar fields are boxed in the POINTER_RECORD; unbox before
             // printing (string fields are already the pointer).
             if is_boxed_scalar(*ty) {
@@ -5928,7 +6017,7 @@ impl Emitter {
             self.emit_print_elem(list_elem_of(*ty).expect("checked above"), span)?;
         }
         self.asm.pop(Reg::X0); // discard the saved object
-        self.asm.emit_write_rodata(STDOUT_FD, b")\n");
+        self.asm.emit_write_rodata(STDOUT_FD, b")");
         Ok(())
     }
 
@@ -6253,6 +6342,167 @@ impl Emitter {
                 self.emit_gc_load_ptr(Reg::X0, 8); // barriered: next is a pointer
                 self.asm.bind(end);
                 Ok(Some(ty))
+            }
+            // `Map#empty()`: the empty chain, which is the null pointer.
+            ("Map#empty", 0) => {
+                self.asm.mov_imm64(Reg::X0, 0);
+                Ok(Some(ValueType::EmptyMap))
+            }
+            // `Map#put(m, key, value)`: a fresh map with that binding. An
+            // existing key keeps its position and takes the new value; a new
+            // one goes on the end, which is the evaluator's own order.
+            ("Map#put", 3) => {
+                let mark = self.open_temp_roots();
+                let map_ty = self.expression(&arguments[0])?;
+                let existing = match map_ty {
+                    ValueType::Map(key, value) => Some((key, value)),
+                    ValueType::EmptyMap => None,
+                    _ => return Err(unsupported(span, "a map builtin on a non-map")),
+                };
+                let cursor = self.reserve_locals(24);
+                let acc = cursor + 8;
+                let replaced = cursor + 16;
+                self.asm.store_local(Reg::X0, cursor);
+                self.emit_root_frame_slot(cursor);
+                self.asm.mov_imm64(Reg::X0, 0);
+                self.asm.store_local(Reg::X0, acc);
+                self.emit_root_frame_slot(acc);
+                self.asm.store_local(Reg::X0, replaced);
+
+                // The key and value are rooted for the whole walk: every entry
+                // copied along the way allocates.
+                let key_ty = self.expression(&arguments[1])?;
+                let Some(key_elem) = list_elem_of(key_ty) else {
+                    return Err(unsupported(arguments[1].span(), "a map key of this type"));
+                };
+                if let Some((existing_key, _)) = existing
+                    && existing_key != key_elem
+                {
+                    return Err(unsupported(arguments[1].span(), "mixed map key types"));
+                }
+                if is_boxed_scalar(key_ty) {
+                    self.emit_box_scalar();
+                }
+                let key_slot = self.reserve_locals(16);
+                let value_slot = key_slot + 8;
+                self.asm.store_local(Reg::X0, key_slot);
+                self.emit_root_frame_slot(key_slot);
+                let value_ty = self.expression(&arguments[2])?;
+                let Some(value_elem) = list_elem_of(value_ty) else {
+                    return Err(unsupported(arguments[2].span(), "a map value of this type"));
+                };
+                if let Some((_, existing_value)) = existing
+                    && existing_value != value_elem
+                {
+                    return Err(unsupported(arguments[2].span(), "mixed map value types"));
+                }
+                if is_boxed_scalar(value_ty) {
+                    self.emit_box_scalar();
+                }
+                self.asm.store_local(Reg::X0, value_slot);
+                self.emit_root_frame_slot(value_slot);
+
+                let loop_start = self.asm.new_label();
+                let done = self.asm.new_label();
+                let keep = self.asm.new_label();
+                let next = self.asm.new_label();
+                self.asm.bind(loop_start);
+                self.asm.load_local(Reg::X0, cursor);
+                self.asm.branch(done, BranchKind::CompareZero(Reg::X0));
+                self.emit_gc_load_ptr(Reg::X0, 0); // this entry
+                self.push_rooted(Reg::X0);
+                self.emit_gc_load_ptr(Reg::X0, 0); // its key
+                if is_boxed_scalar(elem_value_type(key_elem)) {
+                    self.emit_unbox_scalar();
+                }
+                self.asm.load_local(Reg::X1, key_slot);
+                match key_elem {
+                    ListElem::Str => self.emit_str_eq(),
+                    _ => {
+                        if is_boxed_scalar(elem_value_type(key_elem)) {
+                            self.asm.ldr_imm(Reg::X1, Reg::X1, 0);
+                        }
+                        self.asm.cmp_reg(Reg::X0, Reg::X1);
+                        self.asm.cset(Reg::X0, Cond::Eq);
+                    }
+                }
+                self.asm.branch(keep, BranchKind::CompareZero(Reg::X0));
+                self.pop_rooted(Reg::X1); // the old entry, replaced
+                self.asm.mov_imm64(Reg::X0, 1);
+                self.asm.store_local(Reg::X0, replaced);
+                self.emit_put_entry(key_slot, value_slot, acc);
+                self.asm.branch(next, BranchKind::Unconditional);
+                self.asm.bind(keep);
+                self.pop_rooted(Reg::X0); // the entry, kept as it is
+                self.push_rooted(Reg::X0);
+                self.asm.load_local(Reg::X0, acc);
+                self.emit_cons_cell();
+                self.asm.store_local(Reg::X0, acc);
+                self.asm.bind(next);
+                self.asm.load_local(Reg::X0, cursor);
+                self.emit_gc_load_ptr(Reg::X0, 8);
+                self.asm.store_local(Reg::X0, cursor);
+                self.asm.branch(loop_start, BranchKind::Unconditional);
+                self.asm.bind(done);
+                // A key that was not there goes on the end, which is the front
+                // of the accumulator before it is reversed.
+                let appended = self.asm.new_label();
+                self.asm.load_local(Reg::X0, replaced);
+                self.asm
+                    .branch(appended, BranchKind::CompareNonZero(Reg::X0));
+                self.emit_put_entry(key_slot, value_slot, acc);
+                self.asm.bind(appended);
+                self.asm.load_local(Reg::X0, acc);
+                let reverse = self.reverse_label();
+                self.asm.branch(reverse, BranchKind::Link);
+                self.close_temp_roots(mark);
+                Ok(Some(ValueType::Map(key_elem, value_elem)))
+            }
+            // `Map#keys(m)` / `Map#values(m)`: one half of every entry, in
+            // insertion order.
+            ("Map#keys", 1) | ("Map#values", 1) => {
+                let mark = self.open_temp_roots();
+                let map_ty = self.expression(&arguments[0])?;
+                let (key_elem, value_elem) = match map_ty {
+                    ValueType::Map(key, value) => (key, value),
+                    ValueType::EmptyMap => {
+                        self.close_temp_roots(mark);
+                        self.asm.mov_imm64(Reg::X0, 0);
+                        return Ok(Some(ValueType::EmptyList));
+                    }
+                    _ => return Err(unsupported(span, "a map builtin on a non-map")),
+                };
+                let wants_keys = name.ends_with("keys");
+                let field = if wants_keys { 0 } else { 8 };
+                let elem = if wants_keys { key_elem } else { value_elem };
+                let cursor = self.reserve_locals(16);
+                let acc = cursor + 8;
+                self.asm.store_local(Reg::X0, cursor);
+                self.emit_root_frame_slot(cursor);
+                self.asm.mov_imm64(Reg::X0, 0);
+                self.asm.store_local(Reg::X0, acc);
+                self.emit_root_frame_slot(acc);
+                let loop_start = self.asm.new_label();
+                let done = self.asm.new_label();
+                self.asm.bind(loop_start);
+                self.asm.load_local(Reg::X0, cursor);
+                self.asm.branch(done, BranchKind::CompareZero(Reg::X0));
+                self.emit_gc_load_ptr(Reg::X0, 0); // entry
+                self.emit_gc_load_ptr(Reg::X0, field); // its key or value
+                self.push_rooted(Reg::X0);
+                self.asm.load_local(Reg::X0, acc);
+                self.emit_cons_cell();
+                self.asm.store_local(Reg::X0, acc);
+                self.asm.load_local(Reg::X0, cursor);
+                self.emit_gc_load_ptr(Reg::X0, 8);
+                self.asm.store_local(Reg::X0, cursor);
+                self.asm.branch(loop_start, BranchKind::Unconditional);
+                self.asm.bind(done);
+                self.asm.load_local(Reg::X0, acc);
+                let reverse = self.reverse_label();
+                self.asm.branch(reverse, BranchKind::Link);
+                self.close_temp_roots(mark);
+                Ok(Some(ValueType::List(elem)))
             }
             ("isEmpty", 1) | ("Map#isEmpty", 1) => {
                 let ty = self.expression(&arguments[0])?;
@@ -7195,7 +7445,7 @@ impl Emitter {
             ListElem::Int => self.emit_int_to_str(),
             ListElem::Bool => self.emit_bool_to_str(),
             ListElem::Str => {}
-            ListElem::Enum(_) => {
+            ListElem::Enum(_) | ListElem::Record(_) => {
                 return Err(unsupported(span, "rendering an enum element"));
             }
             // Same renderer one level down; the element pointer is already in
@@ -7559,6 +7809,54 @@ impl Emitter {
             // Typed the way the emitter types it, so an `if` with a `null`
             // branch predicts the nullable join rather than the other branch.
             Expr::Null { .. } => Some(ValueType::Null),
+            // `#Name(a, b)`. A generic record's fields take their types from
+            // the arguments, which is the same rule compiling one uses -- so
+            // predicting one interns the shape compilation would intern, and
+            // both agree on the index.
+            Expr::RecordConstructor {
+                name, arguments, ..
+            } => {
+                if let Some(index) = self
+                    .records
+                    .iter()
+                    .position(|record| record.usable && record.name == *name)
+                    .filter(|_| {
+                        !self.generic_records.iter().any(|record| {
+                            record.name == *name && record.fields.len() == arguments.len()
+                        })
+                    })
+                {
+                    return Some(ValueType::Record(index as u32));
+                }
+                let declared = self
+                    .generic_records
+                    .iter()
+                    .find(|record| record.name == *name && record.fields.len() == arguments.len())
+                    .cloned()?;
+                let mut typed = Vec::with_capacity(arguments.len());
+                for (argument, (field, _)) in arguments.iter().zip(declared.fields.iter()) {
+                    let ty = self.static_type_under(argument, locals, depth + 1)?;
+                    if ty == ValueType::Unit || ty == ValueType::Never {
+                        return None;
+                    }
+                    typed.push((field.clone(), ty));
+                }
+                let index = match self.records.iter().position(|record| {
+                    record.usable && record.name == *name && record.fields == typed
+                }) {
+                    Some(index) => index,
+                    None => {
+                        self.records.push(RecordInfo {
+                            name: name.clone(),
+                            fields: typed,
+                            lambda_fields: Vec::new(),
+                            usable: true,
+                        });
+                        self.records.len() - 1
+                    }
+                };
+                Some(ValueType::Record(index as u32))
+            }
             // Collection literals over locals: the whole-program inference
             // cannot see these bindings, so the element type is inferred here.
             // `unit(x) = [x]` in a Monad instance is exactly this shape.
@@ -7921,6 +8219,21 @@ impl Emitter {
                             _ => None,
                         };
                     }
+                    // A map's keys and values are lists of its two halves,
+                    // which is what types every fold that walks a map --
+                    // `std.map`'s `toPairs` among them.
+                    "Map#keys" | "keys" => {
+                        return match first_type {
+                            Some(ValueType::Map(key, _)) => Some(ValueType::List(key)),
+                            _ => None,
+                        };
+                    }
+                    "Map#values" | "values" => {
+                        return match first_type {
+                            Some(ValueType::Map(_, value)) => Some(ValueType::List(value)),
+                            _ => None,
+                        };
+                    }
                     "getOrElse" | "Map#getOrElse" => {
                         return match first_type {
                             Some(ValueType::Map(_, value)) => Some(elem_value_type(value)),
@@ -8004,11 +8317,46 @@ impl Emitter {
                     let params = &generic.params;
                     let body = &generic.body;
                     let mut callee_locals = Vec::with_capacity(params.len());
+                    // A function argument is not a value, so it cannot be
+                    // typed as one: it is bound as a lambda for the callee,
+                    // the way compiling the specialisation binds it. Without
+                    // this a def that hands a lambda on -- `words()` calling
+                    // `stdlibFilter` -- could not be typed at all.
+                    let mut callee_lambdas: Vec<(String, usize)> = Vec::new();
                     for (param, argument) in params.iter().zip(arguments.iter()) {
+                        if let Expr::Lambda {
+                            params: lambda_params,
+                            body: lambda_body,
+                            ..
+                        } = argument
+                        {
+                            let index = self
+                                .intern_lambda(lambda_params.clone(), lambda_body.as_ref().clone());
+                            callee_lambdas.push((param.clone(), index));
+                            continue;
+                        }
+                        if let Expr::Identifier { name, .. } = argument
+                            && let Some(index) = self.lookup_lambda(name)
+                        {
+                            callee_lambdas.push((param.clone(), index));
+                            continue;
+                        }
                         let ty = self.static_type_under(argument, locals, depth + 1)?;
                         callee_locals.push((param.clone(), ty));
                     }
-                    return self.static_type_under(body, &mut callee_locals, depth + 1);
+                    if callee_lambdas.is_empty() {
+                        return self.static_type_under(body, &mut callee_locals, depth + 1);
+                    }
+                    self.push_binding_scopes();
+                    for (param, lambda) in &callee_lambdas {
+                        self.lambda_bindings
+                            .last_mut()
+                            .expect("emitter lambda scope")
+                            .insert(param.clone(), *lambda);
+                    }
+                    let predicted = self.static_type_under(body, &mut callee_locals, depth + 1);
+                    self.pop_binding_scopes();
+                    return predicted;
                 }
                 self.static_type_of(expr)
             }
@@ -8972,7 +9320,10 @@ impl Emitter {
                         self.asm.emit_write_rodata(STDOUT_FD, b"false\n");
                         self.asm.bind(bool_end);
                     }
-                    ListElem::Double | ListElem::Enum(_) | ListElem::Nested { .. } => {
+                    ListElem::Double
+                    | ListElem::Enum(_)
+                    | ListElem::Record(_)
+                    | ListElem::Nested { .. } => {
                         return Err(unsupported(
                             argument.span(),
                             &format!("printing a nullable {elem:?}"),

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -3117,7 +3117,7 @@ impl Emitter {
                     && list_args.len() == 1
                     && let Expr::Identifier { name, .. } = inner.as_ref()
                     && name == "foldLeft"
-                    && let Expr::Lambda { params, body, .. } = &arguments[0]
+                    && let Some((params, body)) = self.lambda_argument(&arguments[0])
                     && params.len() == 2
                 {
                     return self.emit_list_fold_left(
@@ -3125,7 +3125,7 @@ impl Emitter {
                         &initial_args[0],
                         &params[0],
                         &params[1],
-                        body,
+                        &body,
                         *span,
                     );
                 }
@@ -8709,7 +8709,7 @@ impl Emitter {
                     // own fold does: starting from `[]` and appending lists
                     // ends up a list. Take the same fixpoint here so a
                     // fold-based function's return type is the settled one.
-                    if let Expr::Lambda { params, body, .. } = &arguments[0]
+                    if let Some((params, body)) = self.lambda_argument(&arguments[0])
                         && params.len() == 2
                         && list_args.len() == 1
                         && let Some(ValueType::List(elem)) =
@@ -8720,7 +8720,7 @@ impl Emitter {
                         for _ in 0..3 {
                             locals.push((params[0].clone(), acc_ty));
                             locals.push((params[1].clone(), elem_ty));
-                            let folded = self.static_type_under(body, locals, depth + 1);
+                            let folded = self.static_type_under(&body, locals, depth + 1);
                             locals.pop();
                             locals.pop();
                             let Some(merged) = folded.and_then(|f| self.merge_types(acc_ty, f))
@@ -8905,9 +8905,11 @@ impl Emitter {
                     }
                     "isEmpty" | "contains" | "isEmptyString" | "matches" | "containsKey"
                     | "Map#containsKey" | "Map#isEmpty" | "Map#containsValue" | "Set#isEmpty"
-                    | "Set#contains" => {
+                    | "Set#contains" | "startsWith" | "endsWith" | "String#isInt"
+                    | "String#isDouble" => {
                         return Some(ValueType::Bool);
                     }
+                    "String#parseInt" => return Some(ValueType::Int),
                     // The set builders, so `std.set`'s extension methods can
                     // be typed: two of them answer with a set, and reading one
                     // as a list keeps the element type.
@@ -9008,7 +9010,8 @@ impl Emitter {
                     }
                     "__match_fail" => return Some(ValueType::Never),
                     "toString" | "substring" | "trim" | "toUpperCase" | "toLowerCase"
-                    | "reverse" | "join" | "replaceAll" | "replace" | "repeat" | "at" => {
+                    | "reverse" | "join" | "replaceAll" | "replace" | "repeat" | "at"
+                    | "capitalize" | "stripPrefix" | "stripSuffix" | "trimLeft" | "trimRight" => {
                         return Some(ValueType::Str);
                     }
                     _ => {}
@@ -9723,10 +9726,47 @@ impl Emitter {
     fn lambda_argument(&self, expr: &Expr) -> Option<(Vec<String>, Expr)> {
         match expr {
             Expr::Lambda { params, body, .. } => Some((params.clone(), (**body).clone())),
-            Expr::Identifier { name, .. } => {
-                let index = self.lookup_lambda(name)?;
-                let (params, body) = &self.lambdas[index];
-                Some((params.clone(), body.clone()))
+            Expr::Identifier { name, span } => {
+                if let Some(index) = self.lookup_lambda(name) {
+                    let (params, body) = &self.lambdas[index];
+                    return Some((params.clone(), body.clone()));
+                }
+                // A *definition* passed where a function is expected --
+                // `foldLeft(xs)([])(insertSorted)`, which is how `std.list`'s
+                // sort is written. Wrapping it in a lambda that forwards its
+                // arguments is what makes it a value here, since this backend
+                // has no way to pass one.
+                let arity = self
+                    .functions
+                    .iter()
+                    .find(|(n, _)| n == name)
+                    .map(|(_, info)| info.params.len())
+                    .or_else(|| {
+                        self.generic_functions
+                            .iter()
+                            .rev()
+                            .find(|generic| generic.name == *name)
+                            .map(|generic| generic.params.len())
+                    })?;
+                let params: Vec<String> = (0..arity).map(|i| format!("__arg{i}")).collect();
+                let arguments = params
+                    .iter()
+                    .map(|param| Expr::Identifier {
+                        name: param.clone(),
+                        span: *span,
+                    })
+                    .collect();
+                Some((
+                    params,
+                    Expr::Call {
+                        callee: Box::new(Expr::Identifier {
+                            name: name.clone(),
+                            span: *span,
+                        }),
+                        arguments,
+                        span: *span,
+                    },
+                ))
             }
             // `{ (x) => ... }` and `{x, y => ...}`: a braced block whose only
             // expression is the lambda, which is how a trailing block argument

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -1714,6 +1714,8 @@ struct Emitter {
     /// The records whose rendering is currently being emitted, so a record
     /// that holds itself is rejected instead of printed forever.
     printing_records: Vec<u32>,
+    /// The same, for enums: a cons-style one holds its own shape.
+    printing_enums: Vec<u32>,
     /// Lazily emitted set helpers (called via `bl`): scalar / string
     /// membership scans and a cons-list reverse.
     member_scalar_label: Option<Label>,
@@ -3365,6 +3367,9 @@ impl Emitter {
                         let offset = self.asm.intern_string_object("%[]");
                         self.asm.load_rodata_address(Reg::X0, offset);
                         self.emit_heap_string_copy();
+                    }
+                    ValueType::Enum(shape) => {
+                        self.emit_enum_to_str(shape, hole.span())?;
                     }
                     other => {
                         return Err(unsupported(
@@ -5896,10 +5901,8 @@ impl Emitter {
             ListElem::Double => {
                 return Err(unsupported(span, "printing a Double element"));
             }
-            // An enum element would need this backend to know how the
-            // evaluator renders that enum, which it does not.
-            ListElem::Enum(_) => {
-                return Err(unsupported(span, "printing an enum element"));
+            ListElem::Enum(shape) => {
+                self.emit_print_enum_inline(shape, span)?;
             }
             ListElem::Record(index) => {
                 self.emit_print_record_inline(index, span)?;
@@ -6018,6 +6021,76 @@ impl Emitter {
         }
         self.asm.pop(Reg::X0); // discard the saved object
         self.asm.emit_write_rodata(STDOUT_FD, b")");
+        Ok(())
+    }
+
+    /// The evaluator's rendering of an enum value in x0 -- `Some(3)`, `None`,
+    /// `Ok(1)` -- without a newline, so it reads the same alone, inside a list,
+    /// or inside a record. The value is `[boxed tag][payload...]`, so this is a
+    /// comparison per variant against the tag the constructor stored.
+    fn emit_print_enum_inline(&mut self, shape: u32, span: Span) -> Result<(), Diagnostic> {
+        if self.printing_enums.contains(&shape) {
+            return Err(unsupported(span, "printing an enum that holds itself"));
+        }
+        self.printing_enums.push(shape);
+        let result = self.emit_print_enum_variants(shape, span);
+        self.printing_enums.pop();
+        result
+    }
+
+    fn emit_print_enum_variants(&mut self, shape: u32, span: Span) -> Result<(), Diagnostic> {
+        let (enum_index, payloads) = self.enum_shapes[shape as usize].clone();
+        let variants = self.generic_enums[enum_index].1.clone();
+        let end = self.asm.new_label();
+        self.asm.push(Reg::X0); // the value survives the writes below
+        for (tag, (variant, arity)) in variants.iter().enumerate() {
+            // A payload this shape never carries means no value of it is this
+            // variant, which is the same reading `match` takes of `Never`.
+            if payloads[tag].contains(&ValueType::Never) {
+                continue;
+            }
+            let next = self.asm.new_label();
+            self.asm.pop(Reg::X0);
+            self.asm.push(Reg::X0);
+            self.emit_gc_load_ptr(Reg::X0, 0); // the boxed tag
+            self.emit_unbox_scalar();
+            self.asm.cmp_imm(Reg::X0, tag as u32);
+            self.asm.branch(next, BranchKind::Conditional(Cond::Ne));
+            self.asm.emit_write_rodata(STDOUT_FD, variant.as_bytes());
+            if *arity > 0 {
+                self.asm.emit_write_rodata(STDOUT_FD, b"(");
+                let fields = payloads[tag].clone();
+                for (position, field_ty) in fields.iter().copied().take(*arity).enumerate() {
+                    if position > 0 {
+                        self.asm.emit_write_rodata(STDOUT_FD, b", ");
+                    }
+                    self.asm.pop(Reg::X0);
+                    self.asm.push(Reg::X0);
+                    self.emit_gc_load_ptr(Reg::X0, (position as u32 + 1) * 8);
+                    if is_boxed_scalar(field_ty) {
+                        self.emit_unbox_scalar();
+                    }
+                    match field_ty {
+                        ValueType::Enum(inner) => self.emit_print_enum_inline(inner, span)?,
+                        ValueType::Record(inner) => self.emit_print_record_inline(inner, span)?,
+                        other => {
+                            let Some(elem) = list_elem_of(other) else {
+                                return Err(unsupported(
+                                    span,
+                                    "printing an enum payload of this type",
+                                ));
+                            };
+                            self.emit_print_elem(elem, span)?;
+                        }
+                    }
+                }
+                self.asm.emit_write_rodata(STDOUT_FD, b")");
+            }
+            self.asm.branch(end, BranchKind::Unconditional);
+            self.asm.bind(next);
+        }
+        self.asm.bind(end);
+        self.asm.pop(Reg::X0); // discard the saved value
         Ok(())
     }
 
@@ -6504,12 +6577,14 @@ impl Emitter {
                 self.close_temp_roots(mark);
                 Ok(Some(ValueType::List(elem)))
             }
-            ("isEmpty", 1) | ("Map#isEmpty", 1) => {
+            ("isEmpty", 1) | ("Map#isEmpty", 1) | ("Set#isEmpty", 1) => {
                 let ty = self.expression(&arguments[0])?;
                 if !matches!(
                     ty,
                     ValueType::List(_)
                         | ValueType::EmptyList
+                        | ValueType::Set(_)
+                        | ValueType::EmptySet
                         | ValueType::Map(..)
                         | ValueType::EmptyMap
                 ) {
@@ -6543,7 +6618,7 @@ impl Emitter {
                     span,
                 )?))
             }
-            ("size", 1) | ("Map#size", 1) => {
+            ("size", 1) | ("Map#size", 1) | ("Set#size", 1) => {
                 let ty = self.expression(&arguments[0])?;
                 if !matches!(
                     ty,
@@ -6919,7 +6994,7 @@ impl Emitter {
                 self.asm.bind(end);
                 Ok(Some(ValueType::Nullable(value_elem)))
             }
-            ("contains", 2) => {
+            ("contains", 2) | ("Set#contains", 2) => {
                 let set_ty = self.expression(&arguments[0])?;
                 let elem = match set_ty {
                     ValueType::Set(elem) => Some(elem),
@@ -6942,6 +7017,162 @@ impl Emitter {
                     None => self.asm.mov_imm64(Reg::X0, 0),
                 }
                 Ok(Some(ValueType::Bool))
+            }
+            // The rest of the `Set#*` family `std.set`'s extension methods
+            // delegate to. A set is an insertion-ordered chain with no
+            // duplicates, which is the same chain a list is -- so reading one
+            // as a list is a type change, and the two builders below are the
+            // set literal's own loop over a chain that is only known while
+            // running.
+            ("Set#empty", 0) => {
+                self.asm.mov_imm64(Reg::X0, 0);
+                Ok(Some(ValueType::EmptySet))
+            }
+            ("Set#toList", 1) => {
+                let ty = self.expression(&arguments[0])?;
+                match ty {
+                    ValueType::Set(elem) => Ok(Some(ValueType::List(elem))),
+                    ValueType::EmptySet => Ok(Some(ValueType::EmptyList)),
+                    ValueType::List(_) | ValueType::EmptyList => Ok(Some(ty)),
+                    _ => Err(unsupported(span, "a set builtin on a non-set")),
+                }
+            }
+            // `Set#add(s, x)`: the same set when `x` is already in it, and
+            // otherwise a fresh chain holding `x` last -- built by copying the
+            // old one backwards, prepending `x`, and reversing, so insertion
+            // order comes out the way the evaluator prints it.
+            ("Set#add", 2) => {
+                let mark = self.open_temp_roots();
+                let set_ty = self.expression(&arguments[0])?;
+                let declared = match set_ty {
+                    ValueType::Set(elem) => Some(elem),
+                    ValueType::EmptySet => None,
+                    _ => return Err(unsupported(span, "a set builtin on a non-set")),
+                };
+                let source = self.reserve_locals(8);
+                self.asm.store_local(Reg::X0, source);
+                self.emit_root_frame_slot(source);
+                let value_ty = self.expression(&arguments[1])?;
+                let Some(elem) = list_elem_of(value_ty) else {
+                    return Err(unsupported(
+                        arguments[1].span(),
+                        "a set element of this type",
+                    ));
+                };
+                if declared.is_some_and(|declared| declared != elem) {
+                    return Err(unsupported(span, "adding an element of another type"));
+                }
+                let raw = self.reserve_locals(8);
+                self.asm.store_local(Reg::X0, raw);
+                if is_heap_pointer(value_ty) {
+                    self.emit_root_frame_slot(raw);
+                }
+                let boxed = self.reserve_locals(8);
+                if is_boxed_scalar(value_ty) {
+                    self.emit_box_scalar();
+                }
+                self.asm.store_local(Reg::X0, boxed);
+                self.emit_root_frame_slot(boxed);
+                // Already a member? Then the set is its own answer.
+                let present = self.asm.new_label();
+                let end = self.asm.new_label();
+                self.asm.load_local(Reg::X1, raw);
+                self.asm.load_local(Reg::X0, source);
+                let member = self.member_label(elem);
+                self.asm.branch(member, BranchKind::Link);
+                self.asm
+                    .branch(present, BranchKind::CompareNonZero(Reg::X0));
+                let acc = self.reserve_locals(8);
+                self.asm.mov_imm64(Reg::X0, 0);
+                self.asm.store_local(Reg::X0, acc);
+                self.emit_root_frame_slot(acc);
+                let cursor = self.reserve_locals(8);
+                self.asm.load_local(Reg::X0, source);
+                self.asm.store_local(Reg::X0, cursor);
+                self.emit_root_frame_slot(cursor);
+                let loop_start = self.asm.new_label();
+                let copied = self.asm.new_label();
+                self.asm.bind(loop_start);
+                self.asm.load_local(Reg::X0, cursor);
+                self.asm.branch(copied, BranchKind::CompareZero(Reg::X0));
+                self.emit_gc_load_ptr(Reg::X0, 0); // the element, already boxed
+                self.push_rooted(Reg::X0); // head for the cons below
+                self.asm.load_local(Reg::X0, acc);
+                self.emit_cons_cell();
+                self.asm.store_local(Reg::X0, acc);
+                self.asm.load_local(Reg::X0, cursor);
+                self.emit_gc_load_ptr(Reg::X0, 8);
+                self.asm.store_local(Reg::X0, cursor);
+                self.asm.branch(loop_start, BranchKind::Unconditional);
+                self.asm.bind(copied);
+                self.asm.load_local(Reg::X0, boxed);
+                self.push_rooted(Reg::X0);
+                self.asm.load_local(Reg::X0, acc);
+                self.emit_cons_cell();
+                let reverse = self.reverse_label();
+                self.asm.branch(reverse, BranchKind::Link);
+                self.asm.branch(end, BranchKind::Unconditional);
+                self.asm.bind(present);
+                self.asm.load_local(Reg::X0, source);
+                self.asm.bind(end);
+                self.close_temp_roots(mark);
+                Ok(Some(ValueType::Set(elem)))
+            }
+            // `Set#fromList(xs)`: the set literal's loop, over a chain that is
+            // only known while running -- keep the first occurrence of each
+            // element, in the order they arrive.
+            ("Set#fromList", 1) => {
+                let mark = self.open_temp_roots();
+                let ty = self.expression(&arguments[0])?;
+                let elem = match ty {
+                    ValueType::List(elem) | ValueType::Set(elem) => elem,
+                    ValueType::EmptyList | ValueType::EmptySet => {
+                        self.close_temp_roots(mark);
+                        return Ok(Some(ValueType::EmptySet));
+                    }
+                    _ => return Err(unsupported(span, "a set builtin on a non-collection")),
+                };
+                let cursor = self.reserve_locals(8);
+                self.asm.store_local(Reg::X0, cursor);
+                self.emit_root_frame_slot(cursor);
+                let acc = self.reserve_locals(8);
+                self.asm.mov_imm64(Reg::X0, 0);
+                self.asm.store_local(Reg::X0, acc);
+                self.emit_root_frame_slot(acc);
+                let loop_start = self.asm.new_label();
+                let done = self.asm.new_label();
+                self.asm.bind(loop_start);
+                self.asm.load_local(Reg::X0, cursor);
+                self.asm.branch(done, BranchKind::CompareZero(Reg::X0));
+                self.emit_gc_load_ptr(Reg::X0, 0); // the element, already boxed
+                self.push_rooted(Reg::X0); // survives the scan, and is the head
+                if is_boxed_scalar(elem_value_type(elem)) {
+                    self.emit_unbox_scalar();
+                }
+                self.asm.mov_reg(Reg::X1, Reg::X0); // candidate
+                self.asm.load_local(Reg::X0, acc);
+                let member = self.member_label(elem);
+                self.asm.branch(member, BranchKind::Link);
+                let skip = self.asm.new_label();
+                let after = self.asm.new_label();
+                self.asm.branch(skip, BranchKind::CompareNonZero(Reg::X0));
+                self.asm.load_local(Reg::X0, acc);
+                self.emit_cons_cell(); // takes the parked head
+                self.asm.store_local(Reg::X0, acc);
+                self.asm.branch(after, BranchKind::Unconditional);
+                self.asm.bind(skip);
+                self.pop_rooted(Reg::X0); // a duplicate: drop the parked head
+                self.asm.bind(after);
+                self.asm.load_local(Reg::X0, cursor);
+                self.emit_gc_load_ptr(Reg::X0, 8);
+                self.asm.store_local(Reg::X0, cursor);
+                self.asm.branch(loop_start, BranchKind::Unconditional);
+                self.asm.bind(done);
+                self.asm.load_local(Reg::X0, acc);
+                let reverse = self.reverse_label();
+                self.asm.branch(reverse, BranchKind::Link);
+                self.close_temp_roots(mark);
+                Ok(Some(ValueType::Set(elem)))
             }
             // ---- enum-lowering primitives (`desugar_enums`) ----
             // `__gc_record(n)` / `__gc_alloc(bytes)`: zeroed heap
@@ -7445,8 +7676,9 @@ impl Emitter {
             ListElem::Int => self.emit_int_to_str(),
             ListElem::Bool => self.emit_bool_to_str(),
             ListElem::Str => {}
-            ListElem::Enum(_) | ListElem::Record(_) => {
-                return Err(unsupported(span, "rendering an enum element"));
+            ListElem::Enum(shape) => self.emit_enum_to_str(shape, span)?,
+            ListElem::Record(_) => {
+                return Err(unsupported(span, "rendering a record element"));
             }
             // Same renderer one level down; the element pointer is already in
             // x0, and the result replaces it.
@@ -7477,6 +7709,99 @@ impl Emitter {
         self.asm.mov_reg(Reg::X1, Reg::X0);
         self.asm.load_local(Reg::X0, acc);
         self.emit_str_concat();
+        self.close_temp_roots(mark);
+        Ok(())
+    }
+
+    /// Append the text of a literal to the string builder in `acc`.
+    fn emit_append_literal(&mut self, acc: u32, text: &str) {
+        let offset = self.asm.intern_string_object(text);
+        self.asm.load_rodata_address(Reg::X0, offset);
+        self.emit_heap_string_copy();
+        self.asm.mov_reg(Reg::X1, Reg::X0);
+        self.asm.load_local(Reg::X0, acc);
+        self.emit_str_concat();
+        self.asm.store_local(Reg::X0, acc);
+    }
+
+    /// The rendering `emit_print_enum_inline` writes to stdout, built as a heap
+    /// string instead -- which is what `"#{result}"` and a list of enums need.
+    /// The value is in x0 and the string replaces it.
+    fn emit_enum_to_str(&mut self, shape: u32, span: Span) -> Result<(), Diagnostic> {
+        if self.printing_enums.contains(&shape) {
+            return Err(unsupported(span, "rendering an enum that holds itself"));
+        }
+        self.printing_enums.push(shape);
+        let result = self.emit_enum_to_str_variants(shape, span);
+        self.printing_enums.pop();
+        result
+    }
+
+    fn emit_enum_to_str_variants(&mut self, shape: u32, span: Span) -> Result<(), Diagnostic> {
+        let (enum_index, payloads) = self.enum_shapes[shape as usize].clone();
+        let variants = self.generic_enums[enum_index].1.clone();
+        let mark = self.open_temp_roots();
+        let value = self.reserve_locals(16);
+        let acc = value + 8;
+        self.asm.store_local(Reg::X0, value);
+        self.emit_root_frame_slot(value);
+        // The builder starts empty, and is rooted before any branch so every
+        // path through the switch below has pushed the same roots.
+        let empty = self.asm.intern_string_object("");
+        self.asm.load_rodata_address(Reg::X0, empty);
+        self.emit_heap_string_copy();
+        self.asm.store_local(Reg::X0, acc);
+        self.emit_root_frame_slot(acc);
+        let end = self.asm.new_label();
+        for (tag, (variant, arity)) in variants.iter().enumerate() {
+            if payloads[tag].contains(&ValueType::Never) {
+                continue;
+            }
+            let next = self.asm.new_label();
+            self.asm.load_local(Reg::X0, value);
+            self.emit_gc_load_ptr(Reg::X0, 0); // the boxed tag
+            self.emit_unbox_scalar();
+            self.asm.cmp_imm(Reg::X0, tag as u32);
+            self.asm.branch(next, BranchKind::Conditional(Cond::Ne));
+            self.emit_append_literal(acc, variant);
+            if *arity > 0 {
+                self.emit_append_literal(acc, "(");
+                let fields = payloads[tag].clone();
+                for (position, field_ty) in fields.iter().copied().take(*arity).enumerate() {
+                    if position > 0 {
+                        self.emit_append_literal(acc, ", ");
+                    }
+                    self.asm.load_local(Reg::X0, value);
+                    self.emit_gc_load_ptr(Reg::X0, (position as u32 + 1) * 8);
+                    if is_boxed_scalar(field_ty) {
+                        self.emit_unbox_scalar();
+                    }
+                    match field_ty {
+                        ValueType::Int => self.emit_int_to_str(),
+                        ValueType::Bool => self.emit_bool_to_str(),
+                        ValueType::Str => {}
+                        ValueType::Enum(inner) => self.emit_enum_to_str(inner, span)?,
+                        ValueType::List(elem) => self.emit_list_to_str(elem, "[", "]", span)?,
+                        ValueType::Set(elem) => self.emit_list_to_str(elem, "%(", ")", span)?,
+                        other => {
+                            return Err(unsupported(
+                                span,
+                                &format!("rendering an enum payload of type {other:?}"),
+                            ));
+                        }
+                    }
+                    self.asm.mov_reg(Reg::X1, Reg::X0);
+                    self.asm.load_local(Reg::X0, acc);
+                    self.emit_str_concat();
+                    self.asm.store_local(Reg::X0, acc);
+                }
+                self.emit_append_literal(acc, ")");
+            }
+            self.asm.branch(end, BranchKind::Unconditional);
+            self.asm.bind(next);
+        }
+        self.asm.bind(end);
+        self.asm.load_local(Reg::X0, acc);
         self.close_temp_roots(mark);
         Ok(())
     }
@@ -8193,12 +8518,41 @@ impl Emitter {
                     // `floor`/`int`/`ceil` are Int-valued here, like the
                     // evaluator's -- keeping this in step with the emitter
                     // matters, since a wrong guess is a rejected build.
-                    "size" | "length" | "toInt" | "floor" | "int" | "ceil" | "Map#size" => {
+                    "size" | "length" | "toInt" | "floor" | "int" | "ceil" | "Map#size"
+                    | "Set#size" => {
                         return Some(ValueType::Int);
                     }
                     "isEmpty" | "contains" | "isEmptyString" | "matches" | "containsKey"
-                    | "Map#containsKey" | "Map#isEmpty" | "Map#containsValue" => {
+                    | "Map#containsKey" | "Map#isEmpty" | "Map#containsValue" | "Set#isEmpty"
+                    | "Set#contains" => {
                         return Some(ValueType::Bool);
+                    }
+                    // The set builders, so `std.set`'s extension methods can
+                    // be typed: two of them answer with a set, and reading one
+                    // as a list keeps the element type.
+                    "Set#empty" => return Some(ValueType::EmptySet),
+                    "Set#toList" => {
+                        return match first_type {
+                            Some(ValueType::Set(elem)) => Some(ValueType::List(elem)),
+                            Some(ValueType::EmptySet) => Some(ValueType::EmptyList),
+                            other @ (Some(ValueType::List(_)) | Some(ValueType::EmptyList)) => {
+                                other
+                            }
+                            _ => None,
+                        };
+                    }
+                    "Set#add" | "Set#fromList" => {
+                        return match first_type {
+                            Some(ValueType::Set(elem)) | Some(ValueType::List(elem)) => {
+                                Some(ValueType::Set(elem))
+                            }
+                            Some(ValueType::EmptySet) | Some(ValueType::EmptyList)
+                                if name == "Set#fromList" =>
+                            {
+                                Some(ValueType::EmptySet)
+                            }
+                            _ => None,
+                        };
                     }
                     // Splitting a string is how `std.string`'s `lines` and
                     // `words` start, so the inference has to get through it to
@@ -9334,6 +9688,11 @@ impl Emitter {
                 self.asm.bind(null_label);
                 self.asm.emit_write_rodata(STDOUT_FD, b"null\n");
                 self.asm.bind(end_label);
+                Ok(())
+            }
+            ValueType::Enum(shape) => {
+                self.emit_print_enum_inline(shape, argument.span())?;
+                self.asm.emit_write_rodata(STDOUT_FD, b"\n");
                 Ok(())
             }
             other => Err(unsupported(

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -1727,6 +1727,10 @@ struct Emitter {
     printing_records: Vec<u32>,
     /// The same, for enums: a cons-style one holds its own shape.
     printing_enums: Vec<u32>,
+    /// The pseudo-random generator's state, reserved the first time a program
+    /// asks for a random number. Zero until seeded, which is where the
+    /// evaluator's own generator starts.
+    random_state_cell: Option<DataLabel>,
     /// Lazily emitted set helpers (called via `bl`): scalar / string
     /// membership scans and a cons-list reverse.
     member_scalar_label: Option<Label>,
@@ -6553,6 +6557,131 @@ impl Emitter {
                 self.close_temp_roots(mark);
                 Ok(Some(ValueType::Str))
             }
+            // `Random#seed(n)` / `Random#nextInt(bound)`: the evaluator's
+            // generator, which is a 64-bit LCG whose high half is the answer.
+            // The same constants and the same shift, so a seeded program
+            // prints the same numbers here as it does there.
+            ("Random#seed", 1) => {
+                if self.expression(&arguments[0])? != ValueType::Int {
+                    return Err(unsupported(span, "Random#seed of a non-Int"));
+                }
+                let cell = self.random_state_cell();
+                self.asm.load_data_address(Reg::X1, cell);
+                self.asm.str_imm(Reg::X0, Reg::X1, 0);
+                Ok(Some(ValueType::Unit))
+            }
+            ("Random#nextInt", 1) => {
+                if self.expression(&arguments[0])? != ValueType::Int {
+                    return Err(unsupported(span, "Random#nextInt of a non-Int"));
+                }
+                let cell = self.random_state_cell();
+                self.asm.mov_reg(Reg::X4, Reg::X0); // bound
+                self.asm.load_data_address(Reg::X1, cell);
+                self.asm.ldr_imm(Reg::X0, Reg::X1, 0);
+                self.asm.mov_imm64(Reg::X2, 6_364_136_223_846_793_005);
+                self.asm.mul_reg(Reg::X0, Reg::X0, Reg::X2);
+                self.asm.mov_imm64(Reg::X2, 1_442_695_040_888_963_407);
+                self.asm.add_reg(Reg::X0, Reg::X0, Reg::X2);
+                self.asm.str_imm(Reg::X0, Reg::X1, 0);
+                self.asm.lsr_imm(Reg::X0, Reg::X0, 32);
+                self.asm.sdiv_reg(Reg::X2, Reg::X0, Reg::X4);
+                self.asm.msub_reg(Reg::X0, Reg::X2, Reg::X4, Reg::X0);
+                Ok(Some(ValueType::Int))
+            }
+            // The `Math#*` integer helpers, by the evaluator's own algorithms:
+            // Euclid on the absolute values, square-and-multiply, and Newton's
+            // iteration. A negative exponent or radicand is a runtime error in
+            // the evaluator; here they answer 1 and 0, since this backend has
+            // no way to raise one.
+            ("Math#gcd", 2) => {
+                if self.expression(&arguments[0])? != ValueType::Int {
+                    return Err(unsupported(span, "Math#gcd of a non-Int"));
+                }
+                self.asm.push(Reg::X0);
+                if self.expression(&arguments[1])? != ValueType::Int {
+                    return Err(unsupported(span, "Math#gcd of a non-Int"));
+                }
+                self.asm.mov_reg(Reg::X1, Reg::X0);
+                self.asm.pop(Reg::X0);
+                for reg in [Reg::X0, Reg::X1] {
+                    let non_negative = self.asm.new_label();
+                    self.asm.cmp_imm(reg, 0);
+                    self.asm
+                        .branch(non_negative, BranchKind::Conditional(Cond::Ge));
+                    self.asm.mov_imm64(Reg::X2, 0);
+                    self.asm.sub_reg(reg, Reg::X2, reg);
+                    self.asm.bind(non_negative);
+                }
+                let loop_start = self.asm.new_label();
+                let done = self.asm.new_label();
+                self.asm.bind(loop_start);
+                self.asm.branch(done, BranchKind::CompareZero(Reg::X1));
+                self.asm.sdiv_reg(Reg::X2, Reg::X0, Reg::X1);
+                self.asm.msub_reg(Reg::X2, Reg::X2, Reg::X1, Reg::X0); // a % b
+                self.asm.mov_reg(Reg::X0, Reg::X1);
+                self.asm.mov_reg(Reg::X1, Reg::X2);
+                self.asm.branch(loop_start, BranchKind::Unconditional);
+                self.asm.bind(done);
+                Ok(Some(ValueType::Int))
+            }
+            ("Math#powInt", 2) => {
+                if self.expression(&arguments[0])? != ValueType::Int {
+                    return Err(unsupported(span, "Math#powInt of a non-Int"));
+                }
+                self.asm.push(Reg::X0);
+                if self.expression(&arguments[1])? != ValueType::Int {
+                    return Err(unsupported(span, "Math#powInt of a non-Int"));
+                }
+                self.asm.mov_reg(Reg::X1, Reg::X0); // exponent
+                self.asm.pop(Reg::X2); // base
+                self.asm.mov_imm64(Reg::X0, 1); // result
+                let loop_start = self.asm.new_label();
+                let done = self.asm.new_label();
+                let skip = self.asm.new_label();
+                self.asm.bind(loop_start);
+                self.asm.cmp_imm(Reg::X1, 0);
+                self.asm.branch(done, BranchKind::Conditional(Cond::Le));
+                self.asm.mov_imm64(Reg::X3, 1);
+                self.asm.tst_reg(Reg::X1, Reg::X3);
+                self.asm.branch(skip, BranchKind::Conditional(Cond::Eq));
+                self.asm.mul_reg(Reg::X0, Reg::X0, Reg::X2);
+                self.asm.bind(skip);
+                self.asm.lsr_imm(Reg::X1, Reg::X1, 1);
+                self.asm.mul_reg(Reg::X2, Reg::X2, Reg::X2);
+                self.asm.branch(loop_start, BranchKind::Unconditional);
+                self.asm.bind(done);
+                Ok(Some(ValueType::Int))
+            }
+            ("Math#sqrtInt", 1) => {
+                if self.expression(&arguments[0])? != ValueType::Int {
+                    return Err(unsupported(span, "Math#sqrtInt of a non-Int"));
+                }
+                let done = self.asm.new_label();
+                let positive = self.asm.new_label();
+                self.asm.mov_reg(Reg::X1, Reg::X0); // n
+                self.asm.cmp_imm(Reg::X1, 0);
+                self.asm.branch(positive, BranchKind::Conditional(Cond::Gt));
+                self.asm.mov_imm64(Reg::X0, 0);
+                self.asm.branch(done, BranchKind::Unconditional);
+                self.asm.bind(positive);
+                // x = n; y = (x + 1) / 2; while y < x { x = y; y = (x + n/x)/2 }
+                self.asm.mov_reg(Reg::X0, Reg::X1); // x
+                self.asm.add_reg_imm(Reg::X2, Reg::X0, 1);
+                self.asm.mov_imm64(Reg::X3, 2);
+                self.asm.sdiv_reg(Reg::X2, Reg::X2, Reg::X3); // y
+                let loop_start = self.asm.new_label();
+                self.asm.bind(loop_start);
+                self.asm.cmp_reg(Reg::X2, Reg::X0);
+                self.asm.branch(done, BranchKind::Conditional(Cond::Ge));
+                self.asm.mov_reg(Reg::X0, Reg::X2); // x = y
+                self.asm.sdiv_reg(Reg::X4, Reg::X1, Reg::X0); // n / x
+                self.asm.add_reg(Reg::X2, Reg::X0, Reg::X4);
+                self.asm.mov_imm64(Reg::X3, 2);
+                self.asm.sdiv_reg(Reg::X2, Reg::X2, Reg::X3);
+                self.asm.branch(loop_start, BranchKind::Unconditional);
+                self.asm.bind(done);
+                Ok(Some(ValueType::Int))
+            }
             ("startsWith", 2) => {
                 if self.expression(&arguments[0])? != ValueType::Str {
                     return Err(unsupported(span, "startsWith of a non-string"));
@@ -8770,7 +8899,8 @@ impl Emitter {
                     // evaluator's -- keeping this in step with the emitter
                     // matters, since a wrong guess is a rejected build.
                     "size" | "length" | "toInt" | "floor" | "int" | "ceil" | "Map#size"
-                    | "Set#size" | "indexOf" | "lastIndexOf" => {
+                    | "Set#size" | "indexOf" | "lastIndexOf" | "Math#gcd" | "Math#powInt"
+                    | "Math#sqrtInt" => {
                         return Some(ValueType::Int);
                     }
                     "isEmpty" | "contains" | "isEmptyString" | "matches" | "containsKey"
@@ -9750,6 +9880,19 @@ impl Emitter {
                     *entry = (slot, widened);
                     break;
                 }
+            }
+        }
+    }
+
+    /// The generator's state cell, reserved on first use so a program that
+    /// never asks for a random number carries no data section for one.
+    fn random_state_cell(&mut self) -> DataLabel {
+        match self.random_state_cell {
+            Some(cell) => cell,
+            None => {
+                let cell = self.asm.reserve_data_cells(1);
+                self.random_state_cell = Some(cell);
+                cell
             }
         }
     }

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -1477,6 +1477,22 @@ fn elem_value_type(elem: ListElem) -> ValueType {
 /// Replace whole-identifier occurrences of each type parameter in an
 /// annotation with its argument: `Chain<a>` with `a = Int` becomes
 /// `Chain<Int>`, while `Char` is left alone.
+/// The annotation a type would be written as, for the types a type variable
+/// can be solved to from an argument. Anything else answers `None`, which
+/// leaves the variable unsolved rather than guessing.
+fn type_annotation_name(ty: ValueType) -> Option<String> {
+    Some(
+        match ty {
+            ValueType::Int => "Int",
+            ValueType::Str => "String",
+            ValueType::Bool => "Boolean",
+            ValueType::Double => "Double",
+            _ => return None,
+        }
+        .to_string(),
+    )
+}
+
 fn substitute_type_params(text: &str, params: &[String], arguments: &[String]) -> String {
     let mut out = String::with_capacity(text.len());
     let mut token = String::new();
@@ -9492,7 +9508,8 @@ impl Emitter {
         let mut value_params: Vec<(String, ValueType)> = Vec::new();
         let mut lambda_params: Vec<(String, usize)> = Vec::new();
         let mut dict_params: Vec<(String, Vec<(String, usize)>)> = Vec::new();
-        for (param, argument) in params.iter().zip(arguments.iter()) {
+        let mut value_annotations: Vec<Option<String>> = Vec::new();
+        for (position, (param, argument)) in params.iter().zip(arguments.iter()).enumerate() {
             // A lambda argument is not a value: it is interned and the
             // parameter name is bound to it inside the specialisation, so a
             // higher-order def is specialised per lambda as well as per type.
@@ -9535,6 +9552,57 @@ impl Emitter {
             }
             argument_types.push(ty);
             value_params.push((param.clone(), ty));
+            value_annotations.push(param_annotations.get(position).cloned().flatten());
+        }
+        // Solve the definition's type variables from *all* the arguments, and
+        // give an enum-typed parameter whose own argument left them open the
+        // shape those solutions imply. `put(KMNil, "a", 1)` says nothing
+        // through its first argument -- the empty case carries no payloads --
+        // while `key: 'k` and `value: 'v` say everything, and without this the
+        // body destructures the other variant against payloads it does not
+        // know.
+        let mut bindings: Vec<(String, String)> = Vec::new();
+        for ((_, ty), annotation) in value_params.iter().zip(value_annotations.iter()) {
+            let Some(annotation) = annotation else {
+                continue;
+            };
+            let text = annotation.trim();
+            if !text.starts_with('\'') {
+                continue;
+            }
+            let Some(name) = type_annotation_name(*ty) else {
+                continue;
+            };
+            if !bindings.iter().any(|(known, _)| known == text) {
+                bindings.push((text.to_string(), name));
+            }
+        }
+        if !bindings.is_empty() {
+            let variables: Vec<String> = bindings.iter().map(|(name, _)| name.clone()).collect();
+            let solutions: Vec<String> = bindings.iter().map(|(_, name)| name.clone()).collect();
+            for position in 0..value_params.len() {
+                let ValueType::Enum(shape) = value_params[position].1 else {
+                    continue;
+                };
+                let open = self.enum_shapes[shape as usize]
+                    .1
+                    .iter()
+                    .any(|payload| payload.contains(&ValueType::Never));
+                if !open {
+                    continue;
+                }
+                let Some(annotation) = value_annotations[position].clone() else {
+                    continue;
+                };
+                let applied = substitute_type_params(&annotation, &variables, &solutions);
+                if applied == annotation {
+                    continue;
+                }
+                if let Ok(resolved @ ValueType::Enum(_)) = self.annotation_type(&applied, span) {
+                    value_params[position].1 = resolved;
+                    argument_types[position] = resolved;
+                }
+            }
         }
         // The lambda identities are part of what makes a specialisation
         // distinct, so they join the argument types in the key.

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -7394,6 +7394,21 @@ impl Emitter {
             }
             ("contains", 2) | ("Set#contains", 2) => {
                 let set_ty = self.expression(&arguments[0])?;
+                // `contains` reads as membership on a set and as substring
+                // containment on a string -- the evaluator dispatches on the
+                // receiver, and `std.string`'s `containsText` is the second.
+                if set_ty == ValueType::Str {
+                    self.push_rooted(Reg::X0);
+                    if self.expression(&arguments[1])? != ValueType::Str {
+                        return Err(unsupported(span, "contains with a non-string needle"));
+                    }
+                    self.asm.mov_reg(Reg::X1, Reg::X0);
+                    self.pop_rooted(Reg::X0);
+                    self.emit_str_index_of(false);
+                    self.asm.cmp_imm(Reg::X0, 0);
+                    self.asm.cset(Reg::X0, Cond::Ge);
+                    return Ok(Some(ValueType::Bool));
+                }
                 let elem = match set_ty {
                     ValueType::Set(elem) => Some(elem),
                     ValueType::EmptySet => None,

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -2557,6 +2557,10 @@ impl Emitter {
         if is_heap_pointer(elem_ty) {
             self.emit_root_frame_slot(element);
         }
+        // The body's reads have to see what the body's writes will make of a
+        // binding, because every turn after the first reads what the previous
+        // one wrote.
+        self.widen_loop_mutables(body);
         self.statement(body)?;
         self.pop_binding_scopes();
         let roots = self.scope_root_counts.pop().expect("emitter root scope");
@@ -7318,12 +7322,11 @@ impl Emitter {
                 // Already a member? Then the set is its own answer.
                 let present = self.asm.new_label();
                 let end = self.asm.new_label();
-                self.asm.load_local(Reg::X1, raw);
-                self.asm.load_local(Reg::X0, source);
-                let member = self.member_label(elem);
-                self.asm.branch(member, BranchKind::Link);
-                self.asm
-                    .branch(present, BranchKind::CompareNonZero(Reg::X0));
+                // The copy's two slots are rooted before the branch below, not
+                // inside it. The shadow stack is popped by a count worked out
+                // while compiling, so a root pushed on one path only leaves the
+                // other path popping one that was never pushed -- which is what
+                // `Set#add(s, x)` did when `x` was already there.
                 let acc = self.reserve_locals(8);
                 self.asm.mov_imm64(Reg::X0, 0);
                 self.asm.store_local(Reg::X0, acc);
@@ -7332,6 +7335,12 @@ impl Emitter {
                 self.asm.load_local(Reg::X0, source);
                 self.asm.store_local(Reg::X0, cursor);
                 self.emit_root_frame_slot(cursor);
+                self.asm.load_local(Reg::X1, raw);
+                self.asm.load_local(Reg::X0, source);
+                let member = self.member_label(elem);
+                self.asm.branch(member, BranchKind::Link);
+                self.asm
+                    .branch(present, BranchKind::CompareNonZero(Reg::X0));
                 let loop_start = self.asm.new_label();
                 let copied = self.asm.new_label();
                 self.asm.bind(loop_start);
@@ -8833,9 +8842,34 @@ impl Emitter {
                     "getOrElse" | "Map#getOrElse" => {
                         return match first_type {
                             Some(ValueType::Map(_, value)) => Some(elem_value_type(value)),
+                            // On a map with nothing in it the answer is the
+                            // fallback, which is what the emitter does -- and
+                            // typing it is what lets a `mutable` map that is
+                            // grown in a loop settle on a type at all.
+                            Some(ValueType::EmptyMap) if arguments.len() == 3 => {
+                                self.static_type_under(&arguments[2], locals, depth + 1)
+                            }
                             _ => None,
                         };
                     }
+                    // `Map#put(m, k, v)`: a map of what the key and value are.
+                    // Without this a map grown in a loop stays typed as the
+                    // empty map it started as, and every lookup inside the loop
+                    // compiles to its fallback.
+                    "Map#put" if arguments.len() == 3 => {
+                        let key = list_elem_of(self.static_type_under(
+                            &arguments[1],
+                            locals,
+                            depth + 1,
+                        )?)?;
+                        let value = list_elem_of(self.static_type_under(
+                            &arguments[2],
+                            locals,
+                            depth + 1,
+                        )?)?;
+                        return Some(ValueType::Map(key, value));
+                    }
+                    "Map#empty" => return Some(ValueType::EmptyMap),
                     // The enum lowering's allocators. A constructor call like
                     // `Some(x)` becomes one of these, so without them a
                     // function that just wraps a constructor cannot be typed.
@@ -9659,6 +9693,67 @@ impl Emitter {
         Ok(result)
     }
 
+    /// Widen the slots of any bindings a loop body assigns to, before that
+    /// body is compiled.
+    ///
+    /// A `mutable` takes its type from what is assigned to it, and the
+    /// declaration site can settle that for straight-line code. A loop cannot
+    /// be settled there: `m = Map#put(m, k, ...)` mentions the loop's own
+    /// variable, which does not exist yet at the declaration. So the same
+    /// fixpoint is taken again here, with the loop variable bound -- otherwise
+    /// the body's *reads* compile against the type the binding started with
+    /// (`Map#empty()` is the empty map, and a lookup on one is its fallback),
+    /// which is correct on the first turn and wrong on every turn after it.
+    fn widen_loop_mutables(&mut self, body: &Expr) {
+        let names: Vec<String> = self
+            .scopes
+            .iter()
+            .flatten()
+            .map(|(name, _)| name.clone())
+            .collect();
+        for name in names {
+            let mut assigned = Vec::new();
+            collect_assignments(body, &name, &mut assigned);
+            if assigned.is_empty() {
+                continue;
+            }
+            let Some((slot, current)) = self.lookup(&name) else {
+                continue;
+            };
+            let mut widened = current;
+            for _ in 0..4 {
+                let mut grew = false;
+                for value in &assigned {
+                    let mut locals = Vec::new();
+                    let Some(ty) = self.static_type_under(value, &mut locals, 0) else {
+                        continue;
+                    };
+                    let Some(merged) = self.merge_types(widened, ty) else {
+                        continue;
+                    };
+                    if merged != widened {
+                        widened = merged;
+                        grew = true;
+                    }
+                }
+                if !grew {
+                    break;
+                }
+            }
+            if widened == current {
+                continue;
+            }
+            // Both the old type and the new one are heap references, so the
+            // root the slot already has still covers it.
+            for scope in self.scopes.iter_mut().rev() {
+                if let Some(entry) = scope.get_mut(&name) {
+                    *entry = (slot, widened);
+                    break;
+                }
+            }
+        }
+    }
+
     /// The name an `extension (this: T) { ... }` block is keyed by, worked out
     /// from what the receiver's type turns out to be. Typing it emits nothing,
     /// so asking costs only the inference.
@@ -10272,6 +10367,7 @@ impl Emitter {
                     return Err(unsupported(condition.span(), "a non-Bool condition"));
                 }
                 self.asm.branch(end_label, BranchKind::CompareZero(Reg::X0));
+                self.widen_loop_mutables(body);
                 self.statement(body)?;
                 self.asm.branch(loop_label, BranchKind::Unconditional);
                 self.asm.bind(end_label);

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -6432,6 +6432,29 @@ impl Emitter {
                 self.emit_str_matches();
                 Ok(Some(ValueType::Bool))
             }
+            // `String#isInt` / `String#isDouble`: folded when the text is known
+            // while compiling (Rust's own parse decides, so the answer is the
+            // evaluator's by construction), scanned when it is not.
+            ("String#isInt", 1) | ("String#isDouble", 1) => {
+                if let Some(text) = self.literal_string(&arguments[0]) {
+                    let answer = if name == "String#isInt" {
+                        text.trim().parse::<i64>().is_ok()
+                    } else {
+                        text.trim().parse::<f64>().is_ok()
+                    };
+                    self.asm.mov_imm64(Reg::X0, u64::from(answer));
+                    return Ok(Some(ValueType::Bool));
+                }
+                if self.expression(&arguments[0])? != ValueType::Str {
+                    return Err(unsupported(span, "a string test of a non-string"));
+                }
+                if name == "String#isInt" {
+                    self.emit_str_is_int();
+                } else {
+                    self.emit_str_is_double();
+                }
+                Ok(Some(ValueType::Bool))
+            }
             ("indexOf", 2) | ("lastIndexOf", 2) => {
                 if self.expression(&arguments[0])? != ValueType::Str {
                     return Err(unsupported(span, "indexOf of a non-string"));
@@ -8184,6 +8207,295 @@ impl Emitter {
         self.asm.load_local(Reg::X0, acc);
         self.close_temp_roots(mark);
         Ok(())
+    }
+
+    /// Leave the trimmed window of the string in x0 as `[x3, x2)` over the
+    /// bytes at x1: the evaluator's `is_int`/`is_double` both start with
+    /// `trim()`, and everything after reads that window.
+    fn emit_trim_window(&mut self) {
+        self.asm.ldr_imm(Reg::X2, Reg::X0, 0); // length
+        self.asm.add_reg_imm(Reg::X1, Reg::X0, 8); // bytes
+        self.asm.mov_imm64(Reg::X3, 0);
+        let left_loop = self.asm.new_label();
+        let left_done = self.asm.new_label();
+        self.asm.bind(left_loop);
+        self.asm.cmp_reg(Reg::X3, Reg::X2);
+        self.asm
+            .branch(left_done, BranchKind::Conditional(Cond::Ge));
+        self.asm.ldrb_reg_offset(Reg::X4, Reg::X1, Reg::X3);
+        self.emit_branch_unless_ascii_space(Reg::X4, left_done);
+        self.asm.add_reg_imm(Reg::X3, Reg::X3, 1);
+        self.asm.branch(left_loop, BranchKind::Unconditional);
+        self.asm.bind(left_done);
+        let right_loop = self.asm.new_label();
+        let right_done = self.asm.new_label();
+        self.asm.bind(right_loop);
+        self.asm.cmp_reg(Reg::X2, Reg::X3);
+        self.asm
+            .branch(right_done, BranchKind::Conditional(Cond::Le));
+        self.asm.sub_reg_imm(Reg::X5, Reg::X2, 1);
+        self.asm.ldrb_reg_offset(Reg::X4, Reg::X1, Reg::X5);
+        self.emit_branch_unless_ascii_space(Reg::X4, right_done);
+        self.asm.mov_reg(Reg::X2, Reg::X5);
+        self.asm.branch(right_loop, BranchKind::Unconditional);
+        self.asm.bind(right_done);
+    }
+
+    /// Branch to `label` unless the byte in `reg` is ASCII whitespace.
+    fn emit_branch_unless_ascii_space(&mut self, reg: Reg, label: Label) {
+        let is_space = self.asm.new_label();
+        for byte in [b' ', b'\t', b'\n', b'\r', 0x0b, 0x0c] {
+            self.asm.cmp_imm(reg, u32::from(byte));
+            self.asm.branch(is_space, BranchKind::Conditional(Cond::Eq));
+        }
+        self.asm.branch(label, BranchKind::Unconditional);
+        self.asm.bind(is_space);
+    }
+
+    /// `String#isInt(s)` for a string only known at run time: what
+    /// `s.trim().parse::<i64>()` accepts, range included. Nineteen digits is
+    /// the only length that needs comparing, and it compares digits, so no
+    /// 128-bit arithmetic is involved.
+    fn emit_str_is_int(&mut self) {
+        let positive = self.asm.intern_rodata(b"9223372036854775807");
+        let negative = self.asm.intern_rodata(b"9223372036854775808");
+        let no = self.asm.new_label();
+        let yes = self.asm.new_label();
+        let done = self.asm.new_label();
+        self.emit_trim_window();
+        self.asm.cmp_reg(Reg::X3, Reg::X2);
+        self.asm.branch(no, BranchKind::Conditional(Cond::Ge));
+        // An optional sign, remembered in x7.
+        let signed = self.asm.new_label();
+        let after_sign = self.asm.new_label();
+        self.asm.mov_imm64(Reg::X7, 0);
+        self.asm.ldrb_reg_offset(Reg::X4, Reg::X1, Reg::X3);
+        self.asm.cmp_imm(Reg::X4, u32::from(b'+'));
+        self.asm.branch(signed, BranchKind::Conditional(Cond::Eq));
+        self.asm.cmp_imm(Reg::X4, u32::from(b'-'));
+        self.asm
+            .branch(after_sign, BranchKind::Conditional(Cond::Ne));
+        self.asm.mov_imm64(Reg::X7, 1);
+        self.asm.bind(signed);
+        self.asm.add_reg_imm(Reg::X3, Reg::X3, 1);
+        self.asm.bind(after_sign);
+        self.asm.cmp_reg(Reg::X3, Reg::X2);
+        self.asm.branch(no, BranchKind::Conditional(Cond::Ge));
+        // Leading zeros do not count towards the range; keep the last digit.
+        let zero_loop = self.asm.new_label();
+        let zeros_done = self.asm.new_label();
+        self.asm.bind(zero_loop);
+        self.asm.sub_reg(Reg::X5, Reg::X2, Reg::X3);
+        self.asm.cmp_imm(Reg::X5, 1);
+        self.asm
+            .branch(zeros_done, BranchKind::Conditional(Cond::Le));
+        self.asm.ldrb_reg_offset(Reg::X4, Reg::X1, Reg::X3);
+        self.asm.cmp_imm(Reg::X4, u32::from(b'0'));
+        self.asm
+            .branch(zeros_done, BranchKind::Conditional(Cond::Ne));
+        self.asm.add_reg_imm(Reg::X3, Reg::X3, 1);
+        self.asm.branch(zero_loop, BranchKind::Unconditional);
+        self.asm.bind(zeros_done);
+        // Every remaining byte has to be a digit.
+        let digit_loop = self.asm.new_label();
+        let digits_done = self.asm.new_label();
+        self.asm.mov_reg(Reg::X5, Reg::X3);
+        self.asm.bind(digit_loop);
+        self.asm.cmp_reg(Reg::X5, Reg::X2);
+        self.asm
+            .branch(digits_done, BranchKind::Conditional(Cond::Ge));
+        self.asm.ldrb_reg_offset(Reg::X4, Reg::X1, Reg::X5);
+        self.asm.cmp_imm(Reg::X4, u32::from(b'0'));
+        self.asm.branch(no, BranchKind::Conditional(Cond::Lt));
+        self.asm.cmp_imm(Reg::X4, u32::from(b'9'));
+        self.asm.branch(no, BranchKind::Conditional(Cond::Gt));
+        self.asm.add_reg_imm(Reg::X5, Reg::X5, 1);
+        self.asm.branch(digit_loop, BranchKind::Unconditional);
+        self.asm.bind(digits_done);
+        self.asm.sub_reg(Reg::X5, Reg::X2, Reg::X3);
+        self.asm.cmp_imm(Reg::X5, 19);
+        self.asm.branch(no, BranchKind::Conditional(Cond::Gt));
+        self.asm.branch(yes, BranchKind::Conditional(Cond::Lt));
+        let use_negative = self.asm.new_label();
+        let limit_ready = self.asm.new_label();
+        self.asm.cmp_imm(Reg::X7, 0);
+        self.asm
+            .branch(use_negative, BranchKind::Conditional(Cond::Ne));
+        self.asm.load_rodata_address(Reg::X6, positive);
+        self.asm.branch(limit_ready, BranchKind::Unconditional);
+        self.asm.bind(use_negative);
+        self.asm.load_rodata_address(Reg::X6, negative);
+        self.asm.bind(limit_ready);
+        let compare_loop = self.asm.new_label();
+        self.asm.mov_imm64(Reg::X5, 0);
+        self.asm.bind(compare_loop);
+        self.asm.cmp_imm(Reg::X5, 19);
+        self.asm.branch(yes, BranchKind::Conditional(Cond::Ge));
+        self.asm.ldrb_reg_offset(Reg::X4, Reg::X1, Reg::X3);
+        self.asm.ldrb_reg_offset(Reg::X8, Reg::X6, Reg::X5);
+        self.asm.cmp_reg(Reg::X4, Reg::X8);
+        self.asm.branch(yes, BranchKind::Conditional(Cond::Lt));
+        self.asm.branch(no, BranchKind::Conditional(Cond::Gt));
+        self.asm.add_reg_imm(Reg::X3, Reg::X3, 1);
+        self.asm.add_reg_imm(Reg::X5, Reg::X5, 1);
+        self.asm.branch(compare_loop, BranchKind::Unconditional);
+        self.asm.bind(yes);
+        self.asm.mov_imm64(Reg::X0, 1);
+        self.asm.branch(done, BranchKind::Unconditional);
+        self.asm.bind(no);
+        self.asm.mov_imm64(Reg::X0, 0);
+        self.asm.bind(done);
+    }
+
+    /// `String#isDouble(s)` for a string only known at run time: what
+    /// `s.trim().parse::<f64>()` accepts -- an optional sign, then `inf`,
+    /// `infinity` or `nan` in either case, or digits with an optional point
+    /// and an optional exponent. Too large to represent parses as infinity
+    /// rather than failing, so there is no range check.
+    fn emit_str_is_double(&mut self) {
+        let no = self.asm.new_label();
+        let yes = self.asm.new_label();
+        let done = self.asm.new_label();
+        self.emit_trim_window();
+        self.asm.cmp_reg(Reg::X3, Reg::X2);
+        self.asm.branch(no, BranchKind::Conditional(Cond::Ge));
+        let signed = self.asm.new_label();
+        let after_sign = self.asm.new_label();
+        self.asm.ldrb_reg_offset(Reg::X4, Reg::X1, Reg::X3);
+        self.asm.cmp_imm(Reg::X4, u32::from(b'+'));
+        self.asm.branch(signed, BranchKind::Conditional(Cond::Eq));
+        self.asm.cmp_imm(Reg::X4, u32::from(b'-'));
+        self.asm
+            .branch(after_sign, BranchKind::Conditional(Cond::Ne));
+        self.asm.bind(signed);
+        self.asm.add_reg_imm(Reg::X3, Reg::X3, 1);
+        self.asm.bind(after_sign);
+        self.asm.cmp_reg(Reg::X3, Reg::X2);
+        self.asm.branch(no, BranchKind::Conditional(Cond::Ge));
+        // `inf`, `infinity` and `nan`, in any case.
+        for word in [b"infinity".as_slice(), b"inf".as_slice(), b"nan".as_slice()] {
+            let offset = self.asm.intern_rodata(word);
+            let mismatch = self.asm.new_label();
+            let compare = self.asm.new_label();
+            self.asm.sub_reg(Reg::X5, Reg::X2, Reg::X3);
+            self.asm.cmp_imm(Reg::X5, word.len() as u32);
+            self.asm.branch(mismatch, BranchKind::Conditional(Cond::Ne));
+            self.asm.load_rodata_address(Reg::X6, offset);
+            self.asm.mov_imm64(Reg::X5, 0);
+            self.asm.bind(compare);
+            self.asm.cmp_imm(Reg::X5, word.len() as u32);
+            self.asm.branch(yes, BranchKind::Conditional(Cond::Ge));
+            self.asm.add_reg(Reg::X9, Reg::X3, Reg::X5);
+            self.asm.ldrb_reg_offset(Reg::X4, Reg::X1, Reg::X9);
+            // Lower-case the input byte; the words above are lower-case.
+            self.asm.mov_imm64(Reg::X10, 0x20);
+            self.asm.orr_reg(Reg::X4, Reg::X4, Reg::X10);
+            self.asm.ldrb_reg_offset(Reg::X8, Reg::X6, Reg::X5);
+            self.asm.cmp_reg(Reg::X4, Reg::X8);
+            self.asm.branch(mismatch, BranchKind::Conditional(Cond::Ne));
+            self.asm.add_reg_imm(Reg::X5, Reg::X5, 1);
+            self.asm.branch(compare, BranchKind::Unconditional);
+            self.asm.bind(mismatch);
+        }
+        // Digits, an optional point with more digits, at least one of the two.
+        self.asm.mov_imm64(Reg::X7, 0);
+        let int_digits = self.asm.new_label();
+        let int_done = self.asm.new_label();
+        self.asm.bind(int_digits);
+        self.asm.cmp_reg(Reg::X3, Reg::X2);
+        self.asm.branch(int_done, BranchKind::Conditional(Cond::Ge));
+        self.asm.ldrb_reg_offset(Reg::X4, Reg::X1, Reg::X3);
+        self.asm.cmp_imm(Reg::X4, u32::from(b'0'));
+        self.asm.branch(int_done, BranchKind::Conditional(Cond::Lt));
+        self.asm.cmp_imm(Reg::X4, u32::from(b'9'));
+        self.asm.branch(int_done, BranchKind::Conditional(Cond::Gt));
+        self.asm.add_reg_imm(Reg::X3, Reg::X3, 1);
+        self.asm.add_reg_imm(Reg::X7, Reg::X7, 1);
+        self.asm.branch(int_digits, BranchKind::Unconditional);
+        self.asm.bind(int_done);
+        let after_point = self.asm.new_label();
+        self.asm.cmp_reg(Reg::X3, Reg::X2);
+        self.asm
+            .branch(after_point, BranchKind::Conditional(Cond::Ge));
+        self.asm.ldrb_reg_offset(Reg::X4, Reg::X1, Reg::X3);
+        self.asm.cmp_imm(Reg::X4, u32::from(b'.'));
+        self.asm
+            .branch(after_point, BranchKind::Conditional(Cond::Ne));
+        self.asm.add_reg_imm(Reg::X3, Reg::X3, 1);
+        let frac_digits = self.asm.new_label();
+        self.asm.bind(frac_digits);
+        self.asm.cmp_reg(Reg::X3, Reg::X2);
+        self.asm
+            .branch(after_point, BranchKind::Conditional(Cond::Ge));
+        self.asm.ldrb_reg_offset(Reg::X4, Reg::X1, Reg::X3);
+        self.asm.cmp_imm(Reg::X4, u32::from(b'0'));
+        self.asm
+            .branch(after_point, BranchKind::Conditional(Cond::Lt));
+        self.asm.cmp_imm(Reg::X4, u32::from(b'9'));
+        self.asm
+            .branch(after_point, BranchKind::Conditional(Cond::Gt));
+        self.asm.add_reg_imm(Reg::X3, Reg::X3, 1);
+        self.asm.add_reg_imm(Reg::X7, Reg::X7, 1);
+        self.asm.branch(frac_digits, BranchKind::Unconditional);
+        self.asm.bind(after_point);
+        self.asm.cmp_imm(Reg::X7, 0);
+        self.asm.branch(no, BranchKind::Conditional(Cond::Eq));
+        // An optional exponent, which needs at least one digit of its own.
+        let after_exponent = self.asm.new_label();
+        self.asm.cmp_reg(Reg::X3, Reg::X2);
+        self.asm
+            .branch(after_exponent, BranchKind::Conditional(Cond::Ge));
+        self.asm.ldrb_reg_offset(Reg::X4, Reg::X1, Reg::X3);
+        self.asm.mov_imm64(Reg::X10, 0x20);
+        self.asm.orr_reg(Reg::X4, Reg::X4, Reg::X10);
+        self.asm.cmp_imm(Reg::X4, u32::from(b'e'));
+        self.asm
+            .branch(after_exponent, BranchKind::Conditional(Cond::Ne));
+        self.asm.add_reg_imm(Reg::X3, Reg::X3, 1);
+        let exponent_signed = self.asm.new_label();
+        let exponent_digits = self.asm.new_label();
+        self.asm.cmp_reg(Reg::X3, Reg::X2);
+        self.asm.branch(no, BranchKind::Conditional(Cond::Ge));
+        self.asm.ldrb_reg_offset(Reg::X4, Reg::X1, Reg::X3);
+        self.asm.cmp_imm(Reg::X4, u32::from(b'+'));
+        self.asm
+            .branch(exponent_signed, BranchKind::Conditional(Cond::Eq));
+        self.asm.cmp_imm(Reg::X4, u32::from(b'-'));
+        self.asm
+            .branch(exponent_digits, BranchKind::Conditional(Cond::Ne));
+        self.asm.bind(exponent_signed);
+        self.asm.add_reg_imm(Reg::X3, Reg::X3, 1);
+        self.asm.bind(exponent_digits);
+        self.asm.mov_imm64(Reg::X7, 0);
+        let exponent_loop = self.asm.new_label();
+        let exponent_done = self.asm.new_label();
+        self.asm.bind(exponent_loop);
+        self.asm.cmp_reg(Reg::X3, Reg::X2);
+        self.asm
+            .branch(exponent_done, BranchKind::Conditional(Cond::Ge));
+        self.asm.ldrb_reg_offset(Reg::X4, Reg::X1, Reg::X3);
+        self.asm.cmp_imm(Reg::X4, u32::from(b'0'));
+        self.asm
+            .branch(exponent_done, BranchKind::Conditional(Cond::Lt));
+        self.asm.cmp_imm(Reg::X4, u32::from(b'9'));
+        self.asm
+            .branch(exponent_done, BranchKind::Conditional(Cond::Gt));
+        self.asm.add_reg_imm(Reg::X3, Reg::X3, 1);
+        self.asm.add_reg_imm(Reg::X7, Reg::X7, 1);
+        self.asm.branch(exponent_loop, BranchKind::Unconditional);
+        self.asm.bind(exponent_done);
+        self.asm.cmp_imm(Reg::X7, 0);
+        self.asm.branch(no, BranchKind::Conditional(Cond::Eq));
+        self.asm.bind(after_exponent);
+        // Anything left over means it was not a number.
+        self.asm.cmp_reg(Reg::X3, Reg::X2);
+        self.asm.branch(no, BranchKind::Conditional(Cond::Ne));
+        self.asm.bind(yes);
+        self.asm.mov_imm64(Reg::X0, 1);
+        self.asm.branch(done, BranchKind::Unconditional);
+        self.asm.bind(no);
+        self.asm.mov_imm64(Reg::X0, 0);
+        self.asm.bind(done);
     }
 
     /// Is every byte of the string in x0 an ASCII digit? x0 becomes the Bool.

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -1613,6 +1613,17 @@ fn nullable_elem(ty: ValueType) -> Option<ListElem> {
     }
 }
 
+/// A `Double` the way the evaluator displays it: a whole number keeps one
+/// decimal (`3.0`), anything else takes Rust's shortest round-trip form. The
+/// x86-64 backend formats static doubles by the same rule.
+fn format_double(value: f64) -> String {
+    if value.fract() == 0.0 {
+        format!("{value:.1}")
+    } else {
+        value.to_string()
+    }
+}
+
 fn list_elem_of(ty: ValueType) -> Option<ListElem> {
     match ty {
         ValueType::Int => Some(ListElem::Int),
@@ -1817,6 +1828,11 @@ struct Emitter {
     /// so it splits the path here -- and a literal put in a `val` first is the
     /// ordinary way to write one.
     literal_strings: Vec<HashMap<String, String>>,
+    /// `val`-bound doubles whose value is known while compiling, which is the
+    /// only kind this backend can print -- the same limit the x86-64 backend
+    /// has, reached a different way. A `mutable` is never recorded: what it
+    /// holds at a given point depends on the paths taken to get there.
+    literal_doubles: Vec<HashMap<String, f64>>,
     next_local_offset: u32,
     /// The deepest `next_local_offset` reached in the function being emitted.
     /// Slots are handed back when an inlined lambda's parameters die, so the
@@ -2715,6 +2731,26 @@ impl Emitter {
                 self.asm.mov_imm64(Reg::X0, *value as u64);
                 Ok(ValueType::Int)
             }
+            // `expr cleanup { ... }`: the clause runs after the expression it
+            // is attached to, and the expression's value is still the value.
+            // A heap result is parked as a root, because the clause can
+            // allocate.
+            Expr::Cleanup { body, cleanup, .. } => {
+                let body_ty = self.expression(body)?;
+                let rooted = is_heap_pointer(body_ty);
+                if rooted {
+                    self.push_rooted(Reg::X0);
+                } else {
+                    self.asm.push(Reg::X0);
+                }
+                self.statement(cleanup)?;
+                if rooted {
+                    self.pop_rooted(Reg::X0);
+                } else {
+                    self.asm.pop(Reg::X0);
+                }
+                Ok(body_ty)
+            }
             Expr::Double { value, .. } => {
                 // The double travels as its raw IEEE 754 bits in x0.
                 self.asm.mov_imm64(Reg::X0, value.to_bits());
@@ -3185,6 +3221,26 @@ impl Emitter {
                     if let Some(ty) = self.builtin_call(field, &all, *span)? {
                         return Ok(ty);
                     }
+                    // A method that is not a builtin is a function taking the
+                    // receiver first -- which is what an extension method on
+                    // an enum is left as when its name is also a builtin's
+                    // (`Result`'s `getOrElse` and a map's are both spelled
+                    // that way, with different arities).
+                    if self.function_exists(field, all.len()) {
+                        return self.function_call(field, &all, *span);
+                    }
+                    // An extension method declared on more than one type is
+                    // left as a method call by the shared desugar, because a
+                    // name alone does not say which extension is meant. The
+                    // receiver's type does: `Result`'s `getOrElse` and
+                    // `Option`'s are two functions, and this picks between
+                    // them the way the checker does.
+                    if let Some(key) = self.extension_type_key_of(target) {
+                        let mangled = format!("__ext_{key}_{field}");
+                        if self.function_exists(&mangled, all.len()) {
+                            return self.function_call(&mangled, &all, *span);
+                        }
+                    }
                     return Err(unsupported(*span, &format!("method `{field}`")));
                 }
                 // `myFoldLeft(list)(z)(f)`: a def whose body is a chain of
@@ -3341,6 +3397,12 @@ impl Emitter {
                 Ok(())
             }
             StringPart::Interpolation(hole) => {
+                if let Some(number) = self.static_double_of(hole) {
+                    let offset = self.asm.intern_string_object(&format_double(number));
+                    self.asm.load_rodata_address(Reg::X0, offset);
+                    self.emit_heap_string_copy();
+                    return Ok(());
+                }
                 match self.expression(hole)? {
                     ValueType::Str => {}
                     ValueType::Int => self.emit_int_to_str(),
@@ -4570,6 +4632,61 @@ impl Emitter {
         self.asm.branch(end, BranchKind::Unconditional);
         self.asm.bind(fail);
         self.asm.mov_imm64(Reg::X0, 0);
+        self.asm.bind(end);
+    }
+
+    /// `indexOf(s, needle)` / `lastIndexOf(s, needle)`: s in x0, needle in x1
+    /// -> the *byte* offset in x0, or -1. Byte rather than character, because
+    /// the evaluator answers with what Rust's `find`/`rfind` answer with.
+    /// Scanning forward and keeping the last match is `rfind`.
+    fn emit_str_index_of(&mut self, last: bool) {
+        let not_found = self.asm.new_label();
+        let done = self.asm.new_label();
+        let end = self.asm.new_label();
+        self.asm.ldr_imm(Reg::X3, Reg::X0, 0); // haystack length
+        self.asm.ldr_imm(Reg::X5, Reg::X1, 0); // needle length
+        self.asm.add_reg_imm(Reg::X2, Reg::X0, 8); // haystack bytes
+        self.asm.add_reg_imm(Reg::X4, Reg::X1, 8); // needle bytes
+        self.asm.cmp_reg(Reg::X5, Reg::X3);
+        self.asm
+            .branch(not_found, BranchKind::Conditional(Cond::Gt));
+        self.asm.mov_imm64(Reg::X6, 0); // start offset
+        self.asm.mov_imm64(Reg::X7, u64::MAX); // best so far = -1
+        let outer = self.asm.new_label();
+        let inner = self.asm.new_label();
+        let matched = self.asm.new_label();
+        let advance = self.asm.new_label();
+        self.asm.bind(outer);
+        // Stop once fewer bytes are left than the needle needs.
+        self.asm.sub_reg(Reg::X11, Reg::X3, Reg::X6);
+        self.asm.cmp_reg(Reg::X11, Reg::X5);
+        self.asm.branch(done, BranchKind::Conditional(Cond::Lt));
+        self.asm.add_reg(Reg::X10, Reg::X2, Reg::X6); // haystack cursor
+        self.asm.mov_reg(Reg::X11, Reg::X4); // needle cursor
+        self.asm.mov_reg(Reg::X8, Reg::X5); // bytes left to compare
+        self.asm.bind(inner);
+        self.asm.branch(matched, BranchKind::CompareZero(Reg::X8));
+        self.asm.ldrb_post_increment(Reg::X9, Reg::X10);
+        self.asm.ldrb_post_increment(Reg::X12, Reg::X11);
+        self.asm.cmp_reg(Reg::X9, Reg::X12);
+        self.asm.branch(advance, BranchKind::Conditional(Cond::Ne));
+        self.asm.sub_reg_imm(Reg::X8, Reg::X8, 1);
+        self.asm.branch(inner, BranchKind::Unconditional);
+        self.asm.bind(matched);
+        if last {
+            self.asm.mov_reg(Reg::X7, Reg::X6);
+        } else {
+            self.asm.mov_reg(Reg::X0, Reg::X6);
+            self.asm.branch(end, BranchKind::Unconditional);
+        }
+        self.asm.bind(advance);
+        self.asm.add_reg_imm(Reg::X6, Reg::X6, 1);
+        self.asm.branch(outer, BranchKind::Unconditional);
+        self.asm.bind(done);
+        self.asm.mov_reg(Reg::X0, Reg::X7);
+        self.asm.branch(end, BranchKind::Unconditional);
+        self.asm.bind(not_found);
+        self.asm.mov_imm64(Reg::X0, u64::MAX);
         self.asm.bind(end);
     }
 
@@ -6306,6 +6423,131 @@ impl Emitter {
                 self.pop_rooted(Reg::X0);
                 self.emit_str_matches();
                 Ok(Some(ValueType::Bool))
+            }
+            ("indexOf", 2) | ("lastIndexOf", 2) => {
+                if self.expression(&arguments[0])? != ValueType::Str {
+                    return Err(unsupported(span, "indexOf of a non-string"));
+                }
+                self.push_rooted(Reg::X0);
+                if self.expression(&arguments[1])? != ValueType::Str {
+                    return Err(unsupported(span, "indexOf with a non-string needle"));
+                }
+                self.asm.mov_reg(Reg::X1, Reg::X0);
+                self.pop_rooted(Reg::X0);
+                self.emit_str_index_of(name == "lastIndexOf");
+                Ok(Some(ValueType::Int))
+            }
+            // `repeat(s, n)`: n copies of s, built by appending. A count that
+            // is not positive answers with the empty string, which is what
+            // `substring`'s clamping already does with an out-of-range index.
+            ("repeat", 2) => {
+                let mark = self.open_temp_roots();
+                if self.expression(&arguments[0])? != ValueType::Str {
+                    return Err(unsupported(span, "repeat of a non-string"));
+                }
+                let source = self.reserve_locals(24);
+                let acc = source + 8;
+                let count = acc + 8;
+                self.asm.store_local(Reg::X0, source);
+                self.emit_root_frame_slot(source);
+                let empty = self.asm.intern_string_object("");
+                self.asm.load_rodata_address(Reg::X0, empty);
+                self.emit_heap_string_copy();
+                self.asm.store_local(Reg::X0, acc);
+                self.emit_root_frame_slot(acc);
+                if self.expression(&arguments[1])? != ValueType::Int {
+                    return Err(unsupported(span, "repeat with a non-Int count"));
+                }
+                self.asm.store_local(Reg::X0, count);
+                let loop_start = self.asm.new_label();
+                let done = self.asm.new_label();
+                self.asm.bind(loop_start);
+                self.asm.load_local(Reg::X0, count);
+                self.asm.cmp_imm(Reg::X0, 0);
+                self.asm.branch(done, BranchKind::Conditional(Cond::Le));
+                self.asm.load_local(Reg::X1, source);
+                self.asm.load_local(Reg::X0, acc);
+                self.emit_str_concat();
+                self.asm.store_local(Reg::X0, acc);
+                self.asm.load_local(Reg::X0, count);
+                self.asm.sub_reg_imm(Reg::X0, Reg::X0, 1);
+                self.asm.store_local(Reg::X0, count);
+                self.asm.branch(loop_start, BranchKind::Unconditional);
+                self.asm.bind(done);
+                self.asm.load_local(Reg::X0, acc);
+                self.close_temp_roots(mark);
+                Ok(Some(ValueType::Str))
+            }
+            // `replace(s, from, to)`: the *first* occurrence, which is what the
+            // evaluator's `replacen(from, to, 1)` does. `replaceAll` is the
+            // pattern-matching one and lives elsewhere.
+            ("replace", 3) => {
+                let mark = self.open_temp_roots();
+                if self.expression(&arguments[0])? != ValueType::Str {
+                    return Err(unsupported(span, "replace of a non-string"));
+                }
+                let source = self.reserve_locals(40);
+                let from = source + 8;
+                let to = from + 8;
+                let head = to + 8;
+                let at = head + 8;
+                self.asm.store_local(Reg::X0, source);
+                self.emit_root_frame_slot(source);
+                // Every slot that will hold a string is rooted before the
+                // branch below, so both paths have pushed the same roots.
+                self.asm.mov_imm64(Reg::X0, 0);
+                self.asm.store_local(Reg::X0, from);
+                self.emit_root_frame_slot(from);
+                self.asm.mov_imm64(Reg::X0, 0);
+                self.asm.store_local(Reg::X0, to);
+                self.emit_root_frame_slot(to);
+                self.asm.mov_imm64(Reg::X0, 0);
+                self.asm.store_local(Reg::X0, head);
+                self.emit_root_frame_slot(head);
+                if self.expression(&arguments[1])? != ValueType::Str {
+                    return Err(unsupported(span, "replace with a non-string pattern"));
+                }
+                self.asm.store_local(Reg::X0, from);
+                if self.expression(&arguments[2])? != ValueType::Str {
+                    return Err(unsupported(span, "replace with a non-string replacement"));
+                }
+                self.asm.store_local(Reg::X0, to);
+                self.asm.load_local(Reg::X1, from);
+                self.asm.load_local(Reg::X0, source);
+                self.emit_str_index_of(false);
+                self.asm.store_local(Reg::X0, at);
+                let absent = self.asm.new_label();
+                let end = self.asm.new_label();
+                self.asm.cmp_imm(Reg::X0, 0);
+                self.asm.branch(absent, BranchKind::Conditional(Cond::Lt));
+                // head = substring(source, 0, at)
+                self.asm.load_local(Reg::X2, at);
+                self.asm.mov_imm64(Reg::X1, 0);
+                self.asm.load_local(Reg::X0, source);
+                self.emit_substring();
+                self.asm.store_local(Reg::X0, head);
+                // head = head + to
+                self.asm.load_local(Reg::X1, to);
+                self.asm.load_local(Reg::X0, head);
+                self.emit_str_concat();
+                self.asm.store_local(Reg::X0, head);
+                // tail = substring(source, at + len(from), len(source))
+                self.asm.load_local(Reg::X0, from);
+                self.asm.ldr_imm(Reg::X1, Reg::X0, 0);
+                self.asm.load_local(Reg::X0, at);
+                self.asm.add_reg(Reg::X1, Reg::X0, Reg::X1);
+                self.asm.load_local(Reg::X0, source);
+                self.asm.ldr_imm(Reg::X2, Reg::X0, 0);
+                self.emit_substring();
+                self.asm.mov_reg(Reg::X1, Reg::X0);
+                self.asm.load_local(Reg::X0, head);
+                self.emit_str_concat();
+                self.asm.branch(end, BranchKind::Unconditional);
+                self.asm.bind(absent);
+                self.asm.load_local(Reg::X0, source);
+                self.asm.bind(end);
+                self.close_temp_roots(mark);
+                Ok(Some(ValueType::Str))
             }
             ("startsWith", 2) => {
                 if self.expression(&arguments[0])? != ValueType::Str {
@@ -8519,7 +8761,7 @@ impl Emitter {
                     // evaluator's -- keeping this in step with the emitter
                     // matters, since a wrong guess is a rejected build.
                     "size" | "length" | "toInt" | "floor" | "int" | "ceil" | "Map#size"
-                    | "Set#size" => {
+                    | "Set#size" | "indexOf" | "lastIndexOf" => {
                         return Some(ValueType::Int);
                     }
                     "isEmpty" | "contains" | "isEmptyString" | "matches" | "containsKey"
@@ -8602,7 +8844,9 @@ impl Emitter {
                     }
                     "__match_fail" => return Some(ValueType::Never),
                     "toString" | "substring" | "trim" | "toUpperCase" | "toLowerCase"
-                    | "reverse" | "join" | "replaceAll" | "at" => return Some(ValueType::Str),
+                    | "reverse" | "join" | "replaceAll" | "replace" | "repeat" | "at" => {
+                        return Some(ValueType::Str);
+                    }
                     _ => {}
                 }
                 // A generic enum's constructor: the payload types the call
@@ -9077,6 +9321,7 @@ impl Emitter {
         self.dict_bindings.push(HashMap::new());
         self.alias_bindings.push(HashMap::new());
         self.literal_strings.push(HashMap::new());
+        self.literal_doubles.push(HashMap::new());
     }
 
     /// Close the scopes `push_binding_scopes` opened.
@@ -9086,6 +9331,60 @@ impl Emitter {
         self.dict_bindings.pop();
         self.alias_bindings.pop();
         self.literal_strings.pop();
+        self.literal_doubles.pop();
+    }
+
+    /// The value of a `Double` expression, when it is one this backend can work
+    /// out while compiling. Only pure shapes are folded -- literals, arithmetic
+    /// on them, and names bound to one by a `val` -- so folding an expression
+    /// away can never skip an effect.
+    fn static_double_of(&self, expr: &Expr) -> Option<f64> {
+        match expr {
+            Expr::Double { value, .. } => Some(*value),
+            Expr::Identifier { name, .. } => self
+                .literal_doubles
+                .iter()
+                .rev()
+                .find_map(|scope| scope.get(name))
+                .copied(),
+            Expr::Unary { op, expr, .. } => match op {
+                UnaryOp::Minus => Some(-self.static_double_of(expr)?),
+                UnaryOp::Plus => self.static_double_of(expr),
+                _ => None,
+            },
+            Expr::Binary { lhs, op, rhs, .. } => {
+                let left = self.static_double_of(lhs)?;
+                let right = self.static_double_of(rhs)?;
+                match op {
+                    BinaryOp::Add => Some(left + right),
+                    BinaryOp::Subtract => Some(left - right),
+                    BinaryOp::Multiply => Some(left * right),
+                    BinaryOp::Divide => Some(left / right),
+                    _ => None,
+                }
+            }
+            Expr::Call {
+                callee, arguments, ..
+            } => {
+                let Expr::Identifier { name, .. } = callee.as_ref() else {
+                    return None;
+                };
+                if arguments.len() != 1 {
+                    return None;
+                }
+                match name.as_str() {
+                    "sqrt" => Some(self.static_double_of(&arguments[0])?.sqrt()),
+                    "abs" => Some(self.static_double_of(&arguments[0])?.abs()),
+                    // `double(n)` widens an Int, so its argument is one.
+                    "double" => match &arguments[0] {
+                        Expr::Int { value, .. } => Some(*value as f64),
+                        other => self.static_double_of(other),
+                    },
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
     }
 
     /// A name aliasing another name, innermost scope first.
@@ -9360,6 +9659,41 @@ impl Emitter {
         Ok(result)
     }
 
+    /// The name an `extension (this: T) { ... }` block is keyed by, worked out
+    /// from what the receiver's type turns out to be. Typing it emits nothing,
+    /// so asking costs only the inference.
+    fn extension_type_key_of(&mut self, receiver: &Expr) -> Option<String> {
+        let mut locals = Vec::new();
+        let ty = self.static_type_under(receiver, &mut locals, 0)?;
+        Some(match ty {
+            ValueType::Str => "String".to_string(),
+            ValueType::Int => "Int".to_string(),
+            ValueType::Bool => "Boolean".to_string(),
+            ValueType::Double => "Double".to_string(),
+            ValueType::List(_) | ValueType::EmptyList => "List".to_string(),
+            ValueType::Set(_) | ValueType::EmptySet => "Set".to_string(),
+            ValueType::Map(..) | ValueType::EmptyMap => "Map".to_string(),
+            ValueType::Enum(shape) => {
+                let (enum_index, _) = self.enum_shapes.get(shape as usize)?;
+                self.generic_enums.get(*enum_index)?.0.clone()
+            }
+            ValueType::Record(index) => self.records.get(index as usize)?.name.clone(),
+            _ => return None,
+        })
+    }
+
+    /// Is there a definition of this name that takes this many arguments,
+    /// concrete or generic? Asked before turning a method call into one.
+    fn function_exists(&self, name: &str, arity: usize) -> bool {
+        self.functions
+            .iter()
+            .any(|(n, info)| n == name && info.params.len() == arity)
+            || self
+                .generic_functions
+                .iter()
+                .any(|generic| generic.name == name && generic.params.len() == arity)
+    }
+
     fn function_call(
         &mut self,
         name: &str,
@@ -9579,7 +9913,7 @@ impl Emitter {
                 }
                 Ok(Some(format!("{value}\n")))
             }
-            Expr::Double { value, .. } => Ok(Some(format!("{value}\n"))),
+            Expr::Double { value, .. } => Ok(Some(format!("{}\n", format_double(*value)))),
             _ => Ok(None),
         }
     }
@@ -9593,6 +9927,11 @@ impl Emitter {
         }
         let argument = &arguments[0];
         if let Some(line) = Self::literal_line(argument)? {
+            self.asm.emit_write_rodata(STDOUT_FD, line.as_bytes());
+            return Ok(());
+        }
+        if let Some(number) = self.static_double_of(argument) {
+            let line = format!("{}\n", format_double(number));
             self.asm.emit_write_rodata(STDOUT_FD, line.as_bytes());
             return Ok(());
         }
@@ -9732,7 +10071,12 @@ impl Emitter {
             | Expr::EnumDeclaration { .. }
             | Expr::TypeClassDeclaration { .. }
             | Expr::InstanceDeclaration { .. } => Ok(()),
-            Expr::VarDecl { name, value, .. } => {
+            Expr::VarDecl {
+                name,
+                value,
+                mutable,
+                ..
+            } => {
                 // Remember a string literal's text for the builtins that need
                 // it at compile time, and forget any older binding of this name
                 // so a shadowing one does not inherit the wrong text.
@@ -9747,6 +10091,21 @@ impl Emitter {
                         .expect("emitter literal scope");
                     match literal {
                         Some(text) => scope.insert(name.clone(), text),
+                        None => scope.remove(name),
+                    };
+                }
+                {
+                    let folded = if *mutable {
+                        None
+                    } else {
+                        self.static_double_of(value)
+                    };
+                    let scope = self
+                        .literal_doubles
+                        .last_mut()
+                        .expect("emitter literal scope");
+                    match folded {
+                        Some(number) => scope.insert(name.clone(), number),
                         None => scope.remove(name),
                     };
                 }

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -6488,7 +6488,9 @@ impl NativeCodeGenerator {
             | "Dir#current"
             | "Dir#home"
             | "Dir#temp"
-            | "Time#nowMillis" => Some(0),
+            | "Time#nowMillis"
+            | "Map#empty"
+            | "Set#empty" => Some(0),
             "println"
             | "printlnError"
             | "sleep"
@@ -6514,6 +6516,8 @@ impl NativeCodeGenerator {
             | "Map#size"
             | "Map#keys"
             | "Map#values"
+            | "Set#toList"
+            | "Set#fromList"
             | "Set#size"
             | "isEmpty"
             | "Map#isEmpty"
@@ -6552,6 +6556,7 @@ impl NativeCodeGenerator {
             | "join"
             | "contains"
             | "Set#contains"
+            | "Set#add"
             | "Map#containsKey"
             | "containsKey"
             | "Map#containsValue"
@@ -6566,7 +6571,7 @@ impl NativeCodeGenerator {
             | "Dir#move"
             | "Math#powInt"
             | "Math#gcd" => Some(2),
-            "substring" | "replace" | "replaceAll" => Some(3),
+            "substring" | "replace" | "replaceAll" | "Map#put" | "Map#getOrElse" => Some(3),
             _ => None,
         }
     }
@@ -8382,6 +8387,30 @@ impl NativeCodeGenerator {
             }
             "Map#get" | "get" => self.compile_static_map_get_direct(arguments, span),
             "Set#contains" => self.compile_static_set_contains_direct(arguments, span),
+            // The function spellings of the set builders. The method forms
+            // (`s.add(x)`, `s.toList()`) were already here; `std.set`'s own
+            // extension methods call these.
+            "Set#toList" if arguments.len() == 1 => self.compile_set_to_list(&arguments[0], span),
+            "Set#add" if arguments.len() == 2 => {
+                self.compile_set_add(&arguments[0], &arguments[1], span)
+            }
+            "Map#getOrElse" if arguments.len() == 3 => {
+                self.compile_map_get_or_else(&arguments[0], &arguments[1], &arguments[2], span)
+            }
+            "Map#put" if arguments.len() == 3 => {
+                self.compile_map_put(&arguments[0], &arguments[1], &arguments[2], span)
+            }
+            "Map#empty" if arguments.is_empty() => {
+                let label = self.intern_static_map(Vec::new());
+                Ok(self.emit_static_value(&StaticValue::StaticMap { label }))
+            }
+            "Set#empty" if arguments.is_empty() => {
+                let label = self.intern_static_set(Vec::new());
+                Ok(self.emit_static_value(&StaticValue::StaticSet { label }))
+            }
+            "Set#fromList" if arguments.len() == 1 => {
+                self.compile_set_from_list(&arguments[0], span)
+            }
             "FileOutput#write" => self.compile_file_output_write(arguments, false, span),
             "FileOutput#append" => self.compile_file_output_write(arguments, true, span),
             "FileOutput#writeLines" => self.compile_file_output_write_lines(arguments, span),
@@ -15392,6 +15421,32 @@ impl NativeCodeGenerator {
         let elements = self.static_sets[label.0].elements.clone();
         let list_label = self.intern_static_list(elements);
         Ok(self.emit_static_value(&StaticValue::StaticList { label: list_label }))
+    }
+
+    /// `Set#fromList(xs)` — the list's elements as a set, keeping the first
+    /// occurrence of each in the order they arrive, which is what the
+    /// evaluator does and what a set literal already does here.
+    fn compile_set_from_list(
+        &mut self,
+        target: &Expr,
+        span: Span,
+    ) -> Result<NativeValue, Diagnostic> {
+        let elements = self.static_list_values_from_argument_preserving_effects(
+            target,
+            span,
+            "native Set#fromList for non-static list",
+        )?;
+        let mut deduped: Vec<StaticValue> = Vec::with_capacity(elements.len());
+        for element in elements {
+            if !deduped
+                .iter()
+                .any(|seen| self.static_value_equal_user(seen, &element))
+            {
+                deduped.push(element);
+            }
+        }
+        let label = self.intern_static_set(deduped);
+        Ok(self.emit_static_value(&StaticValue::StaticSet { label }))
     }
 
     /// `m.put(k, v)` — a fresh static map with `k -> v` set. An existing key

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -5978,6 +5978,14 @@ impl NativeCodeGenerator {
                         unsupported_recursive_inline,
                         inline_reason,
                         captured_top_level_names,
+                        param_annotations
+                            .iter()
+                            .map(|annotation| {
+                                annotation
+                                    .as_ref()
+                                    .map(|annotation| annotation.text.clone())
+                            })
+                            .collect(),
                     );
                 }
                 Expr::VarDecl {
@@ -6036,6 +6044,7 @@ impl NativeCodeGenerator {
                             // reason is never read.
                             String::new(),
                             HashSet::new(),
+                            vec![None; param_count],
                         );
                     }
                 }
@@ -6088,6 +6097,7 @@ impl NativeCodeGenerator {
         unsupported_recursive_inline: bool,
         inline_reason: String,
         captured_top_level_names: HashSet<String>,
+        param_annotation_texts: Vec<Option<String>>,
     ) {
         if self.functions.contains_key(&name) {
             return;
@@ -6103,6 +6113,7 @@ impl NativeCodeGenerator {
                 flexible_params,
                 param_unannotated,
                 param_enum_shapes,
+                param_annotation_texts,
                 return_value,
                 return_enum_shape,
                 body,
@@ -9726,6 +9737,8 @@ impl NativeCodeGenerator {
             ));
         }
         self.push_scope();
+        let mut solutions: Vec<(String, String)> = Vec::new();
+        let mut open_enum_slots: Vec<(VarSlot, String)> = Vec::new();
         for (index, ((param, expected_value), argument)) in function
             .params
             .iter()
@@ -9733,6 +9746,11 @@ impl NativeCodeGenerator {
             .zip(arguments)
             .enumerate()
         {
+            let annotation_text = function
+                .param_annotation_texts
+                .get(index)
+                .cloned()
+                .flatten();
             let flexible = function
                 .flexible_params
                 .get(index)
@@ -9745,6 +9763,19 @@ impl NativeCodeGenerator {
                 .unwrap_or(false);
             let static_argument = self.static_value_from_pure_expr(argument);
             let value = self.compile_expr(argument)?;
+            // Solved here rather than at any one binding path, because the
+            // paths differ by value kind: a string argument binds as a
+            // constant and never reaches the slot-allocating arm below, and
+            // it is exactly the argument that fixes a `'k`.
+            if let Some(text) = annotation_text.as_deref() {
+                let trimmed = text.trim();
+                if trimmed.starts_with('\'')
+                    && let Some(name) = native_value_annotation_name(value)
+                    && !solutions.iter().any(|(known, _)| known == trimmed)
+                {
+                    solutions.push((trimmed.to_string(), name));
+                }
+            }
             if matches!(expected_value, NativeValue::RuntimeString { .. }) {
                 if self.native_string_ref(value).is_none() {
                     self.pop_scope();
@@ -9826,6 +9857,16 @@ impl NativeCodeGenerator {
                 | NativeValue::RuntimeDouble => {
                     let slot = self.allocate_slot(param.clone(), value);
                     self.asm.store_rbp_slot(slot.offset, Reg::Rax);
+                    if let Some(text) = annotation_text
+                        && text.trim().contains('\'')
+                        && !text.trim().starts_with('\'')
+                        && self
+                            .enum_shapes
+                            .get(&slot.id)
+                            .is_none_or(shape_leaves_payloads_open)
+                    {
+                        open_enum_slots.push((slot, text.trim().to_string()));
+                    }
                     if let Some(value) = static_argument {
                         self.bind_static_value(param.clone(), value);
                     }
@@ -9848,6 +9889,22 @@ impl NativeCodeGenerator {
                 | NativeValue::BuiltinFunction { .. }
                 | NativeValue::RuntimeMapCallableDispatch(_) => {
                     self.bind_constant(param.clone(), value);
+                }
+            }
+        }
+        // The solutions are complete now, so an enum-typed parameter whose own
+        // argument left the variables open takes the shape they imply, read
+        // off the annotation it was declared with. `put(KMNil, "a", 1)` says
+        // nothing through its first argument -- the empty case carries no
+        // payloads -- while `key: 'k` and `value: 'v` say everything, and the
+        // body reads the parameter's shape out of its slot.
+        if !solutions.is_empty() {
+            let variables: Vec<String> = solutions.iter().map(|(name, _)| name.clone()).collect();
+            let names: Vec<String> = solutions.iter().map(|(_, name)| name.clone()).collect();
+            for (slot, annotation) in open_enum_slots {
+                let applied = substitute_type_variables(&annotation, &variables, &names);
+                if let Some(shape) = self.generic_enum_annotation_shape(&applied) {
+                    self.enum_shapes.insert(slot.id, shape);
                 }
             }
         }
@@ -39683,6 +39740,10 @@ struct NativeFunction {
     /// travels by pointer and the callee prologue binds the shape to
     /// its slot so matches inside the body resolve payload reprs.
     param_enum_shapes: Vec<Option<ConcreteEnumShape>>,
+    /// Each parameter's annotation as written, so a call site can solve the
+    /// definition's type variables from the arguments that fix them and read
+    /// the resulting shape off an annotation like `KM<'k, 'v>`.
+    param_annotation_texts: Vec<Option<String>>,
     return_value: NativeValue,
     /// Shape of the returned value when the return annotation names a
     /// fully-applied generic enum; published at call sites so a later
@@ -41459,6 +41520,54 @@ fn numeric_or_comparison_binary_value(
         )),
         _ => None,
     }
+}
+
+fn shape_leaves_payloads_open(shape: &ConcreteEnumShape) -> bool {
+    shape
+        .variants
+        .values()
+        .any(|variant| variant.fields.iter().any(|field| !field.resolved))
+}
+
+fn native_value_annotation_name(value: NativeValue) -> Option<String> {
+    Some(
+        match value {
+            NativeValue::Int => "Int",
+            NativeValue::Bool => "Boolean",
+            NativeValue::RuntimeDouble => "Double",
+            NativeValue::HeapString
+            | NativeValue::StaticString { .. }
+            | NativeValue::RuntimeString { .. } => "String",
+            _ => return None,
+        }
+        .to_string(),
+    )
+}
+
+fn substitute_type_variables(text: &str, variables: &[String], names: &[String]) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut token = String::new();
+    for ch in text.chars() {
+        if ch == '\'' || ch.is_alphanumeric() || ch == '_' {
+            token.push(ch);
+            continue;
+        }
+        if !token.is_empty() {
+            match variables.iter().position(|variable| *variable == token) {
+                Some(at) => out.push_str(&names[at]),
+                None => out.push_str(&token),
+            }
+            token.clear();
+        }
+        out.push(ch);
+    }
+    if !token.is_empty() {
+        match variables.iter().position(|variable| *variable == token) {
+            Some(at) => out.push_str(&names[at]),
+            None => out.push_str(&token),
+        }
+    }
+    out
 }
 
 fn format_static_float(bits: u32) -> String {

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -26986,12 +26986,13 @@ impl NativeCodeGenerator {
     ) -> Result<NativeValue, Diagnostic> {
         self.expect_static_arity(name, arguments, 2, span)?;
         let input = self.compile_expr(&arguments[0])?;
-        let Some(input) = self.native_string_ref(input) else {
-            return Err(unsupported(span, &format!("native {name} for non-string")));
+        let context = format!("native {name} for non-string");
+        let Some(input) = self.native_string_ref_or_copy(input, span, &context) else {
+            return Err(unsupported(span, &context));
         };
         let needle = self.compile_expr(&arguments[1])?;
-        let Some(needle) = self.native_string_ref(needle) else {
-            return Err(unsupported(span, &format!("native {name} for non-string")));
+        let Some(needle) = self.native_string_ref_or_copy(needle, span, &context) else {
+            return Err(unsupported(span, &context));
         };
         match name {
             "startsWith" => self.emit_native_string_starts_with(input, needle),
@@ -34183,6 +34184,26 @@ impl NativeCodeGenerator {
         } else {
             value
         }
+    }
+
+    /// The same as `native_string_ref`, but a heap string is copied into a
+    /// scratch buffer pair first. An extension method's `this: String`
+    /// parameter arrives as a heap string, so without this every string
+    /// builtin written as `this.startsWith(...)` was refused.
+    fn native_string_ref_or_copy(
+        &mut self,
+        value: NativeValue,
+        span: Span,
+        context: &str,
+    ) -> Option<NativeStringRef> {
+        if let Some(reference) = self.native_string_ref(value) {
+            return Some(reference);
+        }
+        if value != NativeValue::HeapString {
+            return None;
+        }
+        let copied = self.emit_heap_string_to_runtime_string_value(span, context);
+        self.native_string_ref(copied)
     }
 
     fn native_string_ref(&self, value: NativeValue) -> Option<NativeStringRef> {

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -5346,13 +5346,6 @@ impl NativeCodeGenerator {
                 .iter()
                 .all(|arm| en_pattern_supported_shaped(shape, &arm.pattern))
         {
-            eprintln!(
-                "DBG shape variants={:?} arms={:?}",
-                shape.variants.keys().collect::<Vec<_>>(),
-                arms.iter()
-                    .map(|a| format!("{:?}", a.pattern))
-                    .collect::<Vec<_>>()
-            );
             return Err(unsupported(
                 span,
                 "native generic enum match: a pattern variant is not in the scrutinee shape",

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -4495,6 +4495,11 @@ struct NativeCodeGenerator {
     functions: HashMap<String, NativeFunction>,
     function_order: Vec<String>,
     referenced_functions: HashSet<String>,
+    /// Definitions that reach themselves. A value backed by a buffer chosen
+    /// while compiling has one buffer per *call site*, which is one buffer for
+    /// every activation of a recursive function -- so building one inside a
+    /// recursive definition has to be refused rather than emitted.
+    recursive_function_names: HashSet<String>,
     active_function_name: Option<String>,
     instance_methods: Vec<NativeInstanceMethod>,
     record_schemas: HashMap<String, Vec<NativeRecordFieldSchema>>,
@@ -4870,6 +4875,7 @@ impl NativeCodeGenerator {
             functions: HashMap::new(),
             function_order: Vec::new(),
             referenced_functions: HashSet::new(),
+            recursive_function_names: HashSet::new(),
             active_function_name: None,
             instance_methods: Vec::new(),
             record_schemas,
@@ -5844,6 +5850,8 @@ impl NativeCodeGenerator {
         };
         let thread_aliases = top_level_thread_aliases(expressions);
         let recursive_names = recursive_def_names(expressions);
+        self.recursive_function_names
+            .extend(recursive_names.iter().cloned());
         let top_level_value_names = top_level_value_names(expressions);
         self.top_level_mutable_names = top_level_mutable_names(expressions);
         for expression in expressions {
@@ -9989,6 +9997,13 @@ impl NativeCodeGenerator {
         }
     }
 
+    /// Is the body being compiled part of a definition that reaches itself?
+    fn inside_recursive_function(&self) -> bool {
+        self.active_function_name
+            .as_ref()
+            .is_some_and(|name| self.recursive_function_names.contains(name))
+    }
+
     fn compile_cons(
         &mut self,
         head_arguments: &[Expr],
@@ -10002,6 +10017,16 @@ impl NativeCodeGenerator {
             ));
         }
         if self.expr_may_yield_runtime_lines_list(&tail_arguments[0]) {
+            // The result is a buffer chosen while compiling, so there is one
+            // per call site -- shared by every activation of a recursive
+            // function, which would print the innermost element in every
+            // position. Refuse rather than answer wrongly.
+            if self.inside_recursive_function() {
+                return Err(unsupported(
+                    span,
+                    "building a list inside a recursive function, whose result buffer is chosen while compiling",
+                ));
+            }
             let head = self.compile_expr(&head_arguments[0])?;
             let Some(head) = self.native_string_ref(head) else {
                 return Err(unsupported(

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -6512,6 +6512,8 @@ impl NativeCodeGenerator {
             | "abs"
             | "size"
             | "Map#size"
+            | "Map#keys"
+            | "Map#values"
             | "Set#size"
             | "isEmpty"
             | "Map#isEmpty"
@@ -8165,6 +8167,24 @@ impl NativeCodeGenerator {
             "contains" => self.compile_static_contains_direct(arguments, span),
             "double" | "sqrt" | "int" | "floor" | "ceil" | "abs" => {
                 self.compile_numeric_helper(name.as_str(), arguments, span)
+            }
+            // A map's two halves as lists, in insertion order. Both are read
+            // off the compile-time entries, which is what `std.map`'s
+            // `toPairs` and `foldMap` walk.
+            "Map#keys" | "Map#values" => {
+                if arguments.len() != 1 {
+                    return Err(Diagnostic::compile(
+                        span,
+                        format!("{name} expects 1 argument but got {}", arguments.len()),
+                    ));
+                }
+                let entries = self.static_map_entries_from_expr(&arguments[0], span)?;
+                let taken = entries
+                    .into_iter()
+                    .map(|(key, value)| if name == "Map#keys" { key } else { value })
+                    .collect();
+                let label = self.intern_static_list(taken);
+                Ok(NativeValue::StaticList { label })
             }
             "size" | "Map#size" | "Set#size" => {
                 if arguments.len() != 1 {

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -13812,6 +13812,23 @@ impl NativeCodeGenerator {
                 Ok(())
             }
             NativeValue::HeapPointer if allow_erased_pointer => Ok(()),
+            // A number or a flag appended to a heap string: render it the way
+            // `toString` does, then copy the text onto the heap so the result
+            // is a heap string like the other operand. Without this,
+            // `acc + key + ": " + value` -- the shape every rendering of a
+            // key/value chain takes -- could not be compiled.
+            NativeValue::Int | NativeValue::Bool => {
+                let text = if value == NativeValue::Int {
+                    self.emit_i64_rax_to_runtime_string_ref(span, context)
+                } else {
+                    self.emit_bool_rax_to_runtime_string_ref(span, context)
+                };
+                let NativeStringLen::Runtime(len) = text.len else {
+                    return Err(unsupported(span, context));
+                };
+                self.emit_runtime_string_to_heap_string(text.data, len);
+                Ok(())
+            }
             _ => Err(unsupported(span, context)),
         }
     }

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -14744,6 +14744,11 @@ impl NativeCodeGenerator {
         let done = self.asm.create_text_label();
         self.asm.cmp_reg_imm8(Reg::Rax, 0);
         self.asm.jcc_label(Condition::Greater, nonzero);
+        // The answer is read out of R9 below, so the zero case has to put it
+        // there. Without this the register still holds the previous
+        // `Math#sqrtInt` in the same program, and `Math#sqrtInt(0)` answered
+        // with that instead of 0.
+        self.asm.mov_reg_reg(Reg::R9, Reg::Rax);
         self.asm.jmp_label(done);
         self.asm.bind_text_label(nonzero);
         // R8 = n (preserved across the loop).

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -6544,6 +6544,8 @@ impl NativeCodeGenerator {
             | "Math#sqrtInt"
             | "String#parseInt"
             | "Random#seed"
+            | "String#isInt"
+            | "String#isDouble"
             | "Random#nextInt" => Some(1),
             "at"
             | "matches"
@@ -8387,6 +8389,34 @@ impl NativeCodeGenerator {
             }
             "Map#get" | "get" => self.compile_static_map_get_direct(arguments, span),
             "Set#contains" => self.compile_static_set_contains_direct(arguments, span),
+            // `String#isInt` / `String#isDouble`: folded when the text is
+            // known while compiling (Rust's own parse decides, so the answer
+            // is the evaluator's by construction), scanned when it is not.
+            "String#isInt" | "String#isDouble" if arguments.len() == 1 => {
+                if self.expr_may_yield_runtime_string(&arguments[0]) {
+                    let input = self.compile_expr(&arguments[0])?;
+                    let Some(input) = self.native_string_ref(input) else {
+                        return Err(unsupported(span, &format!("native {name} for non-string")));
+                    };
+                    return Ok(if name == "String#isInt" {
+                        self.emit_runtime_string_is_int(input)
+                    } else {
+                        self.emit_runtime_string_is_double(input)
+                    });
+                }
+                let text = self.static_string_from_argument_preserving_effects(
+                    &arguments[0],
+                    span,
+                    name.as_str(),
+                )?;
+                let answer = if name == "String#isInt" {
+                    text.trim().parse::<i64>().is_ok()
+                } else {
+                    text.trim().parse::<f64>().is_ok()
+                };
+                self.asm.mov_imm64(Reg::Rax, u64::from(answer));
+                Ok(NativeValue::Bool)
+            }
             // The function spellings of the set builders. The method forms
             // (`s.add(x)`, `s.toList()`) were already here; `std.set`'s own
             // extension methods call these.
@@ -36296,6 +36326,286 @@ impl NativeCodeGenerator {
         self.asm.bind_text_label(done);
         self.asm.mov_data_addr(Reg::R10, offset);
         self.asm.store_ptr_disp32(Reg::R10, 0, Reg::R9);
+    }
+
+    /// Leave `[r9, r8)` holding the input with ASCII whitespace trimmed off
+    /// both ends, with `rsi` = bytes and `rdx` = length. The evaluator's
+    /// `is_int`/`is_double` both start with `trim()`, and everything after
+    /// them reads the window this leaves behind.
+    fn emit_trim_window_r9_r8(&mut self, input: NativeStringRef) {
+        self.asm.mov_data_addr(Reg::Rsi, input.data);
+        self.emit_load_native_string_len(Reg::Rdx, input.len);
+        let left_loop = self.asm.create_text_label();
+        let consume_left = self.asm.create_text_label();
+        let left_done = self.asm.create_text_label();
+        self.asm.mov_imm64(Reg::R9, 0);
+        self.asm.bind_text_label(left_loop);
+        self.asm.cmp_reg_reg(Reg::R9, Reg::Rdx);
+        self.asm.jcc_label(Condition::GreaterEqual, left_done);
+        self.asm.movzx_byte_indexed(Reg::Rax, Reg::Rsi, Reg::R9);
+        self.emit_jump_if_ascii_whitespace(Reg::Rax, consume_left);
+        self.asm.jmp_label(left_done);
+        self.asm.bind_text_label(consume_left);
+        self.asm.inc_reg(Reg::R9);
+        self.asm.jmp_label(left_loop);
+        self.asm.bind_text_label(left_done);
+
+        let right_loop = self.asm.create_text_label();
+        let consume_right = self.asm.create_text_label();
+        let right_done = self.asm.create_text_label();
+        self.asm.mov_reg_reg(Reg::R8, Reg::Rdx);
+        self.asm.bind_text_label(right_loop);
+        self.asm.cmp_reg_reg(Reg::R8, Reg::R9);
+        self.asm.jcc_label(Condition::LessEqual, right_done);
+        self.asm.mov_reg_reg(Reg::R10, Reg::R8);
+        self.asm.dec_reg(Reg::R10);
+        self.asm.movzx_byte_indexed(Reg::Rax, Reg::Rsi, Reg::R10);
+        self.emit_jump_if_ascii_whitespace(Reg::Rax, consume_right);
+        self.asm.jmp_label(right_done);
+        self.asm.bind_text_label(consume_right);
+        self.asm.dec_reg(Reg::R8);
+        self.asm.jmp_label(right_loop);
+        self.asm.bind_text_label(right_done);
+    }
+
+    /// `String#isInt(s)` for a string only known at run time: what
+    /// `s.trim().parse::<i64>()` accepts, range included. The range check is a
+    /// digit count and, at exactly nineteen digits, a comparison against the
+    /// limit's own digits -- no 128-bit arithmetic, and exact.
+    fn emit_runtime_string_is_int(&mut self, input: NativeStringRef) -> NativeValue {
+        let positive_limit = self.asm.data_label_with_bytes(b"9223372036854775807");
+        let negative_limit = self.asm.data_label_with_bytes(b"9223372036854775808");
+        let no = self.asm.create_text_label();
+        let yes = self.asm.create_text_label();
+        let done = self.asm.create_text_label();
+        self.emit_trim_window_r9_r8(input);
+        // Empty after trimming is not a number.
+        self.asm.cmp_reg_reg(Reg::R9, Reg::R8);
+        self.asm.jcc_label(Condition::GreaterEqual, no);
+        // An optional sign, remembered in r11 (1 when negative).
+        let signed = self.asm.create_text_label();
+        let after_sign = self.asm.create_text_label();
+        self.asm.mov_imm64(Reg::R11, 0);
+        self.asm.movzx_byte_indexed(Reg::Rax, Reg::Rsi, Reg::R9);
+        self.asm.cmp_reg_imm8(Reg::Rax, b'+' as i8);
+        self.asm.jcc_label(Condition::Equal, signed);
+        self.asm.cmp_reg_imm8(Reg::Rax, b'-' as i8);
+        self.asm.jcc_label(Condition::NotEqual, after_sign);
+        self.asm.mov_imm64(Reg::R11, 1);
+        self.asm.bind_text_label(signed);
+        self.asm.inc_reg(Reg::R9);
+        self.asm.bind_text_label(after_sign);
+        self.asm.cmp_reg_reg(Reg::R9, Reg::R8);
+        self.asm.jcc_label(Condition::GreaterEqual, no);
+        // Leading zeros do not count towards the range, so drop them -- but
+        // keep the last digit, so "0" stays a number.
+        let zero_loop = self.asm.create_text_label();
+        let zeros_done = self.asm.create_text_label();
+        self.asm.bind_text_label(zero_loop);
+        self.asm.mov_reg_reg(Reg::R10, Reg::R8);
+        self.asm.sub_reg_reg(Reg::R10, Reg::R9);
+        self.asm.cmp_reg_imm8(Reg::R10, 1);
+        self.asm.jcc_label(Condition::LessEqual, zeros_done);
+        self.asm.movzx_byte_indexed(Reg::Rax, Reg::Rsi, Reg::R9);
+        self.asm.cmp_reg_imm8(Reg::Rax, b'0' as i8);
+        self.asm.jcc_label(Condition::NotEqual, zeros_done);
+        self.asm.inc_reg(Reg::R9);
+        self.asm.jmp_label(zero_loop);
+        self.asm.bind_text_label(zeros_done);
+        // Every remaining byte has to be a digit.
+        let digit_loop = self.asm.create_text_label();
+        let digits_done = self.asm.create_text_label();
+        self.asm.mov_reg_reg(Reg::R10, Reg::R9);
+        self.asm.bind_text_label(digit_loop);
+        self.asm.cmp_reg_reg(Reg::R10, Reg::R8);
+        self.asm.jcc_label(Condition::GreaterEqual, digits_done);
+        self.asm.movzx_byte_indexed(Reg::Rax, Reg::Rsi, Reg::R10);
+        self.asm.cmp_reg_imm8(Reg::Rax, b'0' as i8);
+        self.asm.jcc_label(Condition::Less, no);
+        self.asm.cmp_reg_imm8(Reg::Rax, b'9' as i8);
+        self.asm.jcc_label(Condition::Greater, no);
+        self.asm.inc_reg(Reg::R10);
+        self.asm.jmp_label(digit_loop);
+        self.asm.bind_text_label(digits_done);
+        // Nineteen digits is the only length that needs comparing.
+        self.asm.mov_reg_reg(Reg::R10, Reg::R8);
+        self.asm.sub_reg_reg(Reg::R10, Reg::R9);
+        self.asm.cmp_reg_imm8(Reg::R10, 19);
+        self.asm.jcc_label(Condition::Greater, no);
+        self.asm.jcc_label(Condition::Less, yes);
+        let use_negative = self.asm.create_text_label();
+        let limit_ready = self.asm.create_text_label();
+        self.asm.cmp_reg_imm8(Reg::R11, 0);
+        self.asm.jcc_label(Condition::NotEqual, use_negative);
+        self.asm.mov_data_addr(Reg::R11, positive_limit);
+        self.asm.jmp_label(limit_ready);
+        self.asm.bind_text_label(use_negative);
+        self.asm.mov_data_addr(Reg::R11, negative_limit);
+        self.asm.bind_text_label(limit_ready);
+        let compare_loop = self.asm.create_text_label();
+        self.asm.mov_imm64(Reg::R10, 0);
+        self.asm.bind_text_label(compare_loop);
+        self.asm.cmp_reg_imm8(Reg::R10, 19);
+        self.asm.jcc_label(Condition::GreaterEqual, yes);
+        self.asm.movzx_byte_indexed(Reg::Rax, Reg::Rsi, Reg::R9);
+        self.asm.movzx_byte_indexed(Reg::Rcx, Reg::R11, Reg::R10);
+        self.asm.cmp_reg_reg(Reg::Rax, Reg::Rcx);
+        self.asm.jcc_label(Condition::Less, yes);
+        self.asm.jcc_label(Condition::Greater, no);
+        self.asm.inc_reg(Reg::R9);
+        self.asm.inc_reg(Reg::R10);
+        self.asm.jmp_label(compare_loop);
+        self.asm.bind_text_label(yes);
+        self.asm.mov_imm64(Reg::Rax, 1);
+        self.asm.jmp_label(done);
+        self.asm.bind_text_label(no);
+        self.asm.mov_imm64(Reg::Rax, 0);
+        self.asm.bind_text_label(done);
+        NativeValue::Bool
+    }
+
+    /// `String#isDouble(s)` for a string only known at run time: what
+    /// `s.trim().parse::<f64>()` accepts -- an optional sign, then `inf`,
+    /// `infinity` or `nan` (either case), or digits with an optional point
+    /// and an optional exponent. A value too large to represent parses as
+    /// infinity rather than failing, so there is no range check here.
+    fn emit_runtime_string_is_double(&mut self, input: NativeStringRef) -> NativeValue {
+        let no = self.asm.create_text_label();
+        let yes = self.asm.create_text_label();
+        let done = self.asm.create_text_label();
+        self.emit_trim_window_r9_r8(input);
+        self.asm.cmp_reg_reg(Reg::R9, Reg::R8);
+        self.asm.jcc_label(Condition::GreaterEqual, no);
+        // An optional sign.
+        let signed = self.asm.create_text_label();
+        let after_sign = self.asm.create_text_label();
+        self.asm.movzx_byte_indexed(Reg::Rax, Reg::Rsi, Reg::R9);
+        self.asm.cmp_reg_imm8(Reg::Rax, b'+' as i8);
+        self.asm.jcc_label(Condition::Equal, signed);
+        self.asm.cmp_reg_imm8(Reg::Rax, b'-' as i8);
+        self.asm.jcc_label(Condition::NotEqual, after_sign);
+        self.asm.bind_text_label(signed);
+        self.asm.inc_reg(Reg::R9);
+        self.asm.bind_text_label(after_sign);
+        self.asm.cmp_reg_reg(Reg::R9, Reg::R8);
+        self.asm.jcc_label(Condition::GreaterEqual, no);
+        // `inf`, `infinity` and `nan`, in any case.
+        for word in [b"infinity".as_slice(), b"inf".as_slice(), b"nan".as_slice()] {
+            let label = self.asm.data_label_with_bytes(word);
+            let mismatch = self.asm.create_text_label();
+            let compare = self.asm.create_text_label();
+            // Only when what is left is exactly this long.
+            self.asm.mov_reg_reg(Reg::R10, Reg::R8);
+            self.asm.sub_reg_reg(Reg::R10, Reg::R9);
+            self.asm.cmp_reg_imm8(Reg::R10, word.len() as i8);
+            self.asm.jcc_label(Condition::NotEqual, mismatch);
+            self.asm.mov_data_addr(Reg::R11, label);
+            self.asm.mov_imm64(Reg::R10, 0);
+            self.asm.bind_text_label(compare);
+            self.asm.cmp_reg_imm8(Reg::R10, word.len() as i8);
+            self.asm.jcc_label(Condition::GreaterEqual, yes);
+            self.asm.mov_reg_reg(Reg::Rcx, Reg::R9);
+            self.asm.add_reg_reg(Reg::Rcx, Reg::R10);
+            self.asm.movzx_byte_indexed(Reg::Rax, Reg::Rsi, Reg::Rcx);
+            // Lower-case the input byte; the words above are lower-case.
+            self.asm.mov_imm64(Reg::Rcx, 0x20);
+            self.asm.or_reg_reg(Reg::Rax, Reg::Rcx);
+            self.asm.movzx_byte_indexed(Reg::Rcx, Reg::R11, Reg::R10);
+            self.asm.cmp_reg_reg(Reg::Rax, Reg::Rcx);
+            self.asm.jcc_label(Condition::NotEqual, mismatch);
+            self.asm.inc_reg(Reg::R10);
+            self.asm.jmp_label(compare);
+            self.asm.bind_text_label(mismatch);
+        }
+        // Digits, an optional point with more digits, and at least one of
+        // the two. r11 counts them.
+        self.asm.mov_imm64(Reg::R11, 0);
+        let int_digits = self.asm.create_text_label();
+        let int_done = self.asm.create_text_label();
+        self.asm.bind_text_label(int_digits);
+        self.asm.cmp_reg_reg(Reg::R9, Reg::R8);
+        self.asm.jcc_label(Condition::GreaterEqual, int_done);
+        self.asm.movzx_byte_indexed(Reg::Rax, Reg::Rsi, Reg::R9);
+        self.asm.cmp_reg_imm8(Reg::Rax, b'0' as i8);
+        self.asm.jcc_label(Condition::Less, int_done);
+        self.asm.cmp_reg_imm8(Reg::Rax, b'9' as i8);
+        self.asm.jcc_label(Condition::Greater, int_done);
+        self.asm.inc_reg(Reg::R9);
+        self.asm.inc_reg(Reg::R11);
+        self.asm.jmp_label(int_digits);
+        self.asm.bind_text_label(int_done);
+        let after_point = self.asm.create_text_label();
+        self.asm.cmp_reg_reg(Reg::R9, Reg::R8);
+        self.asm.jcc_label(Condition::GreaterEqual, after_point);
+        self.asm.movzx_byte_indexed(Reg::Rax, Reg::Rsi, Reg::R9);
+        self.asm.cmp_reg_imm8(Reg::Rax, b'.' as i8);
+        self.asm.jcc_label(Condition::NotEqual, after_point);
+        self.asm.inc_reg(Reg::R9);
+        let frac_digits = self.asm.create_text_label();
+        self.asm.bind_text_label(frac_digits);
+        self.asm.cmp_reg_reg(Reg::R9, Reg::R8);
+        self.asm.jcc_label(Condition::GreaterEqual, after_point);
+        self.asm.movzx_byte_indexed(Reg::Rax, Reg::Rsi, Reg::R9);
+        self.asm.cmp_reg_imm8(Reg::Rax, b'0' as i8);
+        self.asm.jcc_label(Condition::Less, after_point);
+        self.asm.cmp_reg_imm8(Reg::Rax, b'9' as i8);
+        self.asm.jcc_label(Condition::Greater, after_point);
+        self.asm.inc_reg(Reg::R9);
+        self.asm.inc_reg(Reg::R11);
+        self.asm.jmp_label(frac_digits);
+        self.asm.bind_text_label(after_point);
+        self.asm.cmp_reg_imm8(Reg::R11, 0);
+        self.asm.jcc_label(Condition::Equal, no);
+        // An optional exponent, which needs at least one digit of its own.
+        let after_exponent = self.asm.create_text_label();
+        self.asm.cmp_reg_reg(Reg::R9, Reg::R8);
+        self.asm.jcc_label(Condition::GreaterEqual, after_exponent);
+        self.asm.movzx_byte_indexed(Reg::Rax, Reg::Rsi, Reg::R9);
+        self.asm.mov_imm64(Reg::Rcx, 0x20);
+        self.asm.or_reg_reg(Reg::Rax, Reg::Rcx);
+        self.asm.cmp_reg_imm8(Reg::Rax, b'e' as i8);
+        self.asm.jcc_label(Condition::NotEqual, after_exponent);
+        self.asm.inc_reg(Reg::R9);
+        let exponent_signed = self.asm.create_text_label();
+        let exponent_digits = self.asm.create_text_label();
+        self.asm.cmp_reg_reg(Reg::R9, Reg::R8);
+        self.asm.jcc_label(Condition::GreaterEqual, no);
+        self.asm.movzx_byte_indexed(Reg::Rax, Reg::Rsi, Reg::R9);
+        self.asm.cmp_reg_imm8(Reg::Rax, b'+' as i8);
+        self.asm.jcc_label(Condition::Equal, exponent_signed);
+        self.asm.cmp_reg_imm8(Reg::Rax, b'-' as i8);
+        self.asm.jcc_label(Condition::NotEqual, exponent_digits);
+        self.asm.bind_text_label(exponent_signed);
+        self.asm.inc_reg(Reg::R9);
+        self.asm.bind_text_label(exponent_digits);
+        self.asm.mov_imm64(Reg::R11, 0);
+        let exponent_loop = self.asm.create_text_label();
+        let exponent_done = self.asm.create_text_label();
+        self.asm.bind_text_label(exponent_loop);
+        self.asm.cmp_reg_reg(Reg::R9, Reg::R8);
+        self.asm.jcc_label(Condition::GreaterEqual, exponent_done);
+        self.asm.movzx_byte_indexed(Reg::Rax, Reg::Rsi, Reg::R9);
+        self.asm.cmp_reg_imm8(Reg::Rax, b'0' as i8);
+        self.asm.jcc_label(Condition::Less, exponent_done);
+        self.asm.cmp_reg_imm8(Reg::Rax, b'9' as i8);
+        self.asm.jcc_label(Condition::Greater, exponent_done);
+        self.asm.inc_reg(Reg::R9);
+        self.asm.inc_reg(Reg::R11);
+        self.asm.jmp_label(exponent_loop);
+        self.asm.bind_text_label(exponent_done);
+        self.asm.cmp_reg_imm8(Reg::R11, 0);
+        self.asm.jcc_label(Condition::Equal, no);
+        self.asm.bind_text_label(after_exponent);
+        // Anything left over means it was not a number.
+        self.asm.cmp_reg_reg(Reg::R9, Reg::R8);
+        self.asm.jcc_label(Condition::NotEqual, no);
+        self.asm.bind_text_label(yes);
+        self.asm.mov_imm64(Reg::Rax, 1);
+        self.asm.jmp_label(done);
+        self.asm.bind_text_label(no);
+        self.asm.mov_imm64(Reg::Rax, 0);
+        self.asm.bind_text_label(done);
+        NativeValue::Bool
     }
 
     fn emit_jump_if_ascii_whitespace(&mut self, byte_reg: Reg, label: TextLabel) {

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1560,6 +1560,22 @@ for arm64, let CI run it, read what the collector said.
   is about to be compiled, with the loop variable bound, because every turn
   after the first reads what the previous one wrote.
 
+### Integer math, the generator, and a register never written
+
+`Math#gcd` / `Math#powInt` / `Math#sqrtInt` and `Random#seed` /
+`Random#nextInt` are on the aarch64 backend now, by the evaluator's own
+algorithms: Euclid on the absolute values, square-and-multiply, Newton's
+iteration, and the 64-bit LCG whose high half is the answer. The generator's
+state is a `__DATA` cell reserved on first use, so a program that never asks
+for a random number carries no cell for one. A seeded program prints the same
+sequence on every target, which is the whole point of seeding.
+
+Writing the arm64 side turned up a bug in the x86-64 one: `Math#sqrtInt`
+returns its answer out of `r9`, and the `n == 0` fast path jumped to the exit
+without writing it. `Math#sqrtInt(0)` therefore answered with whatever the
+*previous* square root in the same program left in that register. A single
+call could not show it -- the fixture takes a root of 17 first, then of 0.
+
 ## Design Notes
 
 - The direct evaluator is the current execution engine.

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1712,11 +1712,17 @@ that a heap pointer takes, and a string argument is exactly what fixes a
 rewritten shape is published there once the whole argument list has been
 seen.
 
-What is left is not a representation gap any more but a routing one: the
-*builtin* `Map` and `List` still use compile-time values or fixed-capacity
-buffers on x86-64, so `Map#put` in a loop and `words()` over a runtime list
-stay arm64-only. The chain they would be lowered to is now portable, and a
-lowering can emit its helpers generically rather than one set per type pair.
+What is left is not a representation gap any more but a routing one, and it
+splits in two. `Map#put` in a loop needs the *builtin* map lowered to the
+chain above -- a middle-end pass that injects the enum and its helpers and
+rewrites the `Map#*` calls, the map literals and the rendering; the helpers
+can be generic now, so the pass needs no type inference of its own.
+`words()` needs something else: `stdlibFilter` is a *recursive* generic
+function taking `List<'a>`, and a recursive function has to be compiled once,
+so its parameter kinds must be fixed -- measured again after the type-variable
+solving landed, and the reason is still "this backend cannot pass `xs`
+(`List<'a>`) by itself". That one wants monomorphisation of recursive generic
+definitions, which is a separate piece from the map lowering.
 
 ## Design Notes
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1681,89 +1681,42 @@ string -- and the aarch64 backend only had the first, so `containsText` failed
 there. It dispatches on the receiver now, reusing the byte search `indexOf`
 runs.
 
-### Where the portable collection work resumes
+### Collections whose size is only known while running
 
-The route to `Map` and `List` values whose size is only known while running,
-on every backend, is to build them out of a self-referential enum -- a chain
-of GC cells, which both hand-emitted backends already allocate and walk. A
-*monomorphic* chain works end to end today: fixture 28 grows one in a loop,
-replaces on a repeated key, renders it, and agrees with the evaluator on all
-three targets under `--gc-stress`. A *generic* chain -- which is what a
-lowering would have to emit, since the desugar does not know the key and
-value types -- stops at two places:
+A `Map` or `List` that grows while the program runs is built out of a
+self-referential enum -- a chain of GC cells -- and that works on every
+backend now, generically. Fixture 31 grows one from the *empty case* in a
+loop, at two different key/value type pairs, and agrees with the evaluator on
+all three targets, including under `--gc-stress`; fixture 30 does the same
+with fully applied annotations and a hundred entries.
 
-It is **one** missing inference, and both backends want it. Narrowing the
-repro down to the smallest program that fails shows the same trigger on each:
-a generic helper called with the *empty case of its own enum*.
+Getting there took one inference, which both hand-emitted backends were
+missing in their own way. A call like `put(KMNil, "a", 1)` fixes nothing
+through its first argument -- the empty case of an enum carries no payloads,
+so the other variant's payload reprs stay open -- and both backends then read
+that variant against defaults: x86-64 compared a defaulted scalar to a
+string, aarch64 derived a return shape its own body did not produce. The
+arguments that *do* fix the type variables sit in the same argument list, so
+both now **solve the definition's type variables across every argument**
+(`key: 'k` given a string fixes `'k`) and give an enum-typed parameter whose
+own argument left them open the shape those solutions imply, read off the
+annotation it was declared with.
 
-    def kmPut(m: KM<'k,'v>, key: 'k, value: 'v): KM<'k,'v> = ...
-    kmPut(m, "b", 2)        // fine on both
-    kmPut(KMNil, "a", 1)    // rejected on both
+The two implementations differ where the backends do. aarch64 specialises per
+argument-type tuple, so the solving happens while the specialisation's
+signature is built. x86-64 inlines, so it happens in the binding loop -- and
+the solving has to sit *before* the per-value-kind binding paths, because a
+string argument binds as a constant and never reaches the slot-allocating arm
+that a heap pointer takes, and a string argument is exactly what fixes a
+`'k`. The body reads a parameter's shape out of its slot's entry, so the
+rewritten shape is published there once the whole argument list has been
+seen.
 
-`KMNil` carries no type arguments, so nothing fixes `'k` and `'v` at that
-call. x86-64 then defaults the other variant's payload reprs and rejects
-`k == key` as comparing a `Scalar` to a string; aarch64 derives a return
-shape that its own body does not produce, and rejects the body against its
-annotation. Everything else measured along the way works: shape propagation
-through an inlined generic call, through a `mutable` reassignment and through
-a slot read on x86-64; the same helper on both backends when the chain starts
-from a `KMCons` rather than the empty case.
-
-**The aarch64 half is done.** A specialisation now solves the definition's
-type variables across *all* the arguments -- a parameter annotated `'k` given
-a string fixes `'k` as `String` -- and an enum-typed parameter whose own
-argument left the variables open takes the shape those solutions imply,
-through the annotation it was declared with. `kmPut(KMNil, "a", 1)` and a
-chain grown from the empty case in a loop compile there now, and a
-macOS-gated test runs one.
-
-**The x86-64 half is measured but not landed.** Instrumenting the inline
-binding of `kmPut(KMNil, "a", 1)` shows exactly what a call site has to work
-with:
-
-    param=m     expected=Int  value=HeapPointer  flexible=true
-    param=key   expected=Int  value=StaticString flexible=true
-    param=value expected=Int  value=Int          flexible=true
-
-`KM<'k, 'v>` is not a type this backend models, so the parameter's expected
-value degrades to `Int` and the argument arrives as a bare `HeapPointer` --
-the shape is the only thing that says what its payloads are, and the empty
-case leaves them open. The two arguments that *do* fix the variables are
-right there in the same list, which is what makes the fix the same one
-aarch64 took. An attempt that threaded the annotation text onto
-`NativeFunction`, solved the variables during the binding loop and rewrote
-the slot's shape afterwards compiled but changed nothing observable, so it
-was not kept; the next step is to find where the body reads a parameter's
-shape (the slot's entry in `enum_shapes`, or the `pending_enum_shape` a slot
-read republishes) and make the rewritten shape reach *that*, rather than
-assuming the slot entry is enough.
-
-**What already works on every target, measured:** the same store written with
-*fully applied* annotations -- `kmGet(m: KM<String, Int>, ...)` rather than
-`KM<'k, 'v>` -- compiles and runs on all three, grown from the empty case in
-a loop, a hundred entries deep, agreeing with the evaluator under
-`--gc-stress` (fixture 30). So the representation, the growth, the lookup and
-the rendering are all portable today; the only thing that is not is writing
-the helpers *generically*. That also says what a lowering would have to
-produce to be portable now: monomorphic helpers, one set per key/value type
-pair it sees.
-
-The idea, restated: **recover the type arguments from the other arguments** -- `key: 'k` against a string fixes `'k`, `value: 'v` against an
-Int fixes `'v` -- rather than only from the enum-typed one. aarch64 already
-has the machinery to build a shape from inferred type arguments
-(`canonical_applied_enum_shape`), and x86-64 already has
-`generic_enum_annotation_shape` and `resolve_enum_shape`; what neither does is
-solve for the parameters across *all* of a call's arguments.
-
-Dropping the unresolved arm as dead instead is *not* sound: it was tried, and
-the next call -- whose value really is the other variant -- died with "match:
-no pattern matched" at run time. A compile-time rejection is the safer of the
-two, which is why the rejection stands.
-
-Two language-surface warts turned up alongside them, both worth fixing on
-their own: `x = if (c) a else b` does not parse without parentheses, and a
-`match` arm whose body ends in an assignment takes that assignment's type, so
-two arms ending in assignments to different types disagree.
+What is left is not a representation gap any more but a routing one: the
+*builtin* `Map` and `List` still use compile-time values or fixed-capacity
+buffers on x86-64, so `Map#put` in a loop and `words()` over a runtime list
+stay arm64-only. The chain they would be lowered to is now portable, and a
+lowering can emit its helpers generically rather than one set per type pair.
 
 ## Design Notes
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1692,24 +1692,35 @@ three targets under `--gc-stress`. A *generic* chain -- which is what a
 lowering would have to emit, since the desugar does not know the key and
 value types -- stops at two places:
 
-1. **x86-64.** A helper that both destructures and constructs the same
-   generic enum is rejected: `put(empty, k, v)` inlines with the empty case's
-   shape, where the other variant's payload reprs are *defaulted* rather than
-   resolved, so `k == key` compares a defaulted `Scalar` against a string.
-   Shape propagation itself works -- through an inlined generic call, through
-   a `mutable` reassignment, and through a slot read (all measured) -- so what
-   is missing is narrower: a nullary constructor should take its payload reprs
-   from the annotation (`generic_enum_annotation_shape` already derives them)
-   or from the call site, rather than defaulting them.
+It is **one** missing inference, and both backends want it. Narrowing the
+repro down to the smallest program that fails shows the same trigger on each:
+a generic helper called with the *empty case of its own enum*.
 
-   Dropping the arm as dead instead is *not* sound: it was tried, and the
-   second call -- whose value really is the other variant -- then died with
-   "match: no pattern matched" at run time. A compile-time rejection is the
-   safer of the two, which is why the rejection stands.
+    def kmPut(m: KM<'k,'v>, key: 'k, value: 'v): KM<'k,'v> = ...
+    kmPut(m, "b", 2)        // fine on both
+    kmPut(KMNil, "a", 1)    // rejected on both
 
-2. **aarch64.** The return type of a generic helper written as a `while` loop
-   (rather than recursion, which is what keeps x86-64 able to inline it) is
-   not predicted, so the body is rejected against its own annotation.
+`KMNil` carries no type arguments, so nothing fixes `'k` and `'v` at that
+call. x86-64 then defaults the other variant's payload reprs and rejects
+`k == key` as comparing a `Scalar` to a string; aarch64 derives a return
+shape that its own body does not produce, and rejects the body against its
+annotation. Everything else measured along the way works: shape propagation
+through an inlined generic call, through a `mutable` reassignment and through
+a slot read on x86-64; the same helper on both backends when the chain starts
+from a `KMCons` rather than the empty case.
+
+The fix is the same on both: **recover the type arguments from the other
+arguments** -- `key: 'k` against a string fixes `'k`, `value: 'v` against an
+Int fixes `'v` -- rather than only from the enum-typed one. aarch64 already
+has the machinery to build a shape from inferred type arguments
+(`canonical_applied_enum_shape`), and x86-64 already has
+`generic_enum_annotation_shape` and `resolve_enum_shape`; what neither does is
+solve for the parameters across *all* of a call's arguments.
+
+Dropping the unresolved arm as dead instead is *not* sound: it was tried, and
+the next call -- whose value really is the other variant -- died with "match:
+no pattern matched" at run time. A compile-time rejection is the safer of the
+two, which is why the rejection stands.
 
 Two language-surface warts turned up alongside them, both worth fixing on
 their own: `x = if (c) a else b` does not parse without parentheses, and a

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1681,6 +1681,41 @@ string -- and the aarch64 backend only had the first, so `containsText` failed
 there. It dispatches on the receiver now, reusing the byte search `indexOf`
 runs.
 
+### Where the portable collection work resumes
+
+The route to `Map` and `List` values whose size is only known while running,
+on every backend, is to build them out of a self-referential enum -- a chain
+of GC cells, which both hand-emitted backends already allocate and walk. A
+*monomorphic* chain works end to end today: fixture 28 grows one in a loop,
+replaces on a repeated key, renders it, and agrees with the evaluator on all
+three targets under `--gc-stress`. A *generic* chain -- which is what a
+lowering would have to emit, since the desugar does not know the key and
+value types -- stops at two places:
+
+1. **x86-64.** A helper that both destructures and constructs the same
+   generic enum is rejected: `put(empty, k, v)` inlines with the empty case's
+   shape, where the other variant's payload reprs are *defaulted* rather than
+   resolved, so `k == key` compares a defaulted `Scalar` against a string.
+   Shape propagation itself works -- through an inlined generic call, through
+   a `mutable` reassignment, and through a slot read (all measured) -- so what
+   is missing is narrower: a nullary constructor should take its payload reprs
+   from the annotation (`generic_enum_annotation_shape` already derives them)
+   or from the call site, rather than defaulting them.
+
+   Dropping the arm as dead instead is *not* sound: it was tried, and the
+   second call -- whose value really is the other variant -- then died with
+   "match: no pattern matched" at run time. A compile-time rejection is the
+   safer of the two, which is why the rejection stands.
+
+2. **aarch64.** The return type of a generic helper written as a `while` loop
+   (rather than recursion, which is what keeps x86-64 able to inline it) is
+   not predicted, so the body is rejected against its own annotation.
+
+Two language-surface warts turned up alongside them, both worth fixing on
+their own: `x = if (c) a else b` does not parse without parentheses, and a
+`match` arm whose body ends in an assignment takes that assignment's type, so
+two arms ending in assignments to different types disagree.
+
 ## Design Notes
 
 - The direct evaluator is the current execution engine.

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1738,6 +1738,16 @@ shape (the slot's entry in `enum_shapes`, or the `pending_enum_shape` a slot
 read republishes) and make the rewritten shape reach *that*, rather than
 assuming the slot entry is enough.
 
+**What already works on every target, measured:** the same store written with
+*fully applied* annotations -- `kmGet(m: KM<String, Int>, ...)` rather than
+`KM<'k, 'v>` -- compiles and runs on all three, grown from the empty case in
+a loop, a hundred entries deep, agreeing with the evaluator under
+`--gc-stress` (fixture 30). So the representation, the growth, the lookup and
+the rendering are all portable today; the only thing that is not is writing
+the helpers *generically*. That also says what a lowering would have to
+produce to be portable now: monomorphic helpers, one set per key/value type
+pair it sees.
+
 The idea, restated: **recover the type arguments from the other arguments** -- `key: 'k` against a string fixes `'k`, `value: 'v` against an
 Int fixes `'v` -- rather than only from the enum-typed one. aarch64 already
 has the machinery to build a shape from inferred type arguments

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1576,6 +1576,29 @@ without writing it. `Math#sqrtInt(0)` therefore answered with whatever the
 *previous* square root in the same program left in that register. A single
 call could not show it -- the fixture takes a root of 17 first, then of 0.
 
+### A fold whose function arrives under a name
+
+`std.list`'s sort is `foldLeft(xs)([])(insertSorted)` -- the fold's function is
+a *definition*, not a lambda written at the call site. The aarch64 backend
+only understood the literal form, in the emitter and in the inference alike,
+so `[3, 1, 2].sorted()` could not be compiled. A definition passed where a
+function is expected is now wrapped in a lambda that forwards its arguments,
+which is what makes it a value on a backend with no way to pass one. The
+string side gained the inference cases its extension methods need
+(`startsWith`/`endsWith`, `String#parseInt`, `capitalize`, `stripPrefix`,
+`stripSuffix`), so `words()`, `toInt()` and the rest of `std.string` compile.
+
+Two limits are worth stating plainly, because they are the same limit twice.
+The x86-64 backend cannot pass a runtime list to a function
+(`this backend cannot pass \`xs\` (\`List<'a>\`) by itself`) and cannot grow a
+map while the program runs. Both follow from its design: it partially
+evaluates, holding collections as compile-time values or fixed-capacity
+buffers, where the aarch64 backend holds everything as a boxed pointer and
+passes it like any other. Closing them means giving x86-64 a runtime
+collection ABI, not adding a builtin. `String#isInt` / `String#isDouble` are
+missing on every native backend equally -- matching the evaluator means
+matching `parse::<i64>()`, overflow included.
+
 ## Design Notes
 
 - The direct evaluator is the current execution engine.

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1667,6 +1667,20 @@ the representation that would replace them exists and is proven. Routing the
 builtins through it is a middle-end lowering (map operations to an internal
 enum chain plus the helpers that walk it), not new machine code.
 
+### A string the backend held in the wrong shape
+
+An extension method's `this: String` parameter arrives as a *heap* string,
+while the x86-64 string builtins wanted the other shape of string -- a pair of
+data labels. So `def startsWithText(prefix) = this.startsWith(prefix)`, and
+every `std.string` method written that way, was refused there while compiling
+fine on arm64. The predicate helpers copy a heap string into a scratch pair
+now, which is what the environment-key path already did.
+
+`contains` means two things -- membership in a set, and a substring in a
+string -- and the aarch64 backend only had the first, so `containsText` failed
+there. It dispatches on the receiver now, reusing the byte search `indexOf`
+runs.
+
 ## Design Notes
 
 - The direct evaluator is the current execution engine.

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1618,6 +1618,32 @@ range, since a value too large parses as infinity: an optional sign, then
 optional exponent that needs a digit of its own. `.5` and `5.` are numbers;
 `1e` is not.
 
+### One buffer per call site is one buffer per recursion
+
+A list built by `cons` out of a list that only exists while the program runs
+has, on the x86-64 backend, a result buffer chosen while compiling -- one per
+call site. A recursive function has one call site and many activations, so
+they all shared it, and
+
+    def copyAll(xs: List<String>): List<String> =
+      if (isEmpty(xs)) [] else cons(head(xs))(copyAll(tail(xs)))
+    println(copyAll(split("a b c", " ")))
+
+printed `[c, c, c]` where the evaluator prints `[a, b, c]`. No warning, no
+crash: a wrong answer. The build is refused now, with a diagnostic that says
+which construct it is, and a cli_smoke test pins that.
+
+Refusing is the fix available today; the fix that would make it *work* is the
+same one the other two open gaps need. Runtime-grown maps, generic recursive
+definitions over collections, and this are one missing piece seen from three
+sides: the x86-64 backend has no heap representation for a collection whose
+size is only known while running. Its collections are compile-time values or
+fixed-capacity buffers addressed by compile-time index, which is why
+`FileInput#lines` can be *passed* to a recursive function (it is a buffer pair
+and reading it is fine) but a list *built* inside one cannot be returned.
+Closing all three means giving the backend a GC-allocated list -- cells,
+rooting, and the load barrier -- not another builtin.
+
 ## Design Notes
 
 - The direct evaluator is the current execution engine.

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1599,6 +1599,25 @@ collection ABI, not adding a builtin. `String#isInt` / `String#isDouble` are
 missing on every native backend equally -- matching the evaluator means
 matching `parse::<i64>()`, overflow included.
 
+### Asking whether a string is a number
+
+`String#isInt` and `String#isDouble` were missing from every native backend,
+because matching the evaluator means matching `parse::<i64>()` and
+`parse::<f64>()` on the trimmed text -- range included. Both hand-emitted
+backends have them now, twice over: the text known while compiling is decided
+by Rust's own parse, and the text only known while running is decided by a
+byte scanner.
+
+The range needs no wide arithmetic. Leading zeros are dropped, then the digit
+count decides: more than nineteen is out of range, fewer is in, and exactly
+nineteen compares against the limit's own digits -- `9223372036854775807`
+positive, `9223372036854775808` negative, which is why the sign is remembered
+before the digits are read. The double side is the grammar rather than the
+range, since a value too large parses as infinity: an optional sign, then
+`inf`/`infinity`/`nan` in either case, or digits with an optional point and an
+optional exponent that needs a digit of its own. `.5` and `5.` are numbers;
+`1e` is not.
+
 ## Design Notes
 
 - The direct evaluator is the current execution engine.

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1470,6 +1470,27 @@ cargo run -- -e "1 + 2"
 - REPL
 - Exit-code policy and error presentation
 
+### Map entries, records in lists, and values that may not be there
+
+A map read as entries is where several representations meet, and closing it
+took one change per representation. On the aarch64 backend a list element can
+now be a record (`ListElem::Record`), which is what `toPairs()` hands back; a
+record field can be a nullable, which is what `Map#get` puts in one; printing a
+record is split into an inline form so a nested one renders without a newline
+(a record that transitively holds itself is rejected rather than printed
+forever); and appending a nullable to a string writes the value or the word
+`null`, matching the evaluator. The compile-time inference that decides a
+function's return type gained three cases it was silently failing on --
+`#Name(...)` construction, `Map#keys`/`Map#values`, and a *lambda* passed to a
+def, which is not a value and so could not be typed as one. Without the last
+of those, any function handing a lambda on to another (`words()` calling
+`stdlibFilter`) could not be typed at all. On the x86-64 backend `Map#keys`
+and `Map#values` read the compile-time entries into a static list, which is
+what lets the same `toPairs()` compile there. Runtime-grown maps
+(`Map#empty`/`Map#put` in a loop) remain aarch64-only: x86-64 holds a map as a
+compile-time `StaticMap` or a fixed-capacity `RuntimeList`, neither of which
+can grow by an amount only known while running.
+
 ## Design Notes
 
 - The direct evaluator is the current execution engine.

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1717,8 +1717,28 @@ through the annotation it was declared with. `kmPut(KMNil, "a", 1)` and a
 chain grown from the empty case in a loop compile there now, and a
 macOS-gated test runs one.
 
-The x86-64 half is the same idea in its own machinery: **recover the type
-arguments from the other arguments** -- `key: 'k` against a string fixes `'k`, `value: 'v` against an
+**The x86-64 half is measured but not landed.** Instrumenting the inline
+binding of `kmPut(KMNil, "a", 1)` shows exactly what a call site has to work
+with:
+
+    param=m     expected=Int  value=HeapPointer  flexible=true
+    param=key   expected=Int  value=StaticString flexible=true
+    param=value expected=Int  value=Int          flexible=true
+
+`KM<'k, 'v>` is not a type this backend models, so the parameter's expected
+value degrades to `Int` and the argument arrives as a bare `HeapPointer` --
+the shape is the only thing that says what its payloads are, and the empty
+case leaves them open. The two arguments that *do* fix the variables are
+right there in the same list, which is what makes the fix the same one
+aarch64 took. An attempt that threaded the annotation text onto
+`NativeFunction`, solved the variables during the binding loop and rewrote
+the slot's shape afterwards compiled but changed nothing observable, so it
+was not kept; the next step is to find where the body reads a parameter's
+shape (the slot's entry in `enum_shapes`, or the `pending_enum_shape` a slot
+read republishes) and make the rewritten shape reach *that*, rather than
+assuming the slot entry is enough.
+
+The idea, restated: **recover the type arguments from the other arguments** -- `key: 'k` against a string fixes `'k`, `value: 'v` against an
 Int fixes `'v` -- rather than only from the enum-typed one. aarch64 already
 has the machinery to build a shape from inferred type arguments
 (`canonical_applied_enum_shape`), and x86-64 already has

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1644,6 +1644,29 @@ and reading it is fine) but a list *built* inside one cannot be returned.
 Closing all three means giving the backend a GC-allocated list -- cells,
 rooting, and the load barrier -- not another builtin.
 
+### The heap representation the x86-64 backend already had
+
+Reading the three open gaps as "x86-64 has no heap collection" was one level
+too pessimistic. It has one: a self-referential enum is a chain of
+`__gc_record` cells, built by the shared lowering, and it works under
+recursion -- `CountsCons(k, v, countsPut(rest, ...))` allocates a cell per
+activation, which is exactly what a compile-time buffer cannot do.
+
+What stopped it being *usable* as a key/value store was one missing
+conversion: appending a number to a heap string. `acc + key + ": " + value`
+is the shape every rendering of such a chain takes, and the heap-string
+concatenation refused an `Int` or a `Boolean` operand. It renders them the
+way `toString` does and copies the text onto the heap now, and with that the
+word counter -- grow a chain in a loop, replace on a repeated key, render it
+afterwards -- compiles and runs on all three targets, and agrees with the
+evaluator under `--gc-stress`.
+
+So the remaining gap is narrower than it looked: the builtin `Map` and `List`
+types still use compile-time values or fixed-capacity buffers on x86-64, but
+the representation that would replace them exists and is proven. Routing the
+builtins through it is a middle-end lowering (map operations to an internal
+enum chain plus the helpers that walk it), not new machine code.
+
 ## Design Notes
 
 - The direct evaluator is the current execution engine.

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1709,8 +1709,16 @@ through an inlined generic call, through a `mutable` reassignment and through
 a slot read on x86-64; the same helper on both backends when the chain starts
 from a `KMCons` rather than the empty case.
 
-The fix is the same on both: **recover the type arguments from the other
-arguments** -- `key: 'k` against a string fixes `'k`, `value: 'v` against an
+**The aarch64 half is done.** A specialisation now solves the definition's
+type variables across *all* the arguments -- a parameter annotated `'k` given
+a string fixes `'k` as `String` -- and an enum-typed parameter whose own
+argument left the variables open takes the shape those solutions imply,
+through the annotation it was declared with. `kmPut(KMNil, "a", 1)` and a
+chain grown from the empty case in a loop compile there now, and a
+macOS-gated test runs one.
+
+The x86-64 half is the same idea in its own machinery: **recover the type
+arguments from the other arguments** -- `key: 'k` against a string fixes `'k`, `value: 'v` against an
 Int fixes `'v` -- rather than only from the enum-typed one. aarch64 already
 has the machinery to build a shape from inferred type arguments
 (`canonical_applied_enum_shape`), and x86-64 already has

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1512,6 +1512,32 @@ other list. It is a comparison per variant against the tag the constructor
 stored; a variant whose payload the shape records as `Never` is skipped, which
 is the same reading `match` takes of it.
 
+### Strings, doubles, cleanup, and methods that need their receiver
+
+Four more gaps the aarch64 backend had against the other two, all found by
+building the same probes for all three targets:
+
+- **`indexOf` / `lastIndexOf` / `repeat` / `replace`.** The first two answer
+  with a *byte* offset and -1, which is what the evaluator's `find`/`rfind`
+  answer with; scanning forward and keeping the last match is `rfind`.
+  `replace` touches the first occurrence only, like the evaluator's
+  `replacen(from, to, 1)` -- `replaceAll` is the pattern-matching one.
+- **Printing a double.** A whole number prints as `3.0`, and the backend was
+  formatting a printed literal with a plain float formatter, which would have
+  dropped the decimal and printed a Double as if it were an Int. Doubles that
+  can be worked out while compiling now print, through the same rule the
+  x86-64 backend formats static doubles with; only `val` bindings are folded,
+  because what a `mutable` holds depends on the paths taken to reach it.
+- **`cleanup`.** The clause runs after the expression it is attached to and
+  the expression's value is still the value; a heap result is parked as a
+  root, because the clause can allocate.
+- **Methods that need their receiver's type.** The shared desugar rewrites
+  `x.m(...)` to `__ext_<Type>_m(x, ...)` only when `m` is declared on exactly
+  one extension type. `getOrElse` is declared on `Option`, `Result` and
+  `Map`, so it arrives as a method call, and the backend now picks the
+  extension by what the receiver's type turns out to be -- inferred without
+  emitting anything, so asking is free.
+
 ## Design Notes
 
 - The direct evaluator is the current execution engine.

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1538,6 +1538,28 @@ building the same probes for all three targets:
   extension by what the receiver's type turns out to be -- inferred without
   emitting anything, so asking is free.
 
+### Two bugs the arm64 runner found, and what they have in common
+
+Both were invisible on a Linux host, and both were found the same way: build
+for arm64, let CI run it, read what the collector said.
+
+- **A root pushed on one path only.** `Set#add(s, x)` rooted the two slots its
+  copy needs *after* the branch that skips the copy when `x` is already in the
+  set. The shadow stack is popped by a count worked out while compiling, so
+  the skip path popped two roots it never pushed: "klassic gc: shadow stack
+  underflow". Every root a function pushes has to be pushed before any
+  runtime branch, or popped again on each path -- checking that is now part of
+  writing one.
+- **A loop body compiled against a stale type.** A `mutable` takes its type
+  from what is assigned to it, and the declaration site settles that by
+  prediction. A loop cannot be settled there: `m = Map#put(m, k, ...)`
+  mentions the loop's own variable, which does not exist yet at the
+  declaration -- so the prediction failed, `m` stayed the empty map it started
+  as, and `Map#getOrElse(m, k, 0)` inside the loop compiled to its fallback.
+  It counted every word as 1. The fixpoint is taken again when the loop body
+  is about to be compiled, with the loop variable bound, because every turn
+  after the first reads what the previous one wrote.
+
 ## Design Notes
 
 - The direct evaluator is the current execution engine.

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1491,6 +1491,27 @@ what lets the same `toPairs()` compile there. Runtime-grown maps
 compile-time `StaticMap` or a fixed-capacity `RuntimeList`, neither of which
 can grow by an amount only known while running.
 
+### Sets, and enum values as values
+
+The `Set#*` family the stdlib's extension methods call was uneven across the
+backends: aarch64 had none of it (a set literal worked, but `Set#size` did
+not), and x86-64 had the method spellings (`s.add(x)`, `s.toList()`) without
+the function ones. Both are complete now. On aarch64 a set is the same
+insertion-ordered chain a list is, so `Set#toList` is a type change, `Set#size`
+is the length walk, and `Set#add`/`Set#fromList` are the set literal's own
+dedupe loop over a chain only known while running -- `add` copies the chain
+backwards, prepends, and reverses, so the new element comes out last the way
+the evaluator prints it. On x86-64 the same four are compile-time
+transformations of a `StaticSet`, alongside the function spellings of
+`Map#put`, `Map#empty` and `Map#getOrElse`.
+
+The aarch64 backend can also print an enum value as a value now -- `Some(3)`,
+`None`, `Ok(1)` -- both to stdout and into a string, so `println(result)` and
+`"#{result}"` agree with the evaluator, and a list of enums renders like any
+other list. It is a comparison per variant against the tag the constructor
+stored; a variant whose payload the shape records as `Never` is skipped, which
+is the same reading `match` takes of it.
+
 ## Design Notes
 
 - The direct evaluator is the current execution engine.

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -22696,6 +22696,75 @@ fn build_target_aarch64_apple_darwin_binary_runs() {
     );
 }
 
+/// Maps built while the program runs, on Apple Silicon: `Map#empty` and
+/// `Map#put` are the shape every counting program has, and the arm64 backend
+/// stores a map as a chain of `[key][value]` entries it can grow. Asserted
+/// against the evaluator on the arm64 runner, since that is the only place a
+/// Mach-O runs -- and not as a cross-target fixture, because the x86-64
+/// backend's maps are still decided while compiling.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn build_target_aarch64_apple_darwin_runtime_maps_run() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_macho_maps_{stamp}.kl"));
+    let bin_path = dir.join(format!("klassic_macho_maps_{stamp}.bin"));
+    let source = concat!(
+        "import std.map\n",
+        "mutable counts = Map#empty()\n",
+        "foreach (word in [\"the\", \"fox\", \"the\", \"dog\", \"the\"]) {\n",
+        "  counts = Map#put(counts, word, Map#getOrElse(counts, word, 0) + 1)\n",
+        "}\n",
+        "println(counts)\n",
+        "println(Map#keys(counts))\n",
+        "println(Map#values(counts))\n",
+        "println(Map#size(counts))\n",
+        "println(Map#get(counts, \"the\"))\n",
+        "println(Map#containsKey(counts, \"cat\"))\n",
+        "foreach (entry in counts.toPairs()) { println(entry.key + \"=\" + entry.value) }\n",
+    );
+    fs::write(&source_path, source).expect("temp source file should write");
+
+    let expected = Command::new(klassic_bin())
+        .arg(source_path.to_str().expect("path should be utf-8"))
+        .output()
+        .expect("evaluator should run");
+    assert!(
+        expected.status.success(),
+        "the evaluator should run this program\nstderr:\n{}",
+        String::from_utf8_lossy(&expected.stderr)
+    );
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "aarch64-apple-darwin",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build.status.success(),
+        "darwin native build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&bin_path).output().expect("Mach-O should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&bin_path);
+    assert!(run.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&expected.stdout),
+        "a map built at run time should print what the evaluator prints"
+    );
+}
+
 /// Annotated top-level functions on the direct aarch64 backend:
 /// AAPCS64 calls, deep recursion, mutual recursion with forward
 /// references, multi-argument calls — asserted against the

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -22741,6 +22741,65 @@ fn native_build_refuses_a_list_built_in_a_recursive_function() {
     );
 }
 
+/// The program the x86-64 backend refuses -- a list built inside a recursive
+/// function out of a list that only exists while the program runs -- run on
+/// Apple Silicon, where every list is a GC-allocated chain and each
+/// activation therefore builds its own. This is the parity story in one
+/// test: the same source, refused there and correct here.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn build_target_aarch64_apple_darwin_recursive_list_build_runs() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_macho_reccons_{stamp}.kl"));
+    let bin_path = dir.join(format!("klassic_macho_reccons_{stamp}.bin"));
+    let source = concat!(
+        "def copyAll(xs: List<String>): List<String> =\n",
+        "  if (isEmpty(xs)) [] else cons(head(xs))(copyAll(tail(xs)))\n",
+        "def dropEmpty(xs: List<String>): List<String> =\n",
+        "  if (isEmpty(xs)) [] else if (isEmptyString(head(xs))) dropEmpty(tail(xs))\n",
+        "  else cons(head(xs))(dropEmpty(tail(xs)))\n",
+        "println(copyAll(split(\"a b c\", \" \")))\n",
+        "println(dropEmpty(split(\"a  b\", \" \")))\n",
+    );
+    fs::write(&source_path, source).expect("temp source file should write");
+
+    let expected = Command::new(klassic_bin())
+        .arg(source_path.to_str().expect("path should be utf-8"))
+        .output()
+        .expect("evaluator should run");
+    assert!(expected.status.success());
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "aarch64-apple-darwin",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build.status.success(),
+        "darwin native build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&bin_path).output().expect("Mach-O should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&bin_path);
+    assert!(run.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&expected.stdout),
+        "a list built inside a recursive function should print what the evaluator prints"
+    );
+}
+
 /// Maps built while the program runs, on Apple Silicon: `Map#empty` and
 /// `Map#put` are the shape every counting program has, and the arm64 backend
 /// stores a map as a chain of `[key][value]` entries it can grow. Asserted

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -22696,6 +22696,51 @@ fn build_target_aarch64_apple_darwin_binary_runs() {
     );
 }
 
+/// A list built inside a recursive function, out of a list that only exists
+/// while the program runs: this used to compile and print the innermost
+/// element in every position -- `[c, c, c]` for `[a, b, c]` -- because the
+/// result buffer is chosen while compiling, so every activation shared one.
+/// A wrong answer with no warning is the worst thing a compiler can do, so
+/// the build is refused until the backend can put such a list on the heap.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_build_refuses_a_list_built_in_a_recursive_function() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_rec_cons_{stamp}.kl"));
+    let bin_path = dir.join(format!("klassic_rec_cons_{stamp}.bin"));
+    let source = concat!(
+        "def copyAll(xs: List<String>): List<String> =\n",
+        "  if (isEmpty(xs)) [] else cons(head(xs))(copyAll(tail(xs)))\n",
+        "println(copyAll(split(\"a b c\", \" \")))\n",
+    );
+    fs::write(&source_path, source).expect("temp source file should write");
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&bin_path);
+    assert!(
+        !build.status.success(),
+        "a list built inside a recursive function should be refused, not miscompiled"
+    );
+    let stderr = String::from_utf8_lossy(&build.stderr);
+    assert!(
+        stderr.contains("inside a recursive function"),
+        "the diagnostic should say what cannot be built\nstderr:\n{stderr}"
+    );
+}
+
 /// Maps built while the program runs, on Apple Silicon: `Map#empty` and
 /// `Map#put` are the shape every counting program has, and the arm64 backend
 /// stores a map as a chain of `[key][value]` entries it can grow. Asserted

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -22800,6 +22800,75 @@ fn build_target_aarch64_apple_darwin_recursive_list_build_runs() {
     );
 }
 
+/// A generic chain helper called with the *empty case of its own enum*, on
+/// Apple Silicon. `KMNil` carries no type arguments, so nothing fixes `'k`
+/// and `'v` through that argument -- but `key: 'k` given a string and
+/// `value: 'v` given an Int fix both, and the parameter's shape follows from
+/// them. Before that, the specialisation derived a return shape its own body
+/// did not produce and the build was refused.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn build_target_aarch64_apple_darwin_generic_chain_from_empty_runs() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_macho_chain_{stamp}.kl"));
+    let bin_path = dir.join(format!("klassic_macho_chain_{stamp}.bin"));
+    let source = concat!(
+        "enum KM<'k, 'v> { case KMNil; case KMCons(key: 'k, value: 'v, rest: KM<'k, 'v>) }\n",
+        "def kmPut(m: KM<'k, 'v>, key: 'k, value: 'v): KM<'k, 'v> =\n",
+        "  KMCons(key, value, m)\n",
+        "def kmGetOrElse(m: KM<'k, 'v>, key: 'k, fallback: 'v): 'v = m match {\n",
+        "  case KMNil => fallback\n",
+        "  case KMCons(k, v, rest) => if (k == key) v else kmGetOrElse(rest, key, fallback)\n",
+        "}\n",
+        "mutable counts = KMNil\n",
+        "foreach (w in [\"a\", \"b\", \"a\"]) { counts = kmPut(counts, w, 1) }\n",
+        "println(kmGetOrElse(counts, \"a\", 0))\n",
+        "println(kmGetOrElse(counts, \"b\", 0))\n",
+        "println(kmGetOrElse(counts, \"z\", -1))\n",
+    );
+    fs::write(&source_path, source).expect("temp source file should write");
+
+    let expected = Command::new(klassic_bin())
+        .arg(source_path.to_str().expect("path should be utf-8"))
+        .output()
+        .expect("evaluator should run");
+    assert!(
+        expected.status.success(),
+        "the evaluator should run this program\nstderr:\n{}",
+        String::from_utf8_lossy(&expected.stderr)
+    );
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "aarch64-apple-darwin",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build.status.success(),
+        "darwin native build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&bin_path).output().expect("Mach-O should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&bin_path);
+    assert!(run.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&expected.stdout),
+        "a chain grown from the empty case should print what the evaluator prints"
+    );
+}
+
 /// Maps built while the program runs, on Apple Silicon: `Map#empty` and
 /// `Map#put` are the shape every counting program has, and the arm64 backend
 /// stores a map as a chain of `[key][value]` entries it can grow. Asserted

--- a/tests/cross-exec/21-map-entries-and-records.kl
+++ b/tests/cross-exec/21-map-entries-and-records.kl
@@ -1,0 +1,53 @@
+// Cross-target fixture: a map read as entries, and lists of records.
+//
+// `toPairs()` is where several representations meet at once. It walks
+// `Map#keys`, builds a `#MapEntry(k, Map#get(m, k))` per key, and hands back a
+// list of those records -- so a backend has to hold records as list elements,
+// and has to hold a field whose value may not be there, because `Map#get`
+// answers with the value *or* nothing. Reading one back out and appending it
+// to a string is the third half of the same thing: `"a" + entry.value` has to
+// print the value, and the word `null` when there is none.
+//
+// Every line below is compared against the evaluator on real hardware, which
+// is the only way the three targets can be said to agree.
+
+import std.map
+
+val m = %["a": 1 "b": 2 "c": 3]
+
+// The two halves of a map, in insertion order.
+println(Map#keys(m))
+println(Map#values(m))
+assertResult(["a", "b", "c"])(Map#keys(m))
+assertResult([1, 2, 3])(Map#values(m))
+
+// Entries: a list of records, printed as the evaluator prints them.
+println(m.toPairs())
+println(m.entries())
+println(size(m.toPairs()))
+assertResult(3)(size(m.toPairs()))
+
+// Reading an entry's halves, and appending a value that may not be there.
+foreach (entry in m.toPairs()) {
+  println(entry.key + "=" + entry.value)
+}
+
+// A list of records written directly, so the element representation is
+// exercised without a map in the way.
+record Point3 { x: Int; y: Int; z: Int }
+val points = [#Point3(1, 2, 3), #Point3(4, 5, 6)]
+println(points)
+foreach (p in points) { println(p.x + p.y + p.z) }
+assertResult(2)(size(points))
+
+// A record holding a string and a bool alongside numbers.
+record Row { name: String; count: Int; ok: Boolean }
+val rows = [#Row("alpha", 3, true), #Row("beta", 0, false)]
+println(rows)
+foreach (r in rows) { println(r.name + ": " + r.count + " " + r.ok) }
+
+// A single-entry map, i.e. nothing to iterate past.
+val one = %["only": 42]
+println(one.toPairs())
+println(Map#keys(one))
+println("done")

--- a/tests/cross-exec/22-sets-and-enum-values.kl
+++ b/tests/cross-exec/22-sets-and-enum-values.kl
@@ -1,0 +1,54 @@
+// Cross-target fixture: the set builders, and enum values printed as values.
+//
+// A set is an insertion-ordered chain with no duplicates, and the order is the
+// observable part: adding an element that is already there changes nothing,
+// and adding a new one puts it last. `Set#fromList` keeps the *first*
+// occurrence of each element, which is the same rule a set literal follows --
+// so the duplicate cases below are where a backend that dedupes by sorting, or
+// by keeping the last occurrence, would disagree with the evaluator.
+//
+// The second half prints enum values directly. `Some(3)` and `None` are one
+// enum with two shapes, and `Ok`/`Err` carry payloads of different types, so
+// rendering one means finding the variant from the tag it was built with.
+
+import std.set
+import std.option
+import std.result
+
+val s = %(1, 2, 3)
+println(s)
+println(s.sizeOf())
+println(s.contains(2))
+println(s.contains(9))
+println(s.isEmptySet())
+println(Set#toList(s))
+println(Set#size(s))
+
+// Adding: a new element goes last, one already there changes nothing.
+println(Set#add(s, 4))
+println(Set#add(s, 2))
+println(Set#add(Set#empty(), 7))
+println(Set#empty())
+
+// From a list, keeping the first occurrence of each.
+println(Set#fromList([1, 1, 2]))
+println(Set#fromList(["b", "a", "b", "c"]))
+println(Set#fromList([]))
+assertResult(3)(Set#size(Set#fromList([1, 1, 2, 3, 2])))
+
+// A set of strings, i.e. membership by content rather than by value.
+val words = %("alpha", "beta")
+println(words)
+println(words.contains("beta"))
+println(Set#add(words, "gamma"))
+
+// Enum values printed as themselves.
+def parse(s: String): Result<Int, String> = if (s == "1") Ok(1) else Err("bad")
+println(parse("1"))
+println(parse("x"))
+val some: Option<Int> = Some(7)
+val none: Option<Int> = None
+println(some)
+println(none)
+assertResult("Some(7)")("#{some}")
+println("done")

--- a/tests/cross-exec/23-strings-and-doubles.kl
+++ b/tests/cross-exec/23-strings-and-doubles.kl
@@ -1,0 +1,57 @@
+// Cross-target fixture: the searching and building string builtins, and
+// doubles printed as doubles.
+//
+// `indexOf` answers with a *byte* offset and -1 when the needle is absent,
+// which is what the evaluator's own `find` answers with -- so the empty
+// needle, the needle-longer-than-the-haystack case, and the repeated needle
+// (where `indexOf` and `lastIndexOf` disagree) are the cases worth pinning.
+// `replace` touches the first occurrence only; `replaceAll` is the other one.
+//
+// The doubles matter because a whole number prints as `3.0`, not `3`: a
+// backend formatting with a plain float formatter would drop the decimal and
+// print a Double as if it were an Int.
+
+// Searching.
+println(indexOf("Hello", "l"))
+println(indexOf("Hello", "z"))
+println(indexOf("Hello", "Hello"))
+println(indexOf("Hello", ""))
+println(indexOf("ab", "abc"))
+println(lastIndexOf("abcabc", "b"))
+println(lastIndexOf("abcabc", "c"))
+println(lastIndexOf("abc", "z"))
+assertResult(2)(indexOf("Hello", "l"))
+assertResult(-1)(indexOf("Hello", "z"))
+assertResult(4)(lastIndexOf("abcabc", "b"))
+
+// Building.
+println(repeat("ab", 3))
+println(repeat("x", 1))
+println(repeat("x", 0))
+println(replace("a-b-c", "-", "+"))
+println(replace("a-b-c", "z", "+"))
+println(replace("aaa", "a", ""))
+println(replaceAll("a-b-c", "-", "+"))
+assertResult("ababab")(repeat("ab", 3))
+assertResult("a+b-c")(replace("a-b-c", "-", "+"))
+assertResult("a+b+c")(replaceAll("a-b-c", "-", "+"))
+
+// The method spellings reach the same code.
+println("Hello".indexOf("l"))
+println("ab".repeat(2))
+println("a-b".replace("-", "_"))
+
+// Doubles: a whole number keeps its decimal, a fraction keeps its digits.
+println(3.0)
+println(2.5)
+println(3.5 + 1.25)
+println(2.0 * 3.0)
+println(sqrt(9.0))
+println(-1.5)
+println(double(7))
+val pi = 3.14159
+val r = 2.0
+println(pi * r * r)
+println("area=#{pi * r * r}")
+println("half=#{0.5}")
+println("done")

--- a/tests/cross-exec/24-cleanup-and-methods.kl
+++ b/tests/cross-exec/24-cleanup-and-methods.kl
@@ -1,0 +1,58 @@
+// Cross-target fixture: `cleanup` clauses, and methods that need the
+// receiver's type to resolve.
+//
+// `cleanup` runs after the expression it is attached to and does not change
+// its value, so the ordering below is the whole point: the clause's output
+// comes before the value is used, and the value is still the value.
+//
+// The methods matter because a name alone does not say which extension is
+// meant. `getOrElse` is declared on `Option`, on `Result` and on `Map`, so
+// the shared desugar leaves it as a method call and the backend has to pick
+// by what the receiver turns out to be. Picking the wrong one would compile
+// and print something plausible, which is why every case here is asserted.
+
+import std.option
+import std.result
+import std.map
+
+// A cleanup clause on a value, and on a value that is used afterwards.
+val x = 1 cleanup { println("after one") }
+println(x)
+assertResult(1)(x)
+
+val name = "abc" cleanup { println("after abc") }
+println(name)
+println(name + "!")
+
+val listed = [1, 2, 3] cleanup { println("after list") }
+println(listed)
+println(size(listed))
+assertResult(3)(size(listed))
+
+// `getOrElse` on each of the three types that declare one.
+val ok: Result<Int, String> = Ok(3)
+val bad: Result<Int, String> = Err("nope")
+println(ok.getOrElse(0))
+println(bad.getOrElse(0))
+assertResult(3)(ok.getOrElse(0))
+assertResult(0)(bad.getOrElse(0))
+
+val some: Option<Int> = Some(5)
+val none: Option<Int> = None
+println(some.getOrElse(-1))
+println(none.getOrElse(-1))
+assertResult(5)(some.getOrElse(-1))
+assertResult(-1)(none.getOrElse(-1))
+
+val m = %["a": 1]
+println(m.getOrElse("a", 0))
+println(m.getOrElse("z", 0))
+assertResult(1)(m.getOrElse("a", 0))
+assertResult(0)(m.getOrElse("z", 0))
+
+// The other methods on those enums, which resolve the same way.
+println(ok.isOk())
+println(bad.isOk())
+println(some.isSome())
+println(none.isNone())
+println("done")

--- a/tests/cross-exec/25-math-and-random.kl
+++ b/tests/cross-exec/25-math-and-random.kl
@@ -1,0 +1,49 @@
+// Cross-target fixture: the integer math helpers and the seeded generator.
+//
+// `Math#sqrtInt(0)` is here for a reason: the x86-64 backend read its answer
+// out of a register the zero case never wrote, so a program that took a square
+// root earlier got that earlier answer back. A single call cannot catch that --
+// it needs a *previous* call to leave something behind, which is why the zero
+// case below follows a non-zero one.
+//
+// The generator is a 64-bit LCG whose high half is the answer, so a seeded
+// program prints a fixed sequence. Every target has to print the same one, or
+// a program that seeds for reproducibility is not reproducible across them.
+
+println(Math#gcd(12, 18))
+println(Math#gcd(18, 12))
+println(Math#gcd(-12, 18))
+println(Math#gcd(7, 13))
+println(Math#gcd(0, 5))
+println(Math#gcd(5, 0))
+assertResult(6)(Math#gcd(12, 18))
+assertResult(1)(Math#gcd(7, 13))
+
+println(Math#powInt(2, 10))
+println(Math#powInt(3, 0))
+println(Math#powInt(1, 63))
+println(Math#powInt(-2, 3))
+println(Math#powInt(10, 1))
+assertResult(1024)(Math#powInt(2, 10))
+assertResult(-8)(Math#powInt(-2, 3))
+
+// The non-zero call comes first on purpose; see the note above.
+println(Math#sqrtInt(17))
+println(Math#sqrtInt(0))
+println(Math#sqrtInt(1))
+println(Math#sqrtInt(16))
+println(Math#sqrtInt(9999))
+assertResult(0)(Math#sqrtInt(0))
+assertResult(99)(Math#sqrtInt(9999))
+
+// Seeded, so the sequence is fixed.
+Random#seed(42)
+println(Random#nextInt(100))
+println(Random#nextInt(100))
+println(Random#nextInt(7))
+Random#seed(42)
+println(Random#nextInt(100))
+Random#seed(1)
+println(Random#nextInt(1000))
+println(Random#nextInt(1))
+println("done")

--- a/tests/cross-exec/26-stdlib-methods.kl
+++ b/tests/cross-exec/26-stdlib-methods.kl
@@ -1,0 +1,50 @@
+// Cross-target fixture: the stdlib's own list and string methods.
+//
+// `sorted()` is the one to watch. It is written as
+// `foldLeft(xs)([])(insertSorted)` -- the fold's function arrives as a *name*,
+// not as a lambda written at the call site, so a backend that only understands
+// the literal form cannot compile it at all. It is also an insertion sort, so
+// the order of equal elements is observable, and a backend that reversed the
+// accumulator would print the same set in a different order.
+//
+// The rest are ordinary uses of the methods a program actually reaches for,
+// asserted so a wrong answer fails rather than prints.
+
+import std.list
+import std.string
+
+val xs = [3, 1, 2]
+println(xs.lengthOf())
+println(xs.takeN(2))
+println(xs.dropN(1))
+println(xs.reversed())
+println(xs.sorted())
+println(xs.total())
+assertResult([1, 2, 3])(xs.sorted())
+assertResult(6)(xs.total())
+
+// Already sorted, reverse sorted, and with a repeat -- the three shapes an
+// insertion sort walks differently.
+println([1, 2, 3].sorted())
+println([3, 2, 1].sorted())
+println([2, 1, 2].sorted())
+println([5].sorted())
+assertResult([1, 2, 2])([2, 1, 2].sorted())
+
+// The predicate-taking ones.
+println(xs.filterBy((x) => x > 1))
+println(xs.anyMatch((x) => x == 2))
+println(xs.allMatch((x) => x > 0))
+println(xs.countBy((x) => x > 1))
+assertResult([3, 2])(xs.filterBy((x) => x > 1))
+assertResult(2)(xs.countBy((x) => x > 1))
+
+// Strings.
+println("Hello World".upper())
+println("Hello".lower())
+println("  x  ".trimmed())
+println("abc".reverseChars())
+println("abc".lengthChars())
+assertResult("HELLO WORLD")("Hello World".upper())
+assertResult("cba")("abc".reverseChars())
+println("done")

--- a/tests/cross-exec/27-numeric-strings.kl
+++ b/tests/cross-exec/27-numeric-strings.kl
@@ -1,0 +1,65 @@
+// Cross-target fixture: asking whether a string is a number.
+//
+// The answer has to be the evaluator's, which is Rust's `parse::<i64>()` and
+// `parse::<f64>()` on the trimmed text -- so the range matters: nineteen
+// digits can be either side of the limit, and the limit itself differs by one
+// between positive and negative. `9223372036854775807` is a number and
+// `9223372036854775808` is not, while `-9223372036854775808` is and
+// `-9223372036854775809` is not. Leading zeros do not count towards it.
+//
+// For doubles the corners are the grammar's: `.5` and `5.` are numbers, `1e`
+// is not, `inf` and `NaN` are, and a value too large to represent parses as
+// infinity rather than failing.
+//
+// Each case is asked twice -- once of a literal, which is decided while
+// compiling, and once of a line read back from a file, which is decided while
+// running. The two paths are different code and have to agree.
+
+import std.string
+
+// Literals.
+println(String#isInt("42"))
+println(String#isInt("  42  "))
+println(String#isInt("-42"))
+println(String#isInt("+42"))
+println(String#isInt(""))
+println(String#isInt("4a"))
+println(String#isInt("9223372036854775807"))
+println(String#isInt("9223372036854775808"))
+println(String#isInt("-9223372036854775808"))
+println(String#isInt("-9223372036854775809"))
+println(String#isInt("0000000000000000000005"))
+println(String#isInt("-0"))
+assertResult(true)(String#isInt("9223372036854775807"))
+assertResult(false)(String#isInt("9223372036854775808"))
+
+println(String#isDouble("1.5"))
+println(String#isDouble("1e5"))
+println(String#isDouble("1E+5"))
+println(String#isDouble(".5"))
+println(String#isDouble("5."))
+println(String#isDouble("inf"))
+println(String#isDouble("INFINITY"))
+println(String#isDouble("NaN"))
+println(String#isDouble("1e"))
+println(String#isDouble("abc"))
+println(String#isDouble("1e999"))
+assertResult(true)(String#isDouble(".5"))
+assertResult(false)(String#isDouble("1e"))
+
+// The same questions, of text only known while running.
+val candidates = ["42", "  7  ", "-42", "+42", "4a", "", "9223372036854775807",
+  "9223372036854775808", "-9223372036854775808", "-9223372036854775809",
+  "0000000000000000000005", "-0", "1.5", "1e5", "1E+5", ".5", "5.", "inf",
+  "INFINITY", "NaN", "1e", "abc", "1e999"]
+FileOutput#writeLines("cross-exec-numbers.txt", candidates)
+foreach (line in FileInput#lines("cross-exec-numbers.txt")) {
+  println(line + "|" + String#isInt(line) + "|" + String#isDouble(line))
+}
+FileOutput#delete("cross-exec-numbers.txt")
+
+// The stdlib's own spellings.
+println("42".isInteger())
+println("4a".isInteger())
+println("1.5".isFloat())
+println("done")

--- a/tests/cross-exec/28-chain-map-and-concat.kl
+++ b/tests/cross-exec/28-chain-map-and-concat.kl
@@ -1,0 +1,68 @@
+// Cross-target fixture: a key/value store built while the program runs, out
+// of a self-referential enum, and rendered by appending to a string.
+//
+// This is the word counter written in the language itself, and it exercises
+// the one thing every backend needs for a collection whose size is only known
+// while running: a chain on the heap, grown a cell at a time, walked and
+// rendered afterwards. Counting a word twice means the *replace* path runs;
+// counting three different words means the *append* path runs; and rendering
+// appends a number to a string, which is the shape `key + ": " + value` takes.
+//
+// The insertion order is the observable part: a repeated key keeps its first
+// position while taking its last value, which is what a map does.
+
+enum Counts {
+  case CountsNil
+  case CountsCons(key: String, value: Int, rest: Counts)
+}
+
+def countsPut(m: Counts, key: String, value: Int): Counts = m match {
+  case CountsNil => CountsCons(key, value, CountsNil)
+  case CountsCons(k, v, rest) =>
+    if (k == key) CountsCons(k, value, rest) else CountsCons(k, v, countsPut(rest, key, value))
+}
+
+def countsGet(m: Counts, key: String, fallback: Int): Int = m match {
+  case CountsNil => fallback
+  case CountsCons(k, v, rest) => if (k == key) v else countsGet(rest, key, fallback)
+}
+
+def countsSize(m: Counts, acc: Int): Int = m match {
+  case CountsNil => acc
+  case CountsCons(k, v, rest) => countsSize(rest, acc + 1)
+}
+
+def countsRender(m: Counts, acc: String): String = m match {
+  case CountsNil => acc
+  case CountsCons(k, v, rest) => countsRender(rest, acc + k + ": " + v + " ")
+}
+
+mutable counts = CountsNil
+foreach (word in ["the", "fox", "the", "dog", "the", "fox"]) {
+  counts = countsPut(counts, word, countsGet(counts, word, 0) + 1)
+}
+println(countsRender(counts, ""))
+println(countsSize(counts, 0))
+println(countsGet(counts, "the", 0))
+println(countsGet(counts, "fox", 0))
+println(countsGet(counts, "cat", -1))
+assertResult(3)(countsSize(counts, 0))
+assertResult(3)(countsGet(counts, "the", 0))
+assertResult(2)(countsGet(counts, "fox", 0))
+assertResult(-1)(countsGet(counts, "cat", -1))
+
+// A chain of a hundred entries, so the allocation runs past anything a
+// compile-time buffer would have reserved.
+def fill(m: Counts, n: Int): Counts =
+  if (n == 0) m else fill(countsPut(m, "k" + n, n), n - 1)
+val big = fill(CountsNil, 100)
+println(countsSize(big, 0))
+println(countsGet(big, "k1", 0))
+println(countsGet(big, "k100", 0))
+assertResult(100)(countsSize(big, 0))
+assertResult(50)(countsGet(big, "k50", 0))
+
+// Appending numbers and flags to a string, which the rendering above needs.
+val n = countsSize(counts, 0)
+println("size=" + n + " empty=" + (n == 0))
+println("done")

--- a/tests/cross-exec/29-string-methods.kl
+++ b/tests/cross-exec/29-string-methods.kl
@@ -1,0 +1,48 @@
+// Cross-target fixture: the string methods whose receiver is the extension's
+// own `this`, and substring containment.
+//
+// An extension method's `this: String` arrives as a heap string, and the
+// string builtins wanted a different shape of string -- so every method
+// written as `this.startsWith(...)` was refused on one target and compiled on
+// another. The prefix/suffix cases below are the ones a command-line program
+// writes, and they are asked both of a literal and of text read back from a
+// file, because those are two different paths through the backend.
+//
+// `contains` is here because it means two things: membership in a set, and a
+// substring in a string. Both spellings are exercised so a backend that only
+// implemented one of them fails here rather than in someone's program.
+
+import std.string
+
+println("prefix-abc".startsWithText("prefix"))
+println("prefix-abc".startsWithText("nope"))
+println("prefix-abc".endsWithText("abc"))
+println("prefix-abc".endsWithText("nope"))
+println("prefix-abc".containsText("fix"))
+println("prefix-abc".containsText("zzz"))
+println("prefix-abc".withoutPrefix("prefix-"))
+println("prefix-abc".withoutPrefix("nope"))
+println("prefix-abc".withoutSuffix("-abc"))
+println("prefix-abc".withoutSuffix("nope"))
+assertResult("abc")("prefix-abc".withoutPrefix("prefix-"))
+assertResult(true)("prefix-abc".containsText("fix"))
+
+// The unprefixed spellings, on strings and on a set.
+println(contains("abc", "b"))
+println(contains("abc", "z"))
+println(contains("abc", ""))
+println(startsWith("abc", "ab"))
+println(endsWith("abc", "bc"))
+println(contains(%(1, 2, 3), 2))
+println(contains(%("a", "b"), "b"))
+assertResult(true)(contains("abc", "b"))
+assertResult(true)(contains(%(1, 2, 3), 2))
+
+// The same questions of text only known while running.
+FileOutput#writeLines("cross-exec-strings.txt", ["prefix-one", "two-suffix", "plain"])
+foreach (line in FileInput#lines("cross-exec-strings.txt")) {
+  val flags = line + "|" + line.startsWithText("prefix") + "|" + line.endsWithText("suffix")
+  println(flags + "|" + line.containsText("i") + "|" + line.withoutPrefix("prefix-"))
+}
+FileOutput#delete("cross-exec-strings.txt")
+println("done")

--- a/tests/cross-exec/30-runtime-key-value-store.kl
+++ b/tests/cross-exec/30-runtime-key-value-store.kl
@@ -1,0 +1,76 @@
+// Cross-target fixture: a key/value store grown while the program runs, out
+// of a generic enum with *fully applied* annotations on its helpers.
+//
+// This is the shape a portable `Map` would be lowered to, and it is the
+// boundary worth pinning: written `KM<String, Int>`, every backend compiles
+// it; written `KM<'k, 'v>`, only arm64 does, because a call that starts from
+// the empty case fixes the type variables through its *other* arguments and
+// the x86-64 side does not solve for them yet. A test that reads the same on
+// three targets is what keeps the working half working while that is fixed.
+//
+// The counting below runs both paths through `put`: a key that is already
+// there (replaced in place) and one that is not (appended), a hundred deep
+// so the chain outgrows anything a compile-time buffer would have reserved.
+
+enum KM<'k, 'v> {
+  case KMNil
+  case KMCons(key: 'k, value: 'v, rest: KM<'k, 'v>)
+}
+
+def kmGet(m: KM<String, Int>, key: String, fallback: Int): Int = {
+  mutable cur = m
+  mutable found = fallback
+  mutable go = true
+  while (go) {
+    cur match {
+      case KMNil => { go = false; 0 }
+      case KMCons(k, v, rest) => {
+        found = (if (k == key) v else found)
+        go = (if (k == key) false else true)
+        cur = rest
+        0
+      }
+    }
+  }
+  found
+}
+
+def kmSize(m: KM<String, Int>): Int = {
+  mutable cur = m
+  mutable n = 0
+  mutable go = true
+  while (go) {
+    cur match {
+      case KMNil => { go = false; 0 }
+      case KMCons(k, v, rest) => { n = n + 1; cur = rest; 0 }
+    }
+  }
+  n
+}
+
+def kmPut(m: KM<String, Int>, key: String, value: Int): KM<String, Int> = KMCons(key, value, m)
+
+mutable counts = KMNil
+foreach (w in ["the", "fox", "the", "dog", "the", "fox"]) {
+  counts = kmPut(counts, w, kmGet(counts, w, 0) + 1)
+}
+println(kmGet(counts, "the", 0))
+println(kmGet(counts, "fox", 0))
+println(kmGet(counts, "dog", 0))
+println(kmGet(counts, "cat", -1))
+assertResult(3)(kmGet(counts, "the", 0))
+assertResult(2)(kmGet(counts, "fox", 0))
+assertResult(-1)(kmGet(counts, "cat", -1))
+
+mutable big = KMNil
+mutable i = 0
+while (i < 100) {
+  i = i + 1
+  big = kmPut(big, "k" + i, i)
+}
+println(kmSize(big))
+println(kmGet(big, "k1", 0))
+println(kmGet(big, "k50", 0))
+println(kmGet(big, "k100", 0))
+assertResult(50)(kmGet(big, "k50", 0))
+println("done")

--- a/tests/cross-exec/31-generic-chain-from-empty.kl
+++ b/tests/cross-exec/31-generic-chain-from-empty.kl
@@ -1,0 +1,62 @@
+// Cross-target fixture: a *generic* chain helper called with the empty case
+// of its own enum.
+//
+// `KMNil` carries no type arguments, so nothing fixes `'k` and `'v` through
+// the first argument -- but `key: 'k` given a string and `value: 'v` given an
+// Int fix both, and the parameter's shape follows from them. Solving across
+// all of a call's arguments is what makes this compile; before it, the empty
+// case left the other variant's payloads unknown and the backends rejected
+// reading them.
+//
+// The store is grown from `KMNil` in a loop, which is the case that matters:
+// every turn after the first reads what the previous one wrote.
+
+enum KM<'k, 'v> {
+  case KMNil
+  case KMCons(key: 'k, value: 'v, rest: KM<'k, 'v>)
+}
+
+def kmPut(m: KM<'k, 'v>, key: 'k, value: 'v): KM<'k, 'v> = KMCons(key, value, m)
+
+def kmGet(m: KM<'k, 'v>, key: 'k, fallback: 'v): 'v = {
+  mutable cur = m
+  mutable found = fallback
+  mutable go = true
+  while (go) {
+    cur match {
+      case KMNil => { go = false; 0 }
+      case KMCons(k, v, rest) => {
+        found = (if (k == key) v else found)
+        go = (if (k == key) false else true)
+        cur = rest
+        0
+      }
+    }
+  }
+  found
+}
+
+mutable counts = KMNil
+foreach (w in ["the", "fox", "the", "dog", "the", "fox"]) {
+  counts = kmPut(counts, w, kmGet(counts, w, 0) + 1)
+}
+println(kmGet(counts, "the", 0))
+println(kmGet(counts, "fox", 0))
+println(kmGet(counts, "dog", 0))
+println(kmGet(counts, "cat", -1))
+assertResult(3)(kmGet(counts, "the", 0))
+assertResult(2)(kmGet(counts, "fox", 0))
+assertResult(1)(kmGet(counts, "dog", 0))
+assertResult(-1)(kmGet(counts, "cat", -1))
+
+// The same helpers at another pair of types, so the solving is per call and
+// not remembered from the first one.
+mutable flags = KMNil
+foreach (n in [1, 2, 1]) {
+  flags = kmPut(flags, n, true)
+}
+println(kmGet(flags, 1, false))
+println(kmGet(flags, 9, false))
+assertResult(true)(kmGet(flags, 1, false))
+assertResult(false)(kmGet(flags, 9, false))
+println("done")


### PR DESCRIPTION
Nine rounds of closing native-backend gaps, each found the same way: build the
same feature probe for all three targets and read what only one of them
rejected. Nine cross-exec fixtures run the results on real arm64 and Windows
hardware and diff every line against the evaluator.

## Closed

**aarch64**: maps read as entries (records as list elements, nullable record
fields, records printed inside a list, appending a nullable to a string, maps
grown while the program runs); the `Set#*` family; enum values printed as
values, to stdout and into a string; `indexOf`/`lastIndexOf`/`repeat`/
`replace`; printing a double; `cleanup`; `Math#gcd`/`powInt`/`sqrtInt`;
`Random#seed`/`nextInt`; methods that need their receiver's type to resolve;
a fold whose function arrives under a name; and `contains` as substring
containment, not just set membership.

**x86-64**: `Map#keys`/`Map#values` and the function spellings of `Map#put`,
`Map#empty`, `Map#getOrElse` and the `Set#` builders; appending an `Int` or a
`Boolean` to a heap string; and the string predicates on a heap-string
receiver, which is what an extension method's own `this` is.

**Both**: `String#isInt` and `String#isDouble`, which no native backend had --
folded by Rust's own parse when the text is known while compiling, scanned
byte by byte when it is not, range included.

## Four wrong answers fixed

- **`Math#sqrtInt(0)`** answered with the previous square root in the same
  program.
- **A list built inside a recursive function** printed `[c, c, c]` where the
  evaluator prints `[a, b, c]`: the result buffer is chosen while compiling,
  so one is shared by every activation. Refused now, with a diagnostic, and
  the same program is proven correct on arm64 by a paired test.
- **A word counter counted every word as 1** on arm64: a `mutable` map grown
  in a loop kept the type of the empty map it started as.
- **`Set#add`** rooted its copy's slots after the branch that skips the copy,
  so that path popped roots it never pushed -- the collector said so on the
  arm64 runner.

## What the last round changed about the diagnosis

"x86-64 has no heap collection" was one level too pessimistic. A
self-referential enum *is* a chain of GC cells there, and it works under
recursion -- what stopped it being usable as a key/value store was one missing
conversion, appending a number to a heap string. With that, the word counter
written in the language itself -- grow a chain in a loop, replace on a
repeated key, render it afterwards, a hundred entries deep -- compiles and
runs on all three targets and agrees with the evaluator, including under
`--gc-stress` (fixture 28).

So what remains is narrower than it looked: the *builtin* `Map` and `List`
types still use compile-time values or fixed-capacity buffers on x86-64, so
`Map#put` in a loop, `words()`, and `distinctItems()` over a runtime list stay
arm64-only. The representation that would replace them exists and is proven;
routing the builtins through it is a middle-end lowering, not new machine
code. That is the follow-up this PR scopes rather than attempts.

## Verification

- 58/58 sample programs build on all three targets, unchanged throughout.
- Full suite green (725 tests).
- Fixtures 21-29 build for all three targets, run on real arm64 and Windows in
  CI, and match the evaluator line for line.
- Three macOS-gated tests cover what only Apple Silicon can do today; one
  Linux-gated test pins the refusal that replaced a wrong answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)