### PR TITLE
A map grown while the program runs, and release 0.9.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project Overview
 
 Klassic is a statically typed object-functional programming language implemented
-as a Rust 2024 Cargo workspace (crate version 0.8.1). The `klassic` executable is
+as a Rust 2024 Cargo workspace (crate version 0.9.0). The `klassic` executable is
 both an evaluator/REPL and a native compiler that writes executables **byte by
 byte** — ELF64 on Linux x86_64, ad-hoc-signed Mach-O on Apple Silicon, PE64 on
 Windows x86_64 — with no `cc`/`as`/`ld`/`codesign`/`link.exe` in the loop. The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "klassic"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "klassic-eval",
  "klassic-native",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "klassic"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 default-run = "klassic"
 

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -10522,6 +10522,11 @@ impl Emitter {
         }
         let saved_offset = self.next_local_offset;
         let saved_max = self.max_local_offset;
+        // Slots are frame offsets, and every function starts its frame at the
+        // same place -- so a slot matched in one function has the same offset
+        // as an unrelated slot in the next, and the widening guard read it as
+        // "already matched". The set belongs to one activation of one body.
+        let saved_matched = std::mem::take(&mut self.matched_enum_slots);
         self.next_local_offset = 0;
         self.max_local_offset = 0;
         let mut param_slots = Vec::new();
@@ -10552,6 +10557,7 @@ impl Emitter {
         self.asm.patch_sub_sp(frame_patch, frame_size);
         self.next_local_offset = saved_offset;
         self.max_local_offset = saved_max;
+        self.matched_enum_slots = saved_matched;
         // A body narrower than the registered return type is fine: two shapes
         // of one enum have the same representation, and the wider one is what
         // callers were told. Merging is how "narrower" is decided, since what a

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -487,10 +487,11 @@ pub fn compile_source_to_elf(
     compile_source_for_target(name, text, config)
 }
 
-#[allow(clippy::result_large_err)]
 mod cbackend;
 mod gc_layout;
 mod llvm;
+#[allow(clippy::result_large_err)]
+mod map_chain;
 
 #[allow(clippy::result_large_err)]
 mod aarch64;
@@ -587,6 +588,13 @@ pub fn compile_source_with_prelude_and_modules_for_target(
 ) -> Result<Vec<u8>, NativeCompileError> {
     let mut bundled = String::with_capacity(prelude_text.len() + user_text.len() + 1);
     bundled.push_str(prelude_text);
+    // A map that grows while the program runs is lowered onto a chain, and
+    // the chain's helpers are Klassic source: prepended here so they are
+    // parsed and checked with everything else, and only when a program has a
+    // map to grow.
+    if map_chain::program_creates_runtime_map(user_text) {
+        bundled.push_str(map_chain::HELPERS);
+    }
     if !prelude_text.ends_with('\n') {
         bundled.push('\n');
     }
@@ -634,6 +642,10 @@ fn compile_internal(
             }
         }
     }
+    // Maps that grow while the program runs become chains before the enums
+    // are lowered, so the chain lowers with everything else. Only the user's
+    // own code is rewritten; the stdlib's map functions keep the builtin map.
+    let expr = map_chain::lower_runtime_maps(expr, prelude_offset);
     let (expr, lowered_enum_names, mono_enum_shapes, mono_enum_variants) = desugar_enums(expr);
     // Capture the extension-method registry before the desugar erases the
     // `ExtensionDeclaration`s, so codegen can resolve method names that the

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -7047,7 +7047,16 @@ impl NativeCodeGenerator {
                 match slot.value {
                     NativeValue::RuntimeString { data, len } => {
                         let compiled = self.compile_expr(value)?;
-                        let Some(input) = self.native_string_ref(compiled) else {
+                        // A heap string is copied into the binding's buffer,
+                        // like every other shape of string: building one by
+                        // appending in a loop -- `out = out + k + ": " + v` --
+                        // produces a heap string, and refusing it here refused
+                        // the loop.
+                        let Some(input) = self.native_string_ref_or_copy(
+                            compiled,
+                            *span,
+                            "native string assignment for this value type",
+                        ) else {
                             return Err(unsupported(
                                 *span,
                                 "native string assignment for this value type",
@@ -7113,6 +7122,18 @@ impl NativeCodeGenerator {
                     ));
                 }
                 self.asm.store_rbp_slot(slot.offset, Reg::Rax);
+                // Assigning a generic enum value merges its shape into the
+                // slot's, resolved reprs winning over defaulted ones. A
+                // binding seeded with a nullary constructor -- `mutable m =
+                // KMNil` -- knows nothing about the payloads until something
+                // is put in it, and that something is what says.
+                if let Some(shape) = self.pending_enum_shape.take() {
+                    let merged =
+                        merge_enum_shapes(self.enum_shapes.get(&slot.id).cloned(), Some(shape));
+                    if let Some(merged) = merged {
+                        self.enum_shapes.insert(slot.id, merged);
+                    }
+                }
                 if self.dynamic_control_depth > 0 {
                     self.remove_static_value(name);
                 } else if static_expr_is_pure(value)

--- a/crates/klassic-native/src/map_chain.rs
+++ b/crates/klassic-native/src/map_chain.rs
@@ -1,0 +1,596 @@
+//! Lower a map that has to grow while the program runs onto a chain.
+//!
+//! The builtin `Map` is a compile-time value on the x86-64 backend and a
+//! chain of cells on the aarch64 one, which is why `Map#put` in a loop works
+//! on one and not the other. This pass rewrites such a map onto a
+//! self-referential enum and the helpers in [`HELPERS`], which every backend
+//! compiles (see `tests/cross-exec/32-map-chain-helpers.kl`).
+//!
+//! It is deliberately narrow. A map is lowered only when it is *created* by
+//! `Map#empty()`, and only when every use of it is one of the operations the
+//! helpers provide. Anything else -- handing the map to a function, asking for
+//! its keys, walking its entries -- leaves the whole program alone, so a
+//! program that compiles today keeps compiling the way it did.
+
+use std::collections::HashSet;
+
+use klassic_span::Span;
+use klassic_syntax::{Expr, MatchArm, StringPart};
+
+/// The chain and its helpers, prepended to the prelude when a program needs
+/// them. Written with `while` rather than recursion so every backend can
+/// compile them: a recursive generic function cannot be compiled once, and
+/// these are generic in the key and the value.
+///
+/// The names avoid a leading `__` because a constructor whose name starts
+/// with one does not parse in a pattern.
+pub const HELPERS: &str = r#"
+enum KlassicMapChain<'k, 'v> {
+  case KlassicMapNil
+  case KlassicMapCons(key: 'k, value: 'v, rest: KlassicMapChain<'k, 'v>)
+}
+
+def klassicMapReverse(m: KlassicMapChain<'k, 'v>): KlassicMapChain<'k, 'v> = {
+  mutable cur = m
+  mutable acc = KlassicMapNil
+  mutable go = true
+  while (go) {
+    cur match {
+      case KlassicMapNil => { go = false; 0 }
+      case KlassicMapCons(k, v, rest) => { acc = KlassicMapCons(k, v, acc); cur = rest; 0 }
+    }
+  }
+  acc
+}
+
+def klassicMapPut(m: KlassicMapChain<'k, 'v>, key: 'k, value: 'v): KlassicMapChain<'k, 'v> = {
+  mutable cur = m
+  mutable acc = KlassicMapNil
+  mutable replaced = false
+  mutable go = true
+  while (go) {
+    cur match {
+      case KlassicMapNil => { go = false; 0 }
+      case KlassicMapCons(k, v, rest) => {
+        acc = (if (k == key) KlassicMapCons(k, value, acc) else KlassicMapCons(k, v, acc))
+        replaced = (if (k == key) true else replaced)
+        cur = rest
+        0
+      }
+    }
+  }
+  klassicMapReverse((if (replaced) acc else KlassicMapCons(key, value, acc)))
+}
+
+def klassicMapGetOrElse(m: KlassicMapChain<'k, 'v>, key: 'k, fallback: 'v): 'v = {
+  mutable cur = m
+  mutable found = fallback
+  mutable go = true
+  while (go) {
+    cur match {
+      case KlassicMapNil => { go = false; 0 }
+      case KlassicMapCons(k, v, rest) => {
+        found = (if (k == key) v else found)
+        go = (if (k == key) false else true)
+        cur = rest
+        0
+      }
+    }
+  }
+  found
+}
+
+def klassicMapContainsKey(m: KlassicMapChain<'k, 'v>, key: 'k): Boolean = {
+  mutable cur = m
+  mutable yes = false
+  mutable go = true
+  while (go) {
+    cur match {
+      case KlassicMapNil => { go = false; 0 }
+      case KlassicMapCons(k, v, rest) => {
+        yes = (if (k == key) true else yes)
+        go = (if (k == key) false else true)
+        cur = rest
+        0
+      }
+    }
+  }
+  yes
+}
+
+def klassicMapSize(m: KlassicMapChain<'k, 'v>): Int = {
+  mutable cur = m
+  mutable n = 0
+  mutable go = true
+  while (go) {
+    cur match {
+      case KlassicMapNil => { go = false; 0 }
+      case KlassicMapCons(k, v, rest) => { n = n + 1; cur = rest; 0 }
+    }
+  }
+  n
+}
+
+def klassicMapRender(m: KlassicMapChain<'k, 'v>): String = {
+  mutable cur = m
+  mutable out = ""
+  mutable first = true
+  mutable go = true
+  while (go) {
+    cur match {
+      case KlassicMapNil => { go = false; 0 }
+      case KlassicMapCons(k, v, rest) => {
+        out = (if (first) (out + k + ": " + v) else (out + ", " + k + ": " + v))
+        first = false
+        cur = rest
+        0
+      }
+    }
+  }
+  "%[" + out + "]"
+}
+"#;
+
+/// Does this program create a map with `Map#empty()`? Asked of the user's own
+/// text, before parsing, to decide whether [`HELPERS`] is worth prepending --
+/// a program that never grows a map should not carry them.
+pub fn program_creates_runtime_map(user_text: &str) -> bool {
+    user_text.contains("Map#empty")
+}
+
+/// Rewrite the maps this pass can lower, or leave the program exactly as it
+/// was. `prelude_len` is where the user's own text begins; only the user's
+/// code is rewritten, because the stdlib's own map functions operate on the
+/// builtin map and are compiled the way they always were.
+pub fn lower_runtime_maps(expr: Expr, prelude_len: usize) -> Expr {
+    let mut tracked = HashSet::new();
+    collect_created_maps(&expr, prelude_len, &mut tracked);
+    if tracked.is_empty() {
+        return expr;
+    }
+    if !every_use_is_lowerable(&expr, prelude_len, &tracked) {
+        return expr;
+    }
+    rewrite(expr, prelude_len, &tracked)
+}
+
+fn is_user(span: Span, prelude_len: usize) -> bool {
+    span.start >= prelude_len
+}
+
+/// Names bound to `Map#empty()` in the user's own code.
+fn collect_created_maps(expr: &Expr, prelude_len: usize, out: &mut HashSet<String>) {
+    if let Expr::VarDecl {
+        name, value, span, ..
+    } = expr
+        && is_user(*span, prelude_len)
+        && is_map_empty_call(value)
+    {
+        out.insert(name.clone());
+    }
+    for child in children(expr) {
+        collect_created_maps(child, prelude_len, out);
+    }
+}
+
+fn is_map_empty_call(expr: &Expr) -> bool {
+    matches!(expr, Expr::Call { callee, arguments, .. }
+        if arguments.is_empty()
+            && matches!(callee.as_ref(), Expr::Identifier { name, .. } if name == "Map#empty"))
+}
+
+/// Every mention of a tracked name has to be one of the shapes `rewrite`
+/// knows. One that is not leaves the whole program alone rather than half
+/// lowering it.
+fn every_use_is_lowerable(expr: &Expr, prelude_len: usize, tracked: &HashSet<String>) -> bool {
+    match expr {
+        // A bare mention is fine only where `rewrite` handles it: as the map
+        // of a supported call, as a `println` argument, or as the value of an
+        // assignment to a tracked name. Those cases are checked by their
+        // parents below, so a mention reaching here is not lowerable.
+        Expr::Identifier { name, span } => !(is_user(*span, prelude_len) && tracked.contains(name)),
+        Expr::VarDecl {
+            name, value, span, ..
+        } => {
+            if is_user(*span, prelude_len) && tracked.contains(name) && is_map_empty_call(value) {
+                return true;
+            }
+            every_use_is_lowerable(value, prelude_len, tracked)
+        }
+        Expr::Assign { name, value, span } => {
+            if is_user(*span, prelude_len) && tracked.contains(name) {
+                return lowerable_map_expr(value, prelude_len, tracked);
+            }
+            every_use_is_lowerable(value, prelude_len, tracked)
+        }
+        Expr::Call {
+            callee, arguments, ..
+        } => {
+            if let Some(parts) = supported_call(callee, arguments, tracked, prelude_len) {
+                return parts
+                    .iter()
+                    .all(|part| every_use_is_lowerable(part, prelude_len, tracked));
+            }
+            every_use_is_lowerable(callee, prelude_len, tracked)
+                && arguments
+                    .iter()
+                    .all(|argument| every_use_is_lowerable(argument, prelude_len, tracked))
+        }
+        other => children(other)
+            .into_iter()
+            .all(|child| every_use_is_lowerable(child, prelude_len, tracked)),
+    }
+}
+
+/// An expression that may stand for a lowered map: the empty map, or a `put`
+/// on one.
+fn lowerable_map_expr(expr: &Expr, prelude_len: usize, tracked: &HashSet<String>) -> bool {
+    if is_map_empty_call(expr) {
+        return true;
+    }
+    let Expr::Call {
+        callee, arguments, ..
+    } = expr
+    else {
+        return false;
+    };
+    let Expr::Identifier { name, .. } = callee.as_ref() else {
+        return false;
+    };
+    if name != "Map#put" || arguments.len() != 3 {
+        return false;
+    }
+    matches!(&arguments[0], Expr::Identifier { name, .. } if tracked.contains(name))
+        && every_use_is_lowerable(&arguments[1], prelude_len, tracked)
+        && every_use_is_lowerable(&arguments[2], prelude_len, tracked)
+}
+
+/// The arguments that still need checking when a call is one this pass
+/// rewrites -- the map itself is accounted for by the rewrite.
+fn supported_call<'a>(
+    callee: &'a Expr,
+    arguments: &'a [Expr],
+    tracked: &HashSet<String>,
+    prelude_len: usize,
+) -> Option<Vec<&'a Expr>> {
+    let names_tracked_map = |expr: &Expr| {
+        matches!(expr, Expr::Identifier { name, span }
+            if tracked.contains(name) && is_user(*span, prelude_len))
+    };
+    match callee {
+        Expr::Identifier { name, .. } => {
+            let rest: Vec<&Expr> = arguments.iter().skip(1).collect();
+            match (name.as_str(), arguments.len()) {
+                ("Map#put", 3) | ("Map#getOrElse", 3) | ("getOrElse", 3)
+                    if names_tracked_map(&arguments[0]) =>
+                {
+                    Some(rest)
+                }
+                ("Map#containsKey", 2) | ("containsKey", 2) if names_tracked_map(&arguments[0]) => {
+                    Some(rest)
+                }
+                ("Map#size", 1) | ("size", 1) | ("Map#isEmpty", 1)
+                    if names_tracked_map(&arguments[0]) =>
+                {
+                    Some(Vec::new())
+                }
+                ("println", 1) | ("printlnError", 1) if names_tracked_map(&arguments[0]) => {
+                    Some(Vec::new())
+                }
+                _ => None,
+            }
+        }
+        // `m.getOrElse(k, d)`, `m.containsKey(k)`, `m.sizeOf()`: the receiver
+        // is the map and the method is one of the helpers.
+        Expr::FieldAccess { target, field, .. } if names_tracked_map(target) => {
+            match (field.as_str(), arguments.len()) {
+                ("getOrElse", 2) | ("containsKey", 1) | ("sizeOf", 0) | ("isEmptyMap", 0) => {
+                    Some(arguments.iter().collect())
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn call(name: &str, arguments: Vec<Expr>, span: Span) -> Expr {
+    Expr::Call {
+        callee: Box::new(Expr::Identifier {
+            name: name.to_string(),
+            span,
+        }),
+        arguments,
+        span,
+    }
+}
+
+fn rewrite(expr: Expr, prelude_len: usize, tracked: &HashSet<String>) -> Expr {
+    let names_tracked_map = |expr: &Expr| {
+        matches!(expr, Expr::Identifier { name, span }
+            if tracked.contains(name) && is_user(*span, prelude_len))
+    };
+    match expr {
+        Expr::Call {
+            callee,
+            arguments,
+            span,
+        } => {
+            if is_map_empty_call(&Expr::Call {
+                callee: callee.clone(),
+                arguments: arguments.clone(),
+                span,
+            }) && is_user(span, prelude_len)
+            {
+                return Expr::Identifier {
+                    name: "KlassicMapNil".to_string(),
+                    span,
+                };
+            }
+            let rewritten: Vec<Expr> = arguments
+                .iter()
+                .cloned()
+                .map(|argument| rewrite(argument, prelude_len, tracked))
+                .collect();
+            if let Expr::Identifier { name, .. } = callee.as_ref()
+                && !arguments.is_empty()
+                && names_tracked_map(&arguments[0])
+            {
+                let helper = match (name.as_str(), arguments.len()) {
+                    ("Map#put", 3) => Some("klassicMapPut"),
+                    ("Map#getOrElse", 3) | ("getOrElse", 3) => Some("klassicMapGetOrElse"),
+                    ("Map#containsKey", 2) | ("containsKey", 2) => Some("klassicMapContainsKey"),
+                    ("Map#size", 1) | ("size", 1) => Some("klassicMapSize"),
+                    _ => None,
+                };
+                if let Some(helper) = helper {
+                    return call(helper, rewritten, span);
+                }
+                if name == "Map#isEmpty" && arguments.len() == 1 {
+                    return Expr::Binary {
+                        lhs: Box::new(call("klassicMapSize", rewritten, span)),
+                        op: klassic_syntax::BinaryOp::Equal,
+                        rhs: Box::new(Expr::Int {
+                            value: 0,
+                            kind: klassic_syntax::IntLiteralKind::Int,
+                            span,
+                        }),
+                        span,
+                    };
+                }
+                if matches!(name.as_str(), "println" | "printlnError") && arguments.len() == 1 {
+                    return call(name, vec![call("klassicMapRender", rewritten, span)], span);
+                }
+            }
+            if let Expr::FieldAccess { target, field, .. } = callee.as_ref()
+                && names_tracked_map(target)
+            {
+                let mut all = vec![rewrite((**target).clone(), prelude_len, tracked)];
+                all.extend(rewritten.iter().cloned());
+                match (field.as_str(), arguments.len()) {
+                    ("getOrElse", 2) => return call("klassicMapGetOrElse", all, span),
+                    ("containsKey", 1) => return call("klassicMapContainsKey", all, span),
+                    ("sizeOf", 0) => return call("klassicMapSize", all, span),
+                    ("isEmptyMap", 0) => {
+                        return Expr::Binary {
+                            lhs: Box::new(call("klassicMapSize", all, span)),
+                            op: klassic_syntax::BinaryOp::Equal,
+                            rhs: Box::new(Expr::Int {
+                                value: 0,
+                                kind: klassic_syntax::IntLiteralKind::Int,
+                                span,
+                            }),
+                            span,
+                        };
+                    }
+                    _ => {}
+                }
+            }
+            Expr::Call {
+                callee: Box::new(rewrite(*callee, prelude_len, tracked)),
+                arguments: rewritten,
+                span,
+            }
+        }
+        other => map_children(other, &mut |child| rewrite(child, prelude_len, tracked)),
+    }
+}
+
+/// The children of an expression, for the walks above.
+fn children(expr: &Expr) -> Vec<&Expr> {
+    match expr {
+        Expr::Block { expressions, .. } => expressions.iter().collect(),
+        Expr::Call {
+            callee, arguments, ..
+        } => std::iter::once(callee.as_ref())
+            .chain(arguments.iter())
+            .collect(),
+        Expr::Binary { lhs, rhs, .. } => vec![lhs.as_ref(), rhs.as_ref()],
+        Expr::Unary { expr, .. } => vec![expr.as_ref()],
+        Expr::If {
+            condition,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            let mut out = vec![condition.as_ref(), then_branch.as_ref()];
+            if let Some(branch) = else_branch {
+                out.push(branch.as_ref());
+            }
+            out
+        }
+        Expr::While {
+            condition, body, ..
+        } => vec![condition.as_ref(), body.as_ref()],
+        Expr::Foreach { iterable, body, .. } => vec![iterable.as_ref(), body.as_ref()],
+        Expr::VarDecl { value, .. }
+        | Expr::Assign { value, .. }
+        | Expr::Lambda { body: value, .. }
+        | Expr::DefDecl { body: value, .. } => vec![value.as_ref()],
+        Expr::Cleanup { body, cleanup, .. } => vec![body.as_ref(), cleanup.as_ref()],
+        Expr::Match {
+            scrutinee, arms, ..
+        } => {
+            let mut out = vec![scrutinee.as_ref()];
+            out.extend(arms.iter().map(|arm| &arm.body));
+            out
+        }
+        Expr::ListLiteral { elements, .. } | Expr::SetLiteral { elements, .. } => {
+            elements.iter().collect()
+        }
+        Expr::RecordConstructor { arguments, .. } => arguments.iter().collect(),
+        Expr::FieldAccess { target, .. } => vec![target.as_ref()],
+        Expr::RecordLiteral { fields, .. } => fields.iter().map(|(_, value)| value).collect(),
+        Expr::MapLiteral { entries, .. } => entries
+            .iter()
+            .flat_map(|(key, value)| [key, value])
+            .collect(),
+        Expr::InstanceDeclaration { methods, .. } => methods.iter().collect(),
+        Expr::ExtensionDeclaration { methods, .. } => methods.iter().collect(),
+        // Declarations and literals with nothing to walk. Listed rather than
+        // caught by a wildcard, so a new kind of expression is a compile error
+        // here instead of a silently unchecked one -- this walk deciding "no
+        // children" for something that has them is how a use slips past the
+        // check that keeps the lowering all-or-nothing.
+        Expr::Int { .. }
+        | Expr::Double { .. }
+        | Expr::Bool { .. }
+        | Expr::String { .. }
+        | Expr::Null { .. }
+        | Expr::Unit { .. }
+        | Expr::Identifier { .. }
+        | Expr::ModuleHeader { .. }
+        | Expr::Import { .. }
+        | Expr::RecordDeclaration { .. }
+        | Expr::TypeClassDeclaration { .. }
+        | Expr::TheoremDeclaration { .. }
+        | Expr::AxiomDeclaration { .. }
+        | Expr::EnumDeclaration { .. }
+        | Expr::PegRuleBlock { .. } => Vec::new(),
+        Expr::StringInterpolation { parts, .. } => parts
+            .iter()
+            .filter_map(|part| match part {
+                StringPart::Interpolation(hole) => Some(hole.as_ref()),
+                StringPart::Literal(_) => None,
+            })
+            .collect(),
+    }
+}
+
+/// Rebuild an expression with each child mapped, for the shapes `rewrite`
+/// does not handle itself.
+fn map_children(expr: Expr, f: &mut impl FnMut(Expr) -> Expr) -> Expr {
+    match expr {
+        Expr::Block { expressions, span } => Expr::Block {
+            expressions: expressions.into_iter().map(&mut *f).collect(),
+            span,
+        },
+        Expr::Binary { lhs, op, rhs, span } => Expr::Binary {
+            lhs: Box::new(f(*lhs)),
+            op,
+            rhs: Box::new(f(*rhs)),
+            span,
+        },
+        Expr::Unary { op, expr, span } => Expr::Unary {
+            op,
+            expr: Box::new(f(*expr)),
+            span,
+        },
+        Expr::If {
+            condition,
+            then_branch,
+            else_branch,
+            span,
+        } => Expr::If {
+            condition: Box::new(f(*condition)),
+            then_branch: Box::new(f(*then_branch)),
+            else_branch: else_branch.map(|branch| Box::new(f(*branch))),
+            span,
+        },
+        Expr::While {
+            condition,
+            body,
+            span,
+        } => Expr::While {
+            condition: Box::new(f(*condition)),
+            body: Box::new(f(*body)),
+            span,
+        },
+        Expr::Foreach {
+            binding,
+            iterable,
+            body,
+            span,
+        } => Expr::Foreach {
+            binding,
+            iterable: Box::new(f(*iterable)),
+            body: Box::new(f(*body)),
+            span,
+        },
+        Expr::VarDecl {
+            mutable,
+            name,
+            annotation,
+            value,
+            span,
+        } => Expr::VarDecl {
+            mutable,
+            name,
+            annotation,
+            value: Box::new(f(*value)),
+            span,
+        },
+        Expr::Assign { name, value, span } => Expr::Assign {
+            name,
+            value: Box::new(f(*value)),
+            span,
+        },
+        Expr::Cleanup {
+            body,
+            cleanup,
+            span,
+        } => Expr::Cleanup {
+            body: Box::new(f(*body)),
+            cleanup: Box::new(f(*cleanup)),
+            span,
+        },
+        Expr::Match {
+            scrutinee,
+            arms,
+            span,
+        } => Expr::Match {
+            scrutinee: Box::new(f(*scrutinee)),
+            arms: arms
+                .into_iter()
+                .map(|arm| MatchArm {
+                    pattern: arm.pattern,
+                    guard: arm.guard,
+                    body: f(arm.body),
+                    span: arm.span,
+                })
+                .collect(),
+            span,
+        },
+        Expr::ListLiteral { elements, span } => Expr::ListLiteral {
+            elements: elements.into_iter().map(&mut *f).collect(),
+            span,
+        },
+        Expr::SetLiteral { elements, span } => Expr::SetLiteral {
+            elements: elements.into_iter().map(&mut *f).collect(),
+            span,
+        },
+        Expr::StringInterpolation { parts, span } => Expr::StringInterpolation {
+            parts: parts
+                .into_iter()
+                .map(|part| match part {
+                    StringPart::Interpolation(hole) => {
+                        StringPart::Interpolation(Box::new(f(*hole)))
+                    }
+                    literal => literal,
+                })
+                .collect(),
+            span,
+        },
+        other => other,
+    }
+}

--- a/crates/klassic-native/src/map_chain.rs
+++ b/crates/klassic-native/src/map_chain.rs
@@ -145,6 +145,12 @@ pub fn program_creates_runtime_map(user_text: &str) -> bool {
 pub fn lower_runtime_maps(expr: Expr, prelude_len: usize) -> Expr {
     let mut tracked = HashSet::new();
     collect_created_maps(&expr, prelude_len, &mut tracked);
+    // A map that is never put into has nothing to grow, and nothing in it to
+    // say what its keys and values are -- so it stays the builtin empty map,
+    // which every backend already handles.
+    let mut grown = HashSet::new();
+    collect_grown_maps(&expr, prelude_len, &tracked, &mut grown);
+    let tracked = grown;
     if tracked.is_empty() {
         return expr;
     }
@@ -170,6 +176,27 @@ fn collect_created_maps(expr: &Expr, prelude_len: usize, out: &mut HashSet<Strin
     }
     for child in children(expr) {
         collect_created_maps(child, prelude_len, out);
+    }
+}
+
+/// Of the maps created by `Map#empty()`, the ones something is put into.
+fn collect_grown_maps(
+    expr: &Expr,
+    prelude_len: usize,
+    created: &HashSet<String>,
+    out: &mut HashSet<String>,
+) {
+    if let Expr::Assign { name, value, span } = expr
+        && is_user(*span, prelude_len)
+        && created.contains(name)
+        && matches!(value.as_ref(), Expr::Call { callee, arguments, .. }
+            if arguments.len() == 3
+                && matches!(callee.as_ref(), Expr::Identifier { name, .. } if name == "Map#put"))
+    {
+        out.insert(name.clone());
+    }
+    for child in children(expr) {
+        collect_grown_maps(child, prelude_len, created, out);
     }
 }
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1712,6 +1712,38 @@ that a heap pointer takes, and a string argument is exactly what fixes a
 rewritten shape is published there once the whole argument list has been
 seen.
 
+#### What a portable `Map` lowering runs into, measured
+
+Lowering the builtin map to the chain means emitting helpers -- put, lookup,
+size, rendering -- that the program's own map operations are rewritten to
+call. Written generically, so the lowering needs no type inference of its
+own, they are rejected, and three ways of getting past that were tried and
+refused:
+
+- **Partial shapes are unsound as they stand.** `containsKey(m, key)` fixes
+  the key's type and says nothing about the value's, so the annotation solves
+  to `KlassicMapChain<String, 'v>`. Letting `generic_enum_annotation_shape`
+  resolve what it can and leave the rest defaulted compiles -- and prints
+  `%[3: 3, 3: 1, 3: 1]` for a store whose keys are words. A defaulted repr is
+  read as the wrong kind.
+- **Refusing to read an unresolved field**, which would make partial shapes
+  safe, breaks ten existing tests. The model defaults those fields on purpose:
+  they are read only in arms that are dead at run time, and rejecting the read
+  rejects working programs.
+- **Dropping such an arm as dead** was refuted earlier: the next call, whose
+  value really is that variant, dies with "match: no pattern matched".
+
+So the lowering needs *fully* resolved shapes at every helper call, which
+means either the helpers are monomorphic -- and the desugar does not know the
+key and value types -- or x86-64's shape model gains a precise notion of a
+dead arm rather than a defaulted one. That is a design decision about the
+model, not a missing case, and it is where the next attempt should start.
+
+(A smaller thing found on the way: a constructor whose name begins with `__`
+does not parse in a *pattern* -- `case __Nil =>` is a syntax error while
+`case KNil =>` is fine -- so an injected enum cannot use the usual
+double-underscore convention for synthesized names.)
+
 What is left is not a representation gap any more but a routing one, and it
 splits in two. `Map#put` in a loop needs the *builtin* map lowered to the
 chain above -- a middle-end pass that injects the enum and its helpers and

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1712,7 +1712,29 @@ that a heap pointer takes, and a string argument is exactly what fixes a
 rewritten shape is published there once the whole argument list has been
 seen.
 
-#### What a portable `Map` lowering runs into, measured
+#### The helpers a portable `Map` lowering needs now compile
+
+Written the way a lowering would write them -- a generic self-referential enum
+plus while-loop helpers, so nothing recurses -- put, lookup, membership, size
+and rendering compile and run on all three targets, and the word counter built
+from them agrees with the evaluator including under `--gc-stress`
+(fixture 32). Three holes had to be closed, one per backend concern:
+
+- **A binding seeded with a nullary constructor takes its payload types from
+  what is assigned to it.** `mutable acc = KMNil` knows nothing; the first
+  `acc = KMCons(k, v, acc)` says everything. x86-64 merges the assigned
+  value's shape into the slot's, resolved reprs winning over defaulted ones.
+- **A string built by appending in a loop is assignable back.** `out = out + k
+  + ": " + v` produces a heap string, and a `mutable` string binding is a
+  fixed buffer; the heap string is copied into it now, as every other shape of
+  string already was.
+- **The record of which slots have been matched on belongs to one function.**
+  It is keyed by frame offset, and every function's frame starts at the same
+  place -- so a slot matched in one function blocked widening for an unrelated
+  slot at the same offset in the next. On aarch64 that is what refused
+  `acc = KMCons(...)` with "assignment changing a type".
+
+#### What a portable `Map` lowering ran into before, measured
 
 Lowering the builtin map to the chain means emitting helpers -- put, lookup,
 size, rendering -- that the program's own map operations are rewritten to

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1712,71 +1712,50 @@ that a heap pointer takes, and a string argument is exactly what fixes a
 rewritten shape is published there once the whole argument list has been
 seen.
 
-#### The helpers a portable `Map` lowering needs now compile
+#### A map grown while the program runs, on every target
 
-Written the way a lowering would write them -- a generic self-referential enum
-plus while-loop helpers, so nothing recurses -- put, lookup, membership, size
-and rendering compile and run on all three targets, and the word counter built
-from them agrees with the evaluator including under `--gc-stress`
-(fixture 32). Three holes had to be closed, one per backend concern:
+`Map#empty()` followed by `Map#put` in a loop -- the word counter as anyone
+would write it -- builds on all three targets now. A map created that way is
+lowered onto a chain of GC cells and the helpers in
+`crates/klassic-native/src/map_chain.rs`, which are Klassic source prepended
+to the prelude and compiled like any other definition: a generic
+self-referential enum and `while`-loop helpers, so nothing recurses and every
+backend can compile them (`tests/cross-exec/32-map-chain-helpers.kl` runs
+them on their own, `33-builtin-map-grown-in-a-loop.kl` runs the counter).
+
+The pass is all-or-nothing per program. A map is lowered only when it is
+created by `Map#empty()` and *every* use of it is one of put, `getOrElse`,
+`containsKey`, size, emptiness or printing -- in either the function or the
+method spelling. A map that is handed to a function, asked for its keys or
+walked as entries leaves the whole program alone, so what compiled before
+still compiles the way it did. The walk that decides this enumerates every
+kind of expression rather than falling back to a wildcard: an unlisted one
+would report "no children" and let a use slip past, which is exactly how the
+first version of it half-lowered a program that used `toPairs`.
+
+Three backend holes had to be closed to make the helpers compilable at all,
+one per concern:
 
 - **A binding seeded with a nullary constructor takes its payload types from
   what is assigned to it.** `mutable acc = KMNil` knows nothing; the first
   `acc = KMCons(k, v, acc)` says everything. x86-64 merges the assigned
   value's shape into the slot's, resolved reprs winning over defaulted ones.
 - **A string built by appending in a loop is assignable back.** `out = out + k
-  + ": " + v` produces a heap string, and a `mutable` string binding is a
-  fixed buffer; the heap string is copied into it now, as every other shape of
-  string already was.
+  + ": " + v` produces a heap string while a `mutable` string binding is a
+  fixed buffer; the heap string is copied into it now.
 - **The record of which slots have been matched on belongs to one function.**
-  It is keyed by frame offset, and every function's frame starts at the same
-  place -- so a slot matched in one function blocked widening for an unrelated
-  slot at the same offset in the next. On aarch64 that is what refused
-  `acc = KMCons(...)` with "assignment changing a type".
+  It is keyed by frame offset and every frame starts at the same place, so a
+  slot matched in one function was blocking widening for an unrelated slot at
+  the same offset in the next -- which is what refused `acc = KMCons(...)` on
+  aarch64.
 
-#### What a portable `Map` lowering ran into before, measured
-
-Lowering the builtin map to the chain means emitting helpers -- put, lookup,
-size, rendering -- that the program's own map operations are rewritten to
-call. Written generically, so the lowering needs no type inference of its
-own, they are rejected, and three ways of getting past that were tried and
-refused:
-
-- **Partial shapes are unsound as they stand.** `containsKey(m, key)` fixes
-  the key's type and says nothing about the value's, so the annotation solves
-  to `KlassicMapChain<String, 'v>`. Letting `generic_enum_annotation_shape`
-  resolve what it can and leave the rest defaulted compiles -- and prints
-  `%[3: 3, 3: 1, 3: 1]` for a store whose keys are words. A defaulted repr is
-  read as the wrong kind.
-- **Refusing to read an unresolved field**, which would make partial shapes
-  safe, breaks ten existing tests. The model defaults those fields on purpose:
-  they are read only in arms that are dead at run time, and rejecting the read
-  rejects working programs.
-- **Dropping such an arm as dead** was refuted earlier: the next call, whose
-  value really is that variant, dies with "match: no pattern matched".
-
-So the lowering needs *fully* resolved shapes at every helper call, which
-means either the helpers are monomorphic -- and the desugar does not know the
-key and value types -- or x86-64's shape model gains a precise notion of a
-dead arm rather than a defaulted one. That is a design decision about the
-model, not a missing case, and it is where the next attempt should start.
-
-(A smaller thing found on the way: a constructor whose name begins with `__`
-does not parse in a *pattern* -- `case __Nil =>` is a syntax error while
-`case KNil =>` is fine -- so an injected enum cannot use the usual
-double-underscore convention for synthesized names.)
-
-What is left is not a representation gap any more but a routing one, and it
-splits in two. `Map#put` in a loop needs the *builtin* map lowered to the
-chain above -- a middle-end pass that injects the enum and its helpers and
-rewrites the `Map#*` calls, the map literals and the rendering; the helpers
-can be generic now, so the pass needs no type inference of its own.
-`words()` needs something else: `stdlibFilter` is a *recursive* generic
-function taking `List<'a>`, and a recursive function has to be compiled once,
-so its parameter kinds must be fixed -- measured again after the type-variable
-solving landed, and the reason is still "this backend cannot pass `xs`
-(`List<'a>`) by itself". That one wants monomorphisation of recursive generic
-definitions, which is a separate piece from the map lowering.
+What is still not lowered: a map that is *only* created and never put into
+keeps every payload type unknown, so asking it about a key is refused --
+there is nothing in it to say what its keys are. And `words()` over a runtime
+list is a different piece: `stdlibFilter` is a *recursive* generic function
+taking `List<'a>`, and a recursive function is compiled once, so its
+parameter kinds have to be fixed. That one wants monomorphisation of
+recursive generic definitions.
 
 ## Design Notes
 

--- a/docs/book/src/getting-started/install.md
+++ b/docs/book/src/getting-started/install.md
@@ -25,7 +25,7 @@ Two environment variables tune the installer:
 
 | Variable | Effect |
 | --- | --- |
-| `KLASSIC_VERSION=v0.8.1` | Pin a specific release instead of the latest |
+| `KLASSIC_VERSION=v0.9.0` | Pin a specific release instead of the latest |
 | `KLASSIC_HOME=/opt/klassic` | Change the install root (binaries go to `$KLASSIC_HOME/bin`) |
 
 The Linux build is statically linked (musl) and runs on any x86_64

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -24,7 +24,7 @@
     <em class="kl-terminal-title">klassic — 80×14</em>
   </div>
   <pre><code><span class="kl-prompt">$</span> curl -fsSL https://raw.githubusercontent.com/klassic/klassic/main/install.sh | sh
-<span class="kl-dim">installed: klassic 0.8.1 -&gt; ~/.klassic/bin</span>
+<span class="kl-dim">installed: klassic 0.9.0 -&gt; ~/.klassic/bin</span>
 <span class="kl-prompt">$</span> cat fib.kl
 <span class="kl-out">def fib(n: Int): Int = if (n &lt; 2) n else fib(n - 1) + fib(n - 2)
 println(fib(25))</span>

--- a/docs/release-notes/v0.9.0.md
+++ b/docs/release-notes/v0.9.0.md
@@ -1,0 +1,102 @@
+## Klassic 0.9.0
+
+Klassic 0.9.0 is about the same program compiling everywhere. The release
+before this one brought the three native targets to the same 58 sample
+programs; this one goes after what was left, which turned out to be one
+thing seen from several sides: a collection whose size is only known while
+the program runs.
+
+### A map grown while the program runs
+
+    mutable counts = Map#empty()
+    foreach (word in words) {
+      counts = Map#put(counts, word, counts.getOrElse(word, 0) + 1)
+    }
+    println(counts)
+
+This is the word counter as anyone would write it, and it could not be built
+on x86-64 or Windows at all -- a map there is a compile-time value or a
+fixed-capacity buffer, and neither grows by an amount known only while
+running. It builds on all three targets now.
+
+The map is lowered onto a chain of GC cells, with helpers written as Klassic
+source and prepended to the prelude: a generic self-referential enum and
+`while`-loop helpers, so nothing recurses and every backend compiles them.
+The pass is all-or-nothing per program -- a map is lowered only when it is
+created by `Map#empty()` and every use of it is one the helpers cover (put,
+`getOrElse`, `containsKey`, size, emptiness, printing, in either the function
+or the method spelling). A map handed to a function, asked for its keys or
+walked as entries is left as the builtin map, so what compiled before still
+compiles the way it did.
+
+### The language, on every target
+
+The aarch64 backend gained, in order: maps read as entries (records as list
+elements, nullable record fields, records printed inside a list, appending a
+nullable to a string), the `Set#*` family, enum values printed as values --
+to stdout and into a string -- `indexOf`/`lastIndexOf`/`repeat`/`replace`,
+printing a double, `cleanup`, `Math#gcd`/`powInt`/`sqrtInt`,
+`Random#seed`/`nextInt` (the evaluator's own generator, so a seeded program
+prints the same sequence everywhere), methods that need their receiver's type
+to resolve, a fold whose function arrives under a name, and `contains` as
+substring containment.
+
+The x86-64 backend gained `Map#keys`/`Map#values` and the function spellings
+of the `Map#`/`Set#` builders, appending an `Int` or a `Boolean` to a heap
+string, and the string predicates on a heap-string receiver -- which is what
+an extension method's own `this` is, so `def startsWithText(prefix) =
+this.startsWith(prefix)` and everything written that way now compiles there.
+
+Both gained `String#isInt` and `String#isDouble`, which no native backend
+had: folded by Rust's own parse when the text is known while compiling and
+scanned byte by byte when it is not, range included -- `9223372036854775807`
+is a number and `9223372036854775808` is not.
+
+### One inference both backends were missing
+
+A call like `put(KMNil, "a", 1)` fixes nothing through its first argument --
+the empty case of an enum carries no payloads -- and both backends then read
+the other variant against defaults. The arguments that *do* fix the type
+variables sit in the same argument list, so both now solve a definition's
+type variables across every argument and give an enum-typed parameter whose
+own argument left them open the shape those solutions imply. Generic chain
+helpers called with the empty case compile on all three targets because of
+it, and the map lowering above is built on it.
+
+### Five wrong answers fixed
+
+- **`Math#sqrtInt(0)`** answered with the previous square root in the same
+  program: the answer is read out of a register the zero case never wrote.
+- **A list built inside a recursive function** printed `[c, c, c]` where the
+  evaluator prints `[a, b, c]`, because the result buffer is chosen while
+  compiling -- one per call site, shared by every activation. It is refused
+  now, with a diagnostic; the same program is correct on arm64, which a test
+  pins.
+- **A word counter counted every word as 1** on arm64: a `mutable` map grown
+  in a loop kept the type of the empty map it started as, so every lookup in
+  the loop compiled to its fallback.
+- **`Set#add`** rooted its copy's slots after the branch that skips the copy,
+  so that path popped roots it never pushed -- the collector said so.
+- **`words()` split only on `" "`**, so a document with more than one line
+  counted wrongly. (0.8.1.)
+
+Two debug lines that should never have shipped were removed, one from the
+recursive-inline path and one from the generic-enum match path.
+
+### Verification
+
+Thirteen cross-target fixtures were added this cycle, taking the total to
+thirty-three. Each builds for all three targets and is run on real arm64 and
+Windows hardware in CI, with every line compared against the evaluator; the
+map fixtures also match under `--gc-stress`.
+
+### Not portable yet
+
+`words()` over a list that only exists while the program runs is still
+arm64-only. It needs two things x86-64 does not have: `split` on a runtime
+string, and a list built inside a loop -- the same "size known only while
+running" problem the map lowering solves, for lists. A map that is only
+created and never put into keeps its key and value types unknown, so asking
+it about a key is refused.
+
+**Full Changelog**: https://github.com/klassic/klassic/compare/v0.8.1...v0.9.0

--- a/tests/cross-exec/32-map-chain-helpers.kl
+++ b/tests/cross-exec/32-map-chain-helpers.kl
@@ -1,0 +1,129 @@
+// Cross-target fixture: a key/value store written the way a portable lowering
+// of the builtin `Map` would write it -- a generic self-referential enum plus
+// while-loop helpers, so nothing recurses and every backend can compile them.
+//
+// Three things had to be true at once for this to work on all three targets,
+// and each was a hole: a binding seeded with a nullary constructor has to take
+// its payload types from what is later assigned to it; a string built by
+// appending in a loop has to be assignable back to the binding it came from;
+// and the record of which slots have been matched on has to belong to one
+// function, since frame offsets repeat in the next one.
+//
+// The counting runs both paths through `put` -- a key already there, replaced
+// in place, and a new one appended -- and the rendering appends numbers to a
+// string, which is what every rendering of such a chain does.
+
+enum KlassicMapChain<'k, 'v> {
+  case KlassicMapNil
+  case KlassicMapCons(key: 'k, value: 'v, rest: KlassicMapChain<'k, 'v>)
+}
+
+def klassicMapReverse(m: KlassicMapChain<'k, 'v>): KlassicMapChain<'k, 'v> = {
+  mutable cur = m
+  mutable acc = KlassicMapNil
+  mutable go = true
+  while (go) {
+    cur match {
+      case KlassicMapNil => { go = false; 0 }
+      case KlassicMapCons(k, v, rest) => { acc = KlassicMapCons(k, v, acc); cur = rest; 0 }
+    }
+  }
+  acc
+}
+
+def klassicMapPut(m: KlassicMapChain<'k, 'v>, key: 'k, value: 'v): KlassicMapChain<'k, 'v> = {
+  mutable cur = m
+  mutable acc = KlassicMapNil
+  mutable replaced = false
+  mutable go = true
+  while (go) {
+    cur match {
+      case KlassicMapNil => { go = false; 0 }
+      case KlassicMapCons(k, v, rest) => {
+        acc = (if (k == key) KlassicMapCons(k, value, acc) else KlassicMapCons(k, v, acc))
+        replaced = (if (k == key) true else replaced)
+        cur = rest
+        0
+      }
+    }
+  }
+  klassicMapReverse((if (replaced) acc else KlassicMapCons(key, value, acc)))
+}
+
+def klassicMapGetOrElse(m: KlassicMapChain<'k, 'v>, key: 'k, fallback: 'v): 'v = {
+  mutable cur = m
+  mutable found = fallback
+  mutable go = true
+  while (go) {
+    cur match {
+      case KlassicMapNil => { go = false; 0 }
+      case KlassicMapCons(k, v, rest) => {
+        found = (if (k == key) v else found)
+        go = (if (k == key) false else true)
+        cur = rest
+        0
+      }
+    }
+  }
+  found
+}
+
+def klassicMapContainsKey(m: KlassicMapChain<'k, 'v>, key: 'k): Boolean = {
+  mutable cur = m
+  mutable yes = false
+  mutable go = true
+  while (go) {
+    cur match {
+      case KlassicMapNil => { go = false; 0 }
+      case KlassicMapCons(k, v, rest) => {
+        yes = (if (k == key) true else yes)
+        go = (if (k == key) false else true)
+        cur = rest
+        0
+      }
+    }
+  }
+  yes
+}
+
+def klassicMapSize(m: KlassicMapChain<'k, 'v>): Int = {
+  mutable cur = m
+  mutable n = 0
+  mutable go = true
+  while (go) {
+    cur match {
+      case KlassicMapNil => { go = false; 0 }
+      case KlassicMapCons(k, v, rest) => { n = n + 1; cur = rest; 0 }
+    }
+  }
+  n
+}
+
+def klassicMapRender(m: KlassicMapChain<'k, 'v>): String = {
+  mutable cur = m
+  mutable out = ""
+  mutable first = true
+  mutable go = true
+  while (go) {
+    cur match {
+      case KlassicMapNil => { go = false; 0 }
+      case KlassicMapCons(k, v, rest) => {
+        out = (if (first) (out + k + ": " + v) else (out + ", " + k + ": " + v))
+        first = false
+        cur = rest
+        0
+      }
+    }
+  }
+  "%[" + out + "]"
+}
+
+mutable counts = KlassicMapNil
+foreach (w in ["the", "fox", "the", "dog", "the"]) {
+  counts = klassicMapPut(counts, w, klassicMapGetOrElse(counts, w, 0) + 1)
+}
+println(klassicMapRender(counts))
+println(klassicMapSize(counts))
+println(klassicMapGetOrElse(counts, "the", 0))
+println(klassicMapContainsKey(counts, "cat"))
+println(klassicMapRender(KlassicMapNil))

--- a/tests/cross-exec/33-builtin-map-grown-in-a-loop.kl
+++ b/tests/cross-exec/33-builtin-map-grown-in-a-loop.kl
@@ -1,0 +1,53 @@
+// Cross-target fixture: the *builtin* map, grown while the program runs.
+//
+// This is the word counter as anyone would write it -- `Map#empty()`, then
+// `Map#put` in a loop -- and it is the program that could not be built on
+// x86-64 at all, because a map there is a compile-time value or a
+// fixed-capacity buffer. It is lowered onto a chain of GC cells now, with
+// helpers that every backend compiles, so the same source builds on all
+// three and prints what the evaluator prints -- including the map itself,
+// which has to render in insertion order with a repeated key keeping its
+// first position and its last value.
+//
+// The lowering is all-or-nothing on purpose: a map used in a way the helpers
+// do not cover is left as the builtin map, which is why this fixture stays
+// inside what they cover.
+
+import std.map
+
+mutable counts = Map#empty()
+foreach (word in ["the", "fox", "the", "dog", "the", "fox"]) {
+  counts = Map#put(counts, word, counts.getOrElse(word, 0) + 1)
+}
+println(counts)
+println(Map#size(counts))
+println(counts.sizeOf())
+println(counts.getOrElse("the", 0))
+println(counts.getOrElse("cat", -1))
+println(counts.containsKey("fox"))
+println(counts.containsKey("cat"))
+assertResult(3)(counts.getOrElse("the", 0))
+assertResult(2)(counts.getOrElse("fox", 0))
+assertResult(1)(counts.getOrElse("dog", 0))
+assertResult(-1)(counts.getOrElse("cat", -1))
+assertResult(3)(Map#size(counts))
+
+// A map with a single entry. (A map that is *only* created and never put
+// into keeps every payload type unknown, so asking it about a key is still
+// refused -- there is nothing in it to say what its keys are.)
+mutable one = Map#empty()
+one = Map#put(one, "only", 42)
+println(one)
+println(one.getOrElse("only", 0))
+
+// Int keys and Boolean values, so the lowering is not tied to one pair.
+mutable seen = Map#empty()
+foreach (n in [3, 1, 3]) {
+  seen = Map#put(seen, n, true)
+}
+println(seen)
+println(Map#size(seen))
+println(seen.getOrElse(1, false))
+println(seen.getOrElse(9, false))
+assertResult(2)(Map#size(seen))
+println("done")


### PR DESCRIPTION
`Map#empty()` followed by `Map#put` in a loop -- the word counter as anyone
would write it -- could not be built on x86-64 or Windows at all, because a
map there is a compile-time value or a fixed-capacity buffer. It builds on
all three targets now.

## How

The map is lowered onto a chain of GC cells: a generic self-referential enum
plus `while`-loop helpers, written as Klassic source and prepended to the
prelude, so they are parsed, checked and compiled like any other definition.
Nothing recurses, which is what lets every backend compile them -- a
recursive generic function has to be compiled once and its parameter kinds
cannot be fixed.

The pass is **all-or-nothing per program**. A map is lowered only when it is
created by `Map#empty()` and every use of it is one the helpers cover (put,
`getOrElse`, `containsKey`, size, emptiness, printing -- function or method
spelling). A map handed to a function, asked for its keys, or walked as
entries leaves the whole program alone, so what compiled before still
compiles the way it did. The walk that decides this enumerates every kind of
expression rather than falling back to a wildcard: an unlisted one reports
"no children" and lets a use slip past, which is how the first version
half-lowered a program that used `toPairs` and regressed it on arm64.

## Three backend holes closed on the way

The helpers are ordinary Klassic, and writing them found three things no
backend could do:

- **A binding seeded with a nullary constructor now takes its payload types
  from what is assigned to it.** `mutable acc = KMNil` knows nothing; the
  first `acc = KMCons(k, v, acc)` says everything.
- **A string built by appending in a loop is assignable back** to the
  fixed-buffer binding it came from, instead of being refused.
- **The record of which slots have been matched on is per function.** It is
  keyed by frame offset and every frame starts at the same place, so a slot
  matched in one function blocked widening for an unrelated slot at the same
  offset in the next.

## Verification

- 58/58 sample programs on all three targets, unchanged.
- Full suite green (725 tests).
- Two new cross-exec fixtures: the helpers on their own (32) and the word
  counter through the builtin map (33), both run on real arm64 and Windows in
  CI and matched against the evaluator; 33 also matches under `--gc-stress`.
- Every existing cross-exec fixture still matches the evaluator locally.

## Still not lowered

A map that is *only* created and never put into keeps every payload type
unknown, so asking it about a key is refused -- there is nothing in it to say
what its keys are. And `words()` over a runtime list is a different piece:
`stdlibFilter` is a recursive generic function taking `List<'a>`, which wants
monomorphisation of recursive generic definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)