### PR TITLE
words() and a map's entries, on every target

### DIFF
--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -243,6 +243,23 @@ struct Assembler {
     bt_pending: bool,
 }
 
+/// The registers a barrier's slow path has to leave as it found them here.
+/// x10-x12 have no name in the portable register set, which is why this list
+/// lives on this side of the trait rather than in the shared routine.
+const BARRIER_SAVED: [Reg; 11] = [
+    Reg::X1,
+    Reg::X2,
+    Reg::X3,
+    Reg::X4,
+    Reg::X5,
+    Reg::X6,
+    Reg::X7,
+    Reg::X9,
+    Reg::X10,
+    Reg::X11,
+    Reg::X12,
+];
+
 impl Assembler {
     fn word(&mut self, instruction: u32) {
         self.code.extend_from_slice(&instruction.to_le_bytes());
@@ -1201,6 +1218,20 @@ impl portable_asm::PortableAsm for Assembler {
         self.sub_reg_imm(count, count, 1);
         self.branch(copy_loop, BranchKind::Unconditional);
         self.bind(done);
+    }
+
+    /// The registers this backend has live across a barrier's slow path.
+    /// x10-x12 have no name in the portable set, which is why the list is
+    /// here rather than in the shared routine.
+    fn save_barrier_registers(&mut self) {
+        for reg in BARRIER_SAVED {
+            self.push(reg);
+        }
+    }
+    fn restore_barrier_registers(&mut self) {
+        for reg in BARRIER_SAVED.into_iter().rev() {
+            self.pop(reg);
+        }
     }
 
     fn plat_write_data(&mut self, fd: u64, data: PortDataAddr, len: usize) {
@@ -4547,37 +4578,12 @@ impl Emitter {
     }
 
     /// The barrier proper: x8 = field address on entry, x0 = the raw
-    /// pointer on exit.
+    /// pointer on exit. The test, the call and the strip are the shared
+    /// ones; what this backend adds is the register list above.
     fn emit_gc_load_barriered(&mut self) {
-        const SAVED: [Reg; 11] = [
-            Reg::X1,
-            Reg::X2,
-            Reg::X3,
-            Reg::X4,
-            Reg::X5,
-            Reg::X6,
-            Reg::X7,
-            Reg::X9,
-            Reg::X10,
-            Reg::X11,
-            Reg::X12,
-        ];
         self.asm.ldr_imm(Reg::X0, Reg::X8, 0);
-        let fast = self.asm.new_label();
-        self.asm.tst_reg(Reg::X0, Reg::X26);
-        self.asm.branch(fast, BranchKind::Conditional(Cond::Eq));
         let slow = self.load_barrier_label();
-        self.asm.push_frame_record(); // the bl below clobbers x30
-        for reg in SAVED {
-            self.asm.push(reg);
-        }
-        self.asm.branch(slow, BranchKind::Link); // x0 = value, x8 = field
-        for reg in SAVED.into_iter().rev() {
-            self.asm.pop(reg);
-        }
-        self.asm.pop_frame_record();
-        self.asm.bind(fast);
-        self.asm.and_reg(Reg::X0, Reg::X0, Reg::X24);
+        crate::portable_asm::emit_gc_load_barrier(&mut self.asm, slow);
     }
 
     /// Allocate a GC heap string whose payload is `[len][bytes...]`, with

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -4360,62 +4360,32 @@ impl Emitter {
     /// the same diagnostic the portable routines use for their tables.
     fn emit_shadow_push_routine(&mut self, label: Label) {
         let (base, top) = self.shadow_cells();
-        self.asm.bind(label);
-        self.asm.push(Reg::X1);
-        self.asm.push(Reg::X2);
-        self.asm.push(Reg::X3);
-        self.asm.load_data_address(Reg::X2, top);
-        self.asm.ldr_imm(Reg::X3, Reg::X2, 0); // top
-        let ok = self.asm.new_label();
-        self.asm
-            .mov_imm64(Reg::X1, crate::gc_layout::GC_SHADOW_STACK_LEN as u64);
-        self.asm.cmp_reg(Reg::X3, Reg::X1);
-        self.asm.branch(ok, BranchKind::Conditional(Cond::Lt));
-        self.asm
-            .emit_write_rodata(STDERR_FD, b"klassic gc: shadow stack overflow\n");
-        self.asm.emit_exit(1);
-        self.asm.bind(ok);
-        self.asm.load_data_address(Reg::X1, base);
-        self.asm.ldr_imm(Reg::X1, Reg::X1, 0); // shadow stack base
-        self.asm.lsl_imm(Reg::X3, Reg::X3, 3); // top * 8
-        self.asm.add_reg(Reg::X1, Reg::X1, Reg::X3);
-        self.asm.str_imm(Reg::X0, Reg::X1, 0); // base[top] = slot address
-        self.asm.ldr_imm(Reg::X3, Reg::X2, 0);
-        self.asm.add_reg_imm(Reg::X3, Reg::X3, 1);
-        self.asm.str_imm(Reg::X3, Reg::X2, 0); // top += 1
-        self.asm.pop(Reg::X3);
-        self.asm.pop(Reg::X2);
-        self.asm.pop(Reg::X1);
-        self.asm.ret();
+        let text = self
+            .asm
+            .intern_rodata(b"klassic gc: shadow stack overflow\n");
+        crate::portable_asm::emit_gc_shadow_push_runtime(
+            &mut self.asm,
+            label,
+            PortDataAddr::Bss(base),
+            PortDataAddr::Bss(top),
+            PortDataAddr::Rodata(text),
+            b"klassic gc: shadow stack overflow\n".len(),
+        );
     }
 
     /// `bl`-called: drop one shadow-stack root. Preserves every register.
-    ///
-    /// The underflow check is a deliberate self-test of the root
-    /// bookkeeping: pushes and pops must balance on every path, and an
-    /// imbalance is otherwise silent (a leaked root, or -- worse -- a
-    /// negative top that makes the next push write outside the table).
-    /// Aborting here turns any mismatch into an immediate, obvious CI
-    /// failure on arm64 instead of a rare corruption once the collector is
-    /// live.
     fn emit_shadow_pop_routine(&mut self, label: Label) {
         let (_, top) = self.shadow_cells();
-        self.asm.bind(label);
-        self.asm.push(Reg::X0);
-        self.asm.push(Reg::X1);
-        self.asm.load_data_address(Reg::X0, top);
-        self.asm.ldr_imm(Reg::X1, Reg::X0, 0);
-        let ok = self.asm.new_label();
-        self.asm.branch(ok, BranchKind::CompareNonZero(Reg::X1));
-        self.asm
-            .emit_write_rodata(STDERR_FD, b"klassic gc: shadow stack underflow\n");
-        self.asm.emit_exit(1);
-        self.asm.bind(ok);
-        self.asm.sub_reg_imm(Reg::X1, Reg::X1, 1);
-        self.asm.str_imm(Reg::X1, Reg::X0, 0);
-        self.asm.pop(Reg::X1);
-        self.asm.pop(Reg::X0);
-        self.asm.ret();
+        let text = self
+            .asm
+            .intern_rodata(b"klassic gc: shadow stack underflow\n");
+        crate::portable_asm::emit_gc_shadow_pop_runtime(
+            &mut self.asm,
+            label,
+            PortDataAddr::Bss(top),
+            PortDataAddr::Rodata(text),
+            b"klassic gc: shadow stack underflow\n".len(),
+        );
     }
 
     /// M7: copy the string object in x0 onto the GC heap, leaving the copy

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -4236,16 +4236,14 @@ impl Emitter {
     /// list elements are boxed on write and unboxed on read (the uniform
     /// representation the shared enum lowering already uses).
     fn emit_box_scalar(&mut self) {
-        self.asm.push(Reg::X0); // preserve the scalar across the alloc
-        self.emit_gc_alloc_object(1, crate::gc_layout::GC_TYPE_RAW_BYTES);
-        self.asm.pop(Reg::X1);
-        self.asm.str_imm(Reg::X1, Reg::X0, 0); // [box] = scalar
+        let entry = self.gc_alloc_entry_label();
+        crate::portable_asm::emit_gc_box_scalar(&mut self.asm, entry);
     }
 
     /// Unbox a scalar: load it from the single-slot box whose user
     /// pointer is in x0.
     fn emit_unbox_scalar(&mut self) {
-        self.asm.ldr_imm(Reg::X0, Reg::X0, 0);
+        crate::portable_asm::emit_gc_unbox_scalar(&mut self.asm);
     }
 
     /// M7: colour a heap reference on its way into a heap slot --

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -4207,13 +4207,26 @@ impl Emitter {
     /// Null stays raw zero: `0 | colour` would be a bogus pointer, and the
     /// root scan and barriers all treat 0 as "nothing here".
     fn emit_color_ptr(&mut self, dst: Reg, src: Reg) {
-        let raw = self.asm.new_label();
         if dst != src {
             self.asm.mov_reg(dst, src);
         }
-        self.asm.branch(raw, BranchKind::CompareZero(dst));
-        self.asm.orr_reg(dst, dst, Reg::X25); // | good colour
-        self.asm.bind(raw);
+        // The colouring itself is the shared one: a heap slot holds a
+        // coloured pointer on every backend, and null stays raw on every
+        // backend, so the rule lives in one place.
+        let portable = match dst {
+            Reg::X0 => crate::portable_asm::Reg::V0,
+            Reg::X1 => crate::portable_asm::Reg::V1,
+            Reg::X2 => crate::portable_asm::Reg::V2,
+            Reg::X3 => crate::portable_asm::Reg::V3,
+            other => {
+                let raw = self.asm.new_label();
+                self.asm.branch(raw, BranchKind::CompareZero(other));
+                self.asm.orr_reg(other, other, Reg::X25);
+                self.asm.bind(raw);
+                return;
+            }
+        };
+        crate::portable_asm::emit_gc_colour_pointer(&mut self.asm, portable);
     }
 
     /// The two shadow-stack cells, reserved on first use.

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -2831,6 +2831,14 @@ impl Emitter {
                     return self.emit_enum_value(enum_index, tag, &[], *span);
                 }
                 let Some((offset, ty)) = self.lookup(name) else {
+                    // A builtin mentioned as a value rather than called:
+                    // `Process#exit != null` asks whether it is there, and it
+                    // is. Calling one through a name is a different path (an
+                    // alias), so the only thing this has to be is not null.
+                    if name.contains('#') {
+                        self.asm.mov_imm64(Reg::X0, 1);
+                        return Ok(ValueType::Ptr);
+                    }
                     return Err(unsupported(*span, &format!("identifier `{name}`")));
                 };
                 self.asm.load_local(Reg::X0, offset);
@@ -3937,8 +3945,25 @@ impl Emitter {
         } else {
             self.asm.pop(Reg::X0);
         }
-        if lhs_ty != rhs_ty {
+        // Asking whether a heap reference is `null` compares a pointer with
+        // nothing, so the two sides are different types by construction.
+        let comparing_with_null = matches!(op, BinaryOp::Equal | BinaryOp::NotEqual)
+            && ((lhs_ty == ValueType::Null && is_heap_pointer(rhs_ty))
+                || (rhs_ty == ValueType::Null && is_heap_pointer(lhs_ty)));
+        if lhs_ty != rhs_ty && !comparing_with_null {
             return Err(unsupported(span, "mixed operand types"));
+        }
+        if comparing_with_null {
+            self.asm.cmp_reg(Reg::X0, Reg::X1);
+            self.asm.cset(
+                Reg::X0,
+                if op == BinaryOp::Equal {
+                    Cond::Eq
+                } else {
+                    Cond::Ne
+                },
+            );
+            return Ok(ValueType::Bool);
         }
         if lhs_ty == ValueType::Str {
             return match op {

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -246,6 +246,21 @@ struct Assembler {
 /// The registers a barrier's slow path has to leave as it found them here.
 /// x10-x12 have no name in the portable register set, which is why this list
 /// lives on this side of the trait rather than in the shared routine.
+/// The same, around an allocation: x4/x5 carry the arguments, so they are not
+/// in this list, and x8 is (the barrier's field address is not live here).
+const ALLOC_SAVED: [Reg; 10] = [
+    Reg::X1,
+    Reg::X2,
+    Reg::X3,
+    Reg::X6,
+    Reg::X7,
+    Reg::X8,
+    Reg::X9,
+    Reg::X10,
+    Reg::X11,
+    Reg::X12,
+];
+
 const BARRIER_SAVED: [Reg; 11] = [
     Reg::X1,
     Reg::X2,
@@ -1230,6 +1245,16 @@ impl portable_asm::PortableAsm for Assembler {
     }
     fn restore_barrier_registers(&mut self) {
         for reg in BARRIER_SAVED.into_iter().rev() {
+            self.pop(reg);
+        }
+    }
+    fn save_alloc_registers(&mut self) {
+        for reg in ALLOC_SAVED {
+            self.push(reg);
+        }
+    }
+    fn restore_alloc_registers(&mut self) {
+        for reg in ALLOC_SAVED.into_iter().rev() {
             self.pop(reg);
         }
     }
@@ -4201,9 +4226,8 @@ impl Emitter {
     /// POINTER_RECORD (every payload slot a heap pointer), so the collector
     /// traces only the latter.
     fn emit_gc_alloc_object(&mut self, words: usize, tag: u64) {
-        self.asm.mov_imm64(Reg::X5, (words * 8) as u64); // payload bytes
-        self.asm.mov_imm64(Reg::X4, tag);
-        self.emit_gc_alloc_call(); // x0 = user pointer
+        let entry = self.gc_alloc_entry_label();
+        crate::portable_asm::emit_gc_alloc_object(&mut self.asm, entry, (words * 8) as u64, tag);
     }
 
     /// Box a scalar (in x0) into its own single-slot `RAW_BYTES` object,

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -4468,6 +4468,12 @@ struct NativeCodeGenerator {
     gc_oom_text: DataLabel,
     gc_worklist_overflow_text: DataLabel,
     gc_shadow_overflow_text: DataLabel,
+    gc_shadow_underflow_text: DataLabel,
+    /// The shared shadow-stack push and pop, called rather than inlined: the
+    /// protocol lives in `portable_asm` so both hand-emitted backends run the
+    /// same one.
+    gc_shadow_push: TextLabel,
+    gc_shadow_pop: TextLabel,
     gc_bounds_error_text: DataLabel,
     /// Lowest rsp the program may reach before the prologue probe
     /// aborts: initial rsp minus RLIMIT_STACK plus a safety margin,
@@ -4708,6 +4714,10 @@ impl NativeCodeGenerator {
             asm.data_label_with_bytes(b"klassic gc: mark worklist overflow\n");
         let gc_shadow_overflow_text =
             asm.data_label_with_bytes(b"klassic gc: shadow stack overflow\n");
+        let gc_shadow_underflow_text =
+            asm.data_label_with_bytes(b"klassic gc: shadow stack underflow\n");
+        let gc_shadow_push = asm.create_text_label();
+        let gc_shadow_pop = asm.create_text_label();
         let gc_bounds_error_text = asm.data_label_with_bytes(b"klassic gc: index out of bounds\n");
         let stack_floor = asm.data_label_with_i64s(&[0]);
         let stack_overflow_abort = asm.create_text_label();
@@ -4872,6 +4882,9 @@ impl NativeCodeGenerator {
             gc_oom_text,
             gc_worklist_overflow_text,
             gc_shadow_overflow_text,
+            gc_shadow_underflow_text,
+            gc_shadow_push,
+            gc_shadow_pop,
             gc_bounds_error_text,
             stack_floor,
             stack_overflow_abort,
@@ -5522,6 +5535,7 @@ impl NativeCodeGenerator {
         self.emit_gc_alloc_large_runtime();
         self.emit_gc_grow_budget_runtime();
         self.emit_gc_bounds_error_runtime();
+        self.emit_gc_shadow_runtime();
         if self.is_windows {
             self.emit_win_init_runtime();
             self.emit_win_write_runtime();
@@ -39484,6 +39498,33 @@ impl NativeCodeGenerator {
     /// fixed diagnostic and exits with status 1. The list / string
     /// builtins jump here directly when they detect an index outside
     /// the stored length range.
+    /// The shadow stack's push and pop, from the shared source both
+    /// hand-emitted backends use. Called rather than inlined: the sequence is
+    /// about twenty instructions and every rooted temporary needs one.
+    fn emit_gc_shadow_runtime(&mut self) {
+        let push = self.gc_shadow_push;
+        let pop = self.gc_shadow_pop;
+        let stack = self.gc_shadow_stack;
+        let top = self.gc_shadow_stack_top;
+        let overflow = self.gc_shadow_overflow_text;
+        let underflow = self.gc_shadow_underflow_text;
+        portable_asm::emit_gc_shadow_push_runtime(
+            self,
+            push,
+            stack,
+            top,
+            overflow,
+            b"klassic gc: shadow stack overflow\n".len(),
+        );
+        portable_asm::emit_gc_shadow_pop_runtime(
+            self,
+            pop,
+            top,
+            underflow,
+            b"klassic gc: shadow stack underflow\n".len(),
+        );
+    }
+
     fn emit_gc_bounds_error_runtime(&mut self) {
         // Migrated onto the portable `PortableAsm` emitter trait -- the
         // first GC routine to use its platform primitives. The control
@@ -39547,51 +39588,21 @@ impl NativeCodeGenerator {
     /// callers can use this immediately after computing a heap pointer
     /// without an extra spill.
     fn emit_gc_shadow_push(&mut self, rbp_offset: i32) {
-        let overflow = self.asm.create_text_label();
-        let success = self.asm.create_text_label();
-        // Save rax — most callers have the just-computed heap pointer in
-        // it and need to store it into the new slot after this returns.
+        // The routine takes the slot's address in rax and preserves every
+        // register it can see, so the caller only has to park its own rax --
+        // most callers have the just-computed heap pointer there.
         self.asm.push_reg(Reg::Rax);
-        self.asm.mov_data_addr(Reg::R10, self.gc_shadow_stack_top);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm
-            .cmp_reg_imm32(Reg::Rax, Self::GC_SHADOW_STACK_LEN as i32);
-        self.asm.jcc_label(Condition::AboveOrEqual, overflow);
-        self.asm.mov_data_addr(Reg::R8, self.gc_shadow_stack);
-        self.asm.load_ptr_disp32(Reg::R8, Reg::R8, 0);
-        self.asm.mov_reg_reg(Reg::R9, Reg::Rax);
-        self.asm.shl_reg_imm8(Reg::R9, 3);
-        self.asm.add_reg_reg(Reg::R8, Reg::R9);
-        // rbp moved by 8 due to push rax above; reflect that when forming
-        // the slot address.
-        self.asm.lea_reg_rbp_neg_disp32(Reg::Rcx, rbp_offset);
-        self.asm.store_ptr_disp32(Reg::R8, 0, Reg::Rcx);
-        self.asm.add_reg_imm32(Reg::Rax, 1);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.jmp_label(success);
-        self.asm.bind_text_label(overflow);
-        self.emit_write_data(
-            2,
-            self.gc_shadow_overflow_text,
-            b"klassic gc: shadow stack overflow\n".len(),
-        );
-        self.emit_exit_code(1);
-        self.asm.bind_text_label(success);
+        self.asm.lea_reg_rbp_neg_disp32(Reg::Rax, rbp_offset);
+        self.asm.call_label(self.gc_shadow_push);
         self.asm.pop_reg(Reg::Rax);
     }
 
     /// Emit `gc_shadow_top -= count` so a closing scope drops its
     /// tracked heap-pointer slots from the shadow stack in one shot.
     fn emit_gc_shadow_pop_n(&mut self, count: usize) {
-        if count == 0 {
-            return;
+        for _ in 0..count {
+            self.asm.call_label(self.gc_shadow_pop);
         }
-        self.asm.push_reg(Reg::Rax);
-        self.asm.mov_data_addr(Reg::R10, self.gc_shadow_stack_top);
-        self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
-        self.asm.sub_reg_imm32(Reg::Rax, count as i32);
-        self.asm.store_ptr_disp32(Reg::R10, 0, Reg::Rax);
-        self.asm.pop_reg(Reg::Rax);
     }
 
     fn push_temp_reg(&mut self, reg: Reg) {

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -13708,7 +13708,9 @@ impl NativeCodeGenerator {
         self.emit_non_negative_builtin_int_check(span, "__gc_alloc");
         self.emit_builtin_allocation_size_check(span, "__gc_alloc", Self::GC_MAX_PAYLOAD_SIZE);
         self.asm.mov_reg_reg(Reg::Rdi, Reg::Rax);
-        // Type tag 1 = "raw bytes" (no pointer fields).
+        // Type tag 1 = "raw bytes" (no pointer fields). The size is already
+        // in the argument register, so only the tag and the call come from
+        // the shared sequence here.
         self.asm.mov_imm64(Reg::Rsi, Self::GC_TYPE_RAW_BYTES);
         self.asm.call_label(self.gc_alloc);
         Ok(NativeValue::HeapPointer)

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -14672,11 +14672,7 @@ impl NativeCodeGenerator {
             // bogus non-null pointer; a genuine null stays a raw 0 (which
             // the load barrier passes through untouched). An Int/Double
             // value stored through this same funnel is left uncolored.
-            let store_raw = self.asm.create_text_label();
-            self.asm.test_reg_reg(Reg::Rax, Reg::Rax);
-            self.asm.jcc_label(Condition::Equal, store_raw);
-            self.asm.or_reg_reg(Reg::Rax, Reg::R14); // raw | good_color
-            self.asm.bind_text_label(store_raw);
+            portable_asm::emit_gc_colour_pointer(self, portable_asm::Reg::V0);
         }
         self.asm.store_ptr_disp32(Reg::Rcx, 0, Reg::Rax);
         self.pop_scope();

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -14443,7 +14443,7 @@ impl NativeCodeGenerator {
             let slow = self.gc_load_barrier_slow;
             // Nothing to save: the slow routine keeps what this backend's
             // callers hold.
-            portable_asm::emit_gc_load_barrier(self, slow, &[]);
+            portable_asm::emit_gc_load_barrier(self, slow);
         } else {
             self.asm.load_ptr_disp32(Reg::Rax, Reg::Rax, 0);
         }

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -14438,14 +14438,12 @@ impl NativeCodeGenerator {
             // so the register holds a raw (canonical) pointer. Only the
             // pointer-typed reads barrier -- an Int/Double read through
             // this same funnel must NOT strip (its high bits are data).
-            let ok = self.asm.create_text_label();
-            self.asm.mov_reg_reg(Reg::R10, Reg::Rax); // field addr
+            self.asm.mov_reg_reg(Reg::R10, Reg::Rax); // field addr, for self-heal
             self.asm.load_ptr_disp32(Reg::Rax, Reg::Rax, 0); // colored value
-            self.asm.test_reg_reg(Reg::Rax, Reg::R15); // bad color?
-            self.asm.jcc_label(Condition::Equal, ok);
-            self.asm.call_label(self.gc_load_barrier_slow);
-            self.asm.bind_text_label(ok);
-            self.asm.and_reg_reg(Reg::Rax, Reg::R13); // strip -> raw
+            let slow = self.gc_load_barrier_slow;
+            // Nothing to save: the slow routine keeps what this backend's
+            // callers hold.
+            portable_asm::emit_gc_load_barrier(self, slow, &[]);
         } else {
             self.asm.load_ptr_disp32(Reg::Rax, Reg::Rax, 0);
         }

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -7127,6 +7127,25 @@ impl NativeCodeGenerator {
                     return Err(unsupported(*span, "native assignment to this value type"));
                 }
                 let compiled = self.compile_expr(value)?;
+                // A binding that holds a heap string takes any other shape of
+                // string by lifting it onto the heap first -- which is what
+                // `t = replaceAll(t, ...)` in a loop produces, and refusing it
+                // refused the loop.
+                let compiled = if slot.value == NativeValue::HeapString
+                    && compiled != NativeValue::HeapString
+                    && self
+                        .emit_heap_string_concat_fragment(
+                            compiled,
+                            *span,
+                            "native assignment with changed value type",
+                            false,
+                        )
+                        .is_ok()
+                {
+                    NativeValue::HeapString
+                } else {
+                    compiled
+                };
                 if compiled != slot.value {
                     return Err(unsupported(
                         *span,
@@ -12222,7 +12241,9 @@ impl NativeCodeGenerator {
                 }
                 if self.expr_may_yield_runtime_string(&arguments[0]) {
                     let input = self.compile_expr(&arguments[0])?;
-                    if self.native_string_ref(input).is_some() {
+                    // A string is its own text, whichever shape of string it
+                    // is -- a heap one included.
+                    if self.native_string_ref(input).is_some() || input == NativeValue::HeapString {
                         return Ok(input);
                     }
                     return Err(unsupported(
@@ -12517,9 +12538,23 @@ impl NativeCodeGenerator {
             }
             "split" => {
                 self.expect_static_arity(name, arguments, 2, span)?;
-                if self.expr_may_yield_runtime_string(&arguments[0]) {
+                // A string this backend cannot work out while compiling is
+                // split at run time. `expr_may_yield_runtime_string` only sees
+                // the shapes it knows, so a text built by a *function* -- a
+                // heap string -- used to fall through to the static path and
+                // be refused; asking whether it previews to a static value
+                // covers both.
+                let input_is_static = {
+                    let before = self.static_scopes.clone();
+                    let preview = self.preview_static_value_after_effectful_eval(&arguments[0]);
+                    self.static_scopes = before;
+                    preview.is_some()
+                };
+                if self.expr_may_yield_runtime_string(&arguments[0]) || !input_is_static {
                     let input = self.compile_expr(&arguments[0])?;
-                    let Some(input) = self.native_string_ref(input) else {
+                    let Some(input) =
+                        self.native_string_ref_or_copy(input, span, "native split for non-string")
+                    else {
                         return Err(unsupported(span, "native split for non-string"));
                     };
                     if self.expr_may_yield_runtime_string(&arguments[1]) {
@@ -12570,11 +12605,24 @@ impl NativeCodeGenerator {
             }
             "trim" | "trimLeft" | "trimRight" | "toLowerCase" | "toUpperCase" | "reverse" => {
                 self.expect_static_arity(name, arguments, 1, span)?;
-                if matches!(name, "trim" | "trimLeft" | "trimRight")
-                    && self.expr_may_yield_runtime_string(&arguments[0])
-                {
+                // As in `split` and `replaceAll`: a text this backend cannot
+                // work out while compiling is handled at run time, whatever
+                // shape of string it turned out to be.
+                let input_is_static = {
+                    let before = self.static_scopes.clone();
+                    let preview = self.preview_static_value_after_effectful_eval(&arguments[0]);
+                    self.static_scopes = before;
+                    preview.is_some()
+                };
+                let runtime_input =
+                    self.expr_may_yield_runtime_string(&arguments[0]) || !input_is_static;
+                if matches!(name, "trim" | "trimLeft" | "trimRight") && runtime_input {
                     let input = self.compile_expr(&arguments[0])?;
-                    let Some(input) = self.native_string_ref(input) else {
+                    let Some(input) = self.native_string_ref_or_copy(
+                        input,
+                        span,
+                        &format!("native {name} for non-string"),
+                    ) else {
                         return Err(unsupported(span, &format!("native {name} for non-string")));
                     };
                     return Ok(self.emit_runtime_string_trim(
@@ -12584,18 +12632,24 @@ impl NativeCodeGenerator {
                         span,
                     ));
                 }
-                if matches!(name, "toLowerCase" | "toUpperCase")
-                    && self.expr_may_yield_runtime_string(&arguments[0])
-                {
+                if matches!(name, "toLowerCase" | "toUpperCase") && runtime_input {
                     let input = self.compile_expr(&arguments[0])?;
-                    let Some(input) = self.native_string_ref(input) else {
+                    let Some(input) = self.native_string_ref_or_copy(
+                        input,
+                        span,
+                        &format!("native {name} for non-string"),
+                    ) else {
                         return Err(unsupported(span, &format!("native {name} for non-string")));
                     };
                     return Ok(self.emit_runtime_string_ascii_case(input, name == "toUpperCase"));
                 }
-                if name == "reverse" && self.expr_may_yield_runtime_string(&arguments[0]) {
+                if name == "reverse" && runtime_input {
                     let input = self.compile_expr(&arguments[0])?;
-                    let Some(input) = self.native_string_ref(input) else {
+                    let Some(input) = self.native_string_ref_or_copy(
+                        input,
+                        span,
+                        "native reverse for non-string",
+                    ) else {
                         return Err(unsupported(span, "native reverse for non-string"));
                     };
                     return Ok(self.emit_runtime_string_reverse(input));
@@ -12615,9 +12669,22 @@ impl NativeCodeGenerator {
             }
             "replace" | "replaceAll" => {
                 self.expect_static_arity(name, arguments, 3, span)?;
-                if self.expr_may_yield_runtime_string(&arguments[0]) {
+                // As in `split`: a text this backend cannot work out while
+                // compiling is replaced at run time, whether or not it is one
+                // of the shapes `expr_may_yield_runtime_string` recognises.
+                let input_is_static = {
+                    let before = self.static_scopes.clone();
+                    let preview = self.preview_static_value_after_effectful_eval(&arguments[0]);
+                    self.static_scopes = before;
+                    preview.is_some()
+                };
+                if self.expr_may_yield_runtime_string(&arguments[0]) || !input_is_static {
                     let input = self.compile_expr(&arguments[0])?;
-                    let Some(input) = self.native_string_ref(input) else {
+                    let Some(input) = self.native_string_ref_or_copy(
+                        input,
+                        span,
+                        "native replace for non-string",
+                    ) else {
                         return Err(unsupported(span, "native replace for non-string"));
                     };
                     if name == "replace" {
@@ -30630,6 +30697,24 @@ impl NativeCodeGenerator {
                     && field == "split"
                 {
                     return self.expr_may_yield_runtime_string(target);
+                }
+                // The function spelling of the same thing. Only the method
+                // form was recognised, so `split(s, d)` -- which is how the
+                // stdlib writes it -- was not seen as producing lines, and an
+                // `if` with one in each branch had nothing to join them by.
+                if let Expr::Identifier { name, .. } = callee.as_ref()
+                    && self.builtin_name_for_identifier(name) == "split"
+                    && let Some(input) = arguments.first()
+                {
+                    // A heap string counts here even though it does not count
+                    // as a runtime string generally: what this answers is
+                    // "does splitting this produce lines", and it does. Saying
+                    // so generally would change what every other builtin makes
+                    // of a heap string.
+                    let heap_input = matches!(input, Expr::Identifier { name, .. }
+                        if self.lookup_var(name).map(|slot| slot.value)
+                            == Some(NativeValue::HeapString));
+                    return heap_input || self.expr_may_yield_runtime_string(input);
                 }
                 if let Some(name) = self.file_input_lines_print_call_name(expr) {
                     return matches!(name.as_str(), "FileInput#lines" | "FileInput#readLines")

--- a/crates/klassic-native/src/map_chain.rs
+++ b/crates/klassic-native/src/map_chain.rs
@@ -230,6 +230,19 @@ fn every_use_is_lowerable(expr: &Expr, prelude_len: usize, tracked: &HashSet<Str
             }
             every_use_is_lowerable(value, prelude_len, tracked)
         }
+        Expr::Foreach {
+            binding,
+            iterable,
+            body,
+            span,
+        } if is_user(*span, prelude_len)
+            && entries_call_map(iterable, tracked, prelude_len).is_some() =>
+        {
+            // The body may only read the entry's two halves; anything else
+            // done with it has no chain equivalent here.
+            body_uses_entry_only_as_halves(body, binding)
+                && every_use_is_lowerable(body, prelude_len, tracked)
+        }
         Expr::Call {
             callee, arguments, ..
         } => {
@@ -321,6 +334,90 @@ fn supported_call<'a>(
     }
 }
 
+/// `m.toPairs()` / `m.entries()` on a tracked map, answering with the map.
+fn entries_call_map<'a>(
+    expr: &'a Expr,
+    tracked: &HashSet<String>,
+    prelude_len: usize,
+) -> Option<&'a Expr> {
+    let Expr::Call {
+        callee, arguments, ..
+    } = expr
+    else {
+        return None;
+    };
+    if !arguments.is_empty() {
+        return None;
+    }
+    let Expr::FieldAccess { target, field, .. } = callee.as_ref() else {
+        return None;
+    };
+    if !matches!(field.as_str(), "toPairs" | "entries") {
+        return None;
+    }
+    match target.as_ref() {
+        Expr::Identifier { name, span }
+            if tracked.contains(name) && is_user(*span, prelude_len) =>
+        {
+            Some(target.as_ref())
+        }
+        _ => None,
+    }
+}
+
+/// Is the loop's entry binding only ever read as `.key` and `.value`?
+fn body_uses_entry_only_as_halves(body: &Expr, binding: &str) -> bool {
+    match body {
+        Expr::Identifier { name, .. } => name != binding,
+        Expr::FieldAccess { target, field, .. } => {
+            if matches!(target.as_ref(), Expr::Identifier { name, .. } if name == binding) {
+                return matches!(field.as_str(), "key" | "value");
+            }
+            body_uses_entry_only_as_halves(target, binding)
+        }
+        other => children(other)
+            .into_iter()
+            .all(|child| body_uses_entry_only_as_halves(child, binding)),
+    }
+}
+
+/// Replace `entry.key` / `entry.value` with the names the loop below binds.
+fn substitute_entry_halves(expr: Expr, binding: &str, key: &str, value: &str) -> Expr {
+    if let Expr::FieldAccess {
+        target,
+        field,
+        span,
+    } = &expr
+        && matches!(target.as_ref(), Expr::Identifier { name, .. } if name == binding)
+    {
+        let name = match field.as_str() {
+            "key" => Some(key),
+            "value" => Some(value),
+            _ => None,
+        };
+        if let Some(name) = name {
+            return Expr::Identifier {
+                name: name.to_string(),
+                span: *span,
+            };
+        }
+    }
+    match expr {
+        Expr::FieldAccess {
+            target,
+            field,
+            span,
+        } => Expr::FieldAccess {
+            target: Box::new(substitute_entry_halves(*target, binding, key, value)),
+            field,
+            span,
+        },
+        other => map_children(other, &mut |child| {
+            substitute_entry_halves(child, binding, key, value)
+        }),
+    }
+}
+
 fn call(name: &str, arguments: Vec<Expr>, span: Span) -> Expr {
     Expr::Call {
         callee: Box::new(Expr::Identifier {
@@ -332,12 +429,141 @@ fn call(name: &str, arguments: Vec<Expr>, span: Span) -> Expr {
     }
 }
 
+/// A block, for the loop the entry walk becomes.
+fn block(expressions: Vec<Expr>, span: Span) -> Expr {
+    Expr::Block { expressions, span }
+}
+
+fn ident(name: &str, span: Span) -> Expr {
+    Expr::Identifier {
+        name: name.to_string(),
+        span,
+    }
+}
+
+fn int(value: i64, span: Span) -> Expr {
+    Expr::Int {
+        value,
+        kind: klassic_syntax::IntLiteralKind::Int,
+        span,
+    }
+}
+
+/// `foreach (e in m.toPairs()) { body }` over a chain: walk the cells,
+/// binding each entry's halves to the names the body was rewritten to use.
+fn entry_walk(map: Expr, binding: &str, body: Expr, span: Span, index: usize) -> Expr {
+    let cur = format!("klassicMapCur{index}");
+    let go = format!("klassicMapGo{index}");
+    let key = format!("klassicMapKey{index}");
+    let value = format!("klassicMapValue{index}");
+    let rest = format!("klassicMapRest{index}");
+    let body = substitute_entry_halves(body, binding, &key, &value);
+    let cons_arm = MatchArm {
+        pattern: klassic_syntax::Pattern::Constructor {
+            name: "KlassicMapCons".to_string(),
+            args: vec![
+                klassic_syntax::Pattern::Variable {
+                    name: key.clone(),
+                    span,
+                },
+                klassic_syntax::Pattern::Variable {
+                    name: value.clone(),
+                    span,
+                },
+                klassic_syntax::Pattern::Variable {
+                    name: rest.clone(),
+                    span,
+                },
+            ],
+            span,
+        },
+        guard: None,
+        body: block(
+            vec![
+                body,
+                Expr::Assign {
+                    name: cur.clone(),
+                    value: Box::new(ident(&rest, span)),
+                    span,
+                },
+                int(0, span),
+            ],
+            span,
+        ),
+        span,
+    };
+    let nil_arm = MatchArm {
+        pattern: klassic_syntax::Pattern::Constructor {
+            name: "KlassicMapNil".to_string(),
+            args: Vec::new(),
+            span,
+        },
+        guard: None,
+        body: block(
+            vec![
+                Expr::Assign {
+                    name: go.clone(),
+                    value: Box::new(Expr::Bool { value: false, span }),
+                    span,
+                },
+                int(0, span),
+            ],
+            span,
+        ),
+        span,
+    };
+    block(
+        vec![
+            Expr::VarDecl {
+                mutable: true,
+                name: cur.clone(),
+                annotation: None,
+                value: Box::new(map),
+                span,
+            },
+            Expr::VarDecl {
+                mutable: true,
+                name: go.clone(),
+                annotation: None,
+                value: Box::new(Expr::Bool { value: true, span }),
+                span,
+            },
+            Expr::While {
+                condition: Box::new(ident(&go, span)),
+                body: Box::new(Expr::Match {
+                    scrutinee: Box::new(ident(&cur, span)),
+                    arms: vec![nil_arm, cons_arm],
+                    span,
+                }),
+                span,
+            },
+        ],
+        span,
+    )
+}
+
 fn rewrite(expr: Expr, prelude_len: usize, tracked: &HashSet<String>) -> Expr {
     let names_tracked_map = |expr: &Expr| {
         matches!(expr, Expr::Identifier { name, span }
             if tracked.contains(name) && is_user(*span, prelude_len))
     };
     match expr {
+        Expr::Foreach {
+            binding,
+            iterable,
+            body,
+            span,
+        } if is_user(span, prelude_len)
+            && entries_call_map(&iterable, tracked, prelude_len).is_some() =>
+        {
+            let map = entries_call_map(&iterable, tracked, prelude_len)
+                .expect("checked just above")
+                .clone();
+            let body = rewrite(*body, prelude_len, tracked);
+            // The names are keyed by where the loop is, so nested walks in one
+            // program do not shadow each other.
+            entry_walk(map, &binding, body, span, span.start)
+        }
         Expr::Call {
             callee,
             arguments,
@@ -596,6 +822,58 @@ fn map_children(expr: Expr, f: &mut impl FnMut(Expr) -> Expr) -> Expr {
                     span: arm.span,
                 })
                 .collect(),
+            span,
+        },
+        Expr::Call {
+            callee,
+            arguments,
+            span,
+        } => Expr::Call {
+            callee: Box::new(f(*callee)),
+            arguments: arguments.into_iter().map(&mut *f).collect(),
+            span,
+        },
+        Expr::FieldAccess {
+            target,
+            field,
+            span,
+        } => Expr::FieldAccess {
+            target: Box::new(f(*target)),
+            field,
+            span,
+        },
+        Expr::RecordConstructor {
+            name,
+            arguments,
+            span,
+        } => Expr::RecordConstructor {
+            name,
+            arguments: arguments.into_iter().map(&mut *f).collect(),
+            span,
+        },
+        Expr::RecordLiteral { fields, span } => Expr::RecordLiteral {
+            fields: fields
+                .into_iter()
+                .map(|(name, value)| (name, f(value)))
+                .collect(),
+            span,
+        },
+        Expr::MapLiteral { entries, span } => Expr::MapLiteral {
+            entries: entries
+                .into_iter()
+                .map(|(key, value)| (f(key), f(value)))
+                .collect(),
+            span,
+        },
+        Expr::Lambda {
+            params,
+            param_annotations,
+            body,
+            span,
+        } => Expr::Lambda {
+            params,
+            param_annotations,
+            body: Box::new(f(*body)),
             span,
         },
         Expr::ListLiteral { elements, span } => Expr::ListLiteral {

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -471,6 +471,28 @@ pub fn emit_gc_alloc_object<E: PortableAsm>(
     out.restore_alloc_registers();
 }
 
+/// Box a scalar into its own single-slot `RAW_BYTES` object, scalar in `V0`
+/// and the box's user pointer out in `V0`.
+///
+/// Every slot of a `POINTER_RECORD` has to hold a pointer, so a scalar record
+/// field or list element is boxed on the way in and unboxed on the way out.
+/// That uniform representation is the collector's, not one backend's: it is
+/// what lets the mark phase walk a record without knowing what its fields
+/// mean.
+pub fn emit_gc_box_scalar<E: PortableAsm>(out: &mut E, entry: E::TextLabel) {
+    out.push_reg(Reg::V0); // the scalar, across the allocation
+    emit_gc_alloc_object(out, entry, 8, crate::gc_layout::GC_TYPE_RAW_BYTES);
+    out.pop_reg(Reg::V1);
+    out.store_ptr_disp32(Reg::V0, 0, Reg::V1);
+}
+
+/// Read a scalar back out of its box: the box's user pointer in `V0`, the
+/// scalar out in `V0`. The counterpart of `emit_gc_box_scalar`, and the
+/// reason it is here is the same -- the layout is the collector's.
+pub fn emit_gc_unbox_scalar<E: PortableAsm>(out: &mut E) {
+    out.load_ptr_disp32(Reg::V0, Reg::V0, 0);
+}
+
 /// The load barrier's fast path, around the shared slow routine.
 ///
 /// Three stages, and all three are policy rather than machinery: a value

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -501,9 +501,11 @@ pub fn emit_gc_shadow_pop_runtime<E: PortableAsm>(
     out.push_reg(Reg::V1);
     out.mov_data_addr(Reg::V0, shadow_stack_top);
     out.load_ptr_disp32(Reg::V1, Reg::V0, 0);
+    // Compared against an immediate rather than through a scratch register:
+    // this routine promises to preserve every register the caller can see,
+    // and it has only saved the two it uses.
     let ok = out.create_text_label();
-    out.mov_imm64(Reg::V2, 0);
-    out.cmp_reg_reg(Reg::V1, Reg::V2);
+    out.cmp_reg_imm8(Reg::V1, 0);
     out.jcc_label(Condition::NotEqual, ok);
     out.plat_write_data(2, underflow_text, underflow_text_len);
     out.plat_exit(1);

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -151,6 +151,11 @@ pub trait PortableAsm {
     fn save_barrier_registers(&mut self) {}
     fn restore_barrier_registers(&mut self) {}
 
+    /// The same, around an allocation. A different list from the barrier's:
+    /// the allocation's own arguments are live where the barrier's are not.
+    fn save_alloc_registers(&mut self) {}
+    fn restore_alloc_registers(&mut self) {}
+
     fn plat_write_data(&mut self, fd: u64, data: Self::DataLabel, len: usize);
     /// Terminate the process with status `code` (does not return).
     fn plat_exit(&mut self, code: u64);
@@ -446,6 +451,26 @@ pub fn emit_gc_grow_budget<E: PortableAsm>(
 /// (`plat_write_data` / `plat_exit`): the routine's control flow is
 /// architecture-independent, while each backend's impl chooses the actual
 /// OS interface (Linux/macOS `syscall` vs Windows shim `call`).
+/// Ask the collector for an object: a 16-byte header `[size|mark][type_tag]`
+/// followed by `payload_bytes` of payload, answered as the *user* pointer in
+/// `V0` (the block plus the header), so every payload access is unchanged.
+///
+/// The argument registers are the shared `gc_alloc`'s own -- `V7` the size
+/// and `V6` the tag -- which is why this can be written once. What a backend
+/// needs kept across the call is asked of it, as with the barrier.
+pub fn emit_gc_alloc_object<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    payload_bytes: u64,
+    tag: u64,
+) {
+    out.mov_imm64(Reg::V7, payload_bytes);
+    out.mov_imm64(Reg::V6, tag);
+    out.save_alloc_registers();
+    out.call_label(entry);
+    out.restore_alloc_registers();
+}
+
 /// The load barrier's fast path, around the shared slow routine.
 ///
 /// Three stages, and all three are policy rather than machinery: a value

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -141,6 +141,16 @@ pub trait PortableAsm {
     // future ARM-Linux `svc`), so that per-OS emission stays inside the
     // impl and never leaks into the portable GC code that calls them.
     /// Write `len` bytes at data label `data` to file descriptor `fd`.
+    /// Save whatever this backend needs kept across the load barrier's slow
+    /// path, and restore it. The policy around the call is shared; *which
+    /// registers a backend has live there* is the one genuinely
+    /// platform-specific part of it, and three of the aarch64 ones have no
+    /// name in the portable register set. The default is to save nothing,
+    /// which is what a backend whose slow routine already keeps what its
+    /// callers hold wants.
+    fn save_barrier_registers(&mut self) {}
+    fn restore_barrier_registers(&mut self) {}
+
     fn plat_write_data(&mut self, fd: u64, data: Self::DataLabel, len: usize);
     /// Terminate the process with status `code` (does not return).
     fn plat_exit(&mut self, code: u64);
@@ -446,20 +456,15 @@ pub fn emit_gc_grow_budget<E: PortableAsm>(
 ///
 /// The value is in `V0` and the field's address is wherever the slow routine
 /// expects it -- the caller puts it there, since that is the one part of this
-/// that differs. `saved` is what the caller needs kept across the call: the
-/// slow routine preserves what the x86-64 backend cares about, and the
-/// aarch64 backend names the rest.
-pub fn emit_gc_load_barrier<E: PortableAsm>(out: &mut E, slow: E::TextLabel, saved: &[Reg]) {
+/// that differs. What has to be kept across the call is asked of the backend
+/// (`save_barrier_registers`), because that is the other part.
+pub fn emit_gc_load_barrier<E: PortableAsm>(out: &mut E, slow: E::TextLabel) {
     let ok = out.create_text_label();
     out.test_reg_reg(Reg::V0, Reg::BadMask);
     out.jcc_label(Condition::Equal, ok);
-    for reg in saved {
-        out.push_reg(*reg);
-    }
+    out.save_barrier_registers();
     out.call_label(slow);
-    for reg in saved.iter().rev() {
-        out.pop_reg(*reg);
-    }
+    out.restore_barrier_registers();
     out.bind_text_label(ok);
     out.and_reg_reg(Reg::V0, Reg::ColorStrip);
 }

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -436,6 +436,23 @@ pub fn emit_gc_grow_budget<E: PortableAsm>(
 /// (`plat_write_data` / `plat_exit`): the routine's control flow is
 /// architecture-independent, while each backend's impl chooses the actual
 /// OS interface (Linux/macOS `syscall` vs Windows shim `call`).
+/// Colour a pointer on its way into a heap slot.
+///
+/// A heap slot holds a *coloured* pointer, which is what makes the load
+/// barrier able to tell a stale reference from a current one. Null is left
+/// alone: `0 | good_colour` would be a bogus non-null pointer, and a genuine
+/// null has to stay a raw zero for the barrier to pass it through.
+///
+/// Emitted inline rather than called -- it is three instructions, and every
+/// store of a reference needs it.
+pub fn emit_gc_colour_pointer<E: PortableAsm>(out: &mut E, reg: Reg) {
+    let raw = out.create_text_label();
+    out.test_reg_reg(reg, reg);
+    out.jcc_label(Condition::Equal, raw);
+    out.or_reg_reg(reg, Reg::GoodColor);
+    out.bind_text_label(raw);
+}
+
 /// The shadow stack's push, as one routine both backends call.
 ///
 /// The protocol is the whole point of sharing it: a root is the *address* of

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -436,6 +436,34 @@ pub fn emit_gc_grow_budget<E: PortableAsm>(
 /// (`plat_write_data` / `plat_exit`): the routine's control flow is
 /// architecture-independent, while each backend's impl chooses the actual
 /// OS interface (Linux/macOS `syscall` vs Windows shim `call`).
+/// The load barrier's fast path, around the shared slow routine.
+///
+/// Three stages, and all three are policy rather than machinery: a value
+/// whose colour is *bad* has to go through the slow path, everything else is
+/// current, and either way the colour is stripped so the register holds a
+/// canonical pointer. Written once, the two backends cannot disagree about
+/// which mask means bad or which one strips.
+///
+/// The value is in `V0` and the field's address is wherever the slow routine
+/// expects it -- the caller puts it there, since that is the one part of this
+/// that differs. `saved` is what the caller needs kept across the call: the
+/// slow routine preserves what the x86-64 backend cares about, and the
+/// aarch64 backend names the rest.
+pub fn emit_gc_load_barrier<E: PortableAsm>(out: &mut E, slow: E::TextLabel, saved: &[Reg]) {
+    let ok = out.create_text_label();
+    out.test_reg_reg(Reg::V0, Reg::BadMask);
+    out.jcc_label(Condition::Equal, ok);
+    for reg in saved {
+        out.push_reg(*reg);
+    }
+    out.call_label(slow);
+    for reg in saved.iter().rev() {
+        out.pop_reg(*reg);
+    }
+    out.bind_text_label(ok);
+    out.and_reg_reg(Reg::V0, Reg::ColorStrip);
+}
+
 /// Colour a pointer on its way into a heap slot.
 ///
 /// A heap slot holds a *coloured* pointer, which is what makes the load

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -436,6 +436,85 @@ pub fn emit_gc_grow_budget<E: PortableAsm>(
 /// (`plat_write_data` / `plat_exit`): the routine's control flow is
 /// architecture-independent, while each backend's impl chooses the actual
 /// OS interface (Linux/macOS `syscall` vs Windows shim `call`).
+/// The shadow stack's push, as one routine both backends call.
+///
+/// The protocol is the whole point of sharing it: a root is the *address* of
+/// a slot, so the collector can rewrite what the slot holds when it moves an
+/// object; the table has a fixed length and overflowing it is fatal rather
+/// than silent. Written once here, the two backends cannot drift on either.
+///
+/// Called with the slot's address in the first argument register. Preserves
+/// every register the caller can see.
+pub fn emit_gc_shadow_push_runtime<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    shadow_stack: E::DataLabel,
+    shadow_stack_top: E::DataLabel,
+    overflow_text: E::DataLabel,
+    overflow_text_len: usize,
+) {
+    use crate::gc_layout::GC_SHADOW_STACK_LEN;
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V1);
+    out.push_reg(Reg::V2);
+    out.push_reg(Reg::V3);
+    out.mov_data_addr(Reg::V2, shadow_stack_top);
+    out.load_ptr_disp32(Reg::V3, Reg::V2, 0);
+    let ok = out.create_text_label();
+    out.mov_imm64(Reg::V1, GC_SHADOW_STACK_LEN as u64);
+    out.cmp_reg_reg(Reg::V3, Reg::V1);
+    out.jcc_label(Condition::Below, ok);
+    out.plat_write_data(2, overflow_text, overflow_text_len);
+    out.plat_exit(1);
+    out.bind_text_label(ok);
+    out.mov_data_addr(Reg::V1, shadow_stack);
+    out.load_ptr_disp32(Reg::V1, Reg::V1, 0);
+    out.shl_reg_imm8(Reg::V3, 3);
+    out.add_reg_reg(Reg::V1, Reg::V3);
+    out.store_ptr_disp32(Reg::V1, 0, Reg::V0);
+    out.load_ptr_disp32(Reg::V3, Reg::V2, 0);
+    out.add_reg_imm32(Reg::V3, 1);
+    out.store_ptr_disp32(Reg::V2, 0, Reg::V3);
+    out.pop_reg(Reg::V3);
+    out.pop_reg(Reg::V2);
+    out.pop_reg(Reg::V1);
+    out.ret();
+}
+
+/// The shadow stack's pop, as one routine both backends call.
+///
+/// The underflow check is a self-test of the root bookkeeping: pushes and
+/// pops have to balance on every path through every function, and an
+/// imbalance is otherwise silent -- a leaked root, or a negative top that
+/// makes the next push write outside the table. Aborting turns any mismatch
+/// into an immediate failure instead of a rare corruption once the collector
+/// is live.
+pub fn emit_gc_shadow_pop_runtime<E: PortableAsm>(
+    out: &mut E,
+    entry: E::TextLabel,
+    shadow_stack_top: E::DataLabel,
+    underflow_text: E::DataLabel,
+    underflow_text_len: usize,
+) {
+    out.bind_text_label(entry);
+    out.push_reg(Reg::V0);
+    out.push_reg(Reg::V1);
+    out.mov_data_addr(Reg::V0, shadow_stack_top);
+    out.load_ptr_disp32(Reg::V1, Reg::V0, 0);
+    let ok = out.create_text_label();
+    out.mov_imm64(Reg::V2, 0);
+    out.cmp_reg_reg(Reg::V1, Reg::V2);
+    out.jcc_label(Condition::NotEqual, ok);
+    out.plat_write_data(2, underflow_text, underflow_text_len);
+    out.plat_exit(1);
+    out.bind_text_label(ok);
+    out.sub_reg_imm32(Reg::V1, 1);
+    out.store_ptr_disp32(Reg::V0, 0, Reg::V1);
+    out.pop_reg(Reg::V1);
+    out.pop_reg(Reg::V0);
+    out.ret();
+}
+
 pub fn emit_gc_bounds_error<E: PortableAsm>(
     out: &mut E,
     entry: E::TextLabel,

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1800,6 +1800,25 @@ taking `List<'a>`, and a recursive function is compiled once, so its
 parameter kinds have to be fixed. That one wants monomorphisation of
 recursive generic definitions.
 
+### The shadow stack, written once
+
+The 24 GC runtime routines have been emitted through `PortableAsm` since
+#600, but the *mutator* side -- the sequences a compiled program runs to push
+a root, drop one, load through the barrier, colour a store -- was written
+twice, once per hand-emitted backend. The shadow stack's push and pop are the
+first of those to move: `emit_gc_shadow_push_runtime` and
+`emit_gc_shadow_pop_runtime` in `portable_asm.rs` are now the single source
+of the protocol -- a root is the *address* of a slot so the collector can
+rewrite it when it moves an object, the table has a fixed length, and
+overflowing or underflowing it is fatal rather than silent. The aarch64
+backend calls them; the x86-64 backend still inlines its own copies, which is
+the next thing to fold in.
+
+The underflow check is worth keeping in the shared version: pushes and pops
+have to balance on every path through every function, an imbalance is
+otherwise invisible, and it is what caught `Set#add` rooting its slots on one
+side of a branch.
+
 ## Design Notes
 
 - The direct evaluator is the current execution engine.

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1749,10 +1749,36 @@ one per concern:
   the same offset in the next -- which is what refused `acc = KMCons(...)` on
   aarch64.
 
+#### `words()`, and walking a map's entries
+
+`words()` used to filter the pieces a split leaves behind, which means
+building a list while the program runs -- the one thing the x86-64 backend
+cannot do. It collapses runs of whitespace in the *text* instead, so the
+split leaves no empty pieces and no list is built, and the answer is the same
+list for every input (checked against the old implementation case by case).
+Text with nothing in it has no words, which is why `splitWords` splits on the
+empty delimiter there: both branches of the `if` then produce lines, which is
+what a backend needs to join them.
+
+Four string builtins had to stop insisting on a text known while compiling:
+`split`, `replace`/`replaceAll`, `trim` and its neighbours all take a heap
+string now, copying it into a scratch buffer the way the environment-key path
+already did. A binding that holds a heap string also takes any other shape of
+string, by lifting it onto the heap first -- which is what
+`t = replaceAll(t, ...)` in a loop produces.
+
+`foreach (e in m.toPairs())` over a lowered map becomes a walk over the
+chain, with the entry's halves bound directly and `e.key` / `e.value`
+rewritten to those bindings. A body that does anything else with the entry
+leaves the program alone, like every other case the pass does not cover.
+
+With those, every recipe in the cookbook builds on all three targets.
+
 What is still not lowered: a map that is *only* created and never put into
 keeps every payload type unknown, so asking it about a key is refused --
-there is nothing in it to say what its keys are. And `words()` over a runtime
-list is a different piece: `stdlibFilter` is a *recursive* generic function
+there is nothing in it to say what its keys are. A general runtime list is
+still not built on x86-64, which is why the lowering above rewrites
+`words()` rather than the filter it used to call: `stdlibFilter` is a *recursive* generic function
 taking `List<'a>`, and a recursive function is compiled once, so its
 parameter kinds have to be fixed. That one wants monomorphisation of
 recursive generic definitions.

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1832,6 +1832,20 @@ shared. That division -- policy in the shared routine, register allocation in
 the backend -- is the one to reach for whenever the next piece looks
 unportable.
 
+Asking the collector for an object folded next, on the same pattern. The
+argument registers were already agreed -- the shared `gc_alloc` reads the size
+from `V7` and the tag from `V6` -- so `emit_gc_alloc_object` is the sequence
+around them: put the two arguments in place, keep what this backend needs,
+call. The aarch64 list differs from the barrier's, which is the point of
+asking the backend rather than hard-coding one: x4/x5 carry the arguments
+here and x8 is live where it was not.
+
+So the mutator's side of the collector now reads the same on both: root push
+and pop, colour on store, the load barrier's three stages, and the allocation
+call. What is left is boxing a scalar into its own one-slot object and
+unboxing it -- a `RAW_BYTES` allocation plus a store, and a load -- which is
+the same shape again.
+
 Colour-on-store also folded: a heap slot holds a coloured pointer on both
 backends and null stays raw on both, so `emit_gc_colour_pointer` is that rule
 written once. It is emitted inline rather than called -- three instructions,

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1811,8 +1811,10 @@ first of those to move: `emit_gc_shadow_push_runtime` and
 of the protocol -- a root is the *address* of a slot so the collector can
 rewrite it when it moves an object, the table has a fixed length, and
 overflowing or underflowing it is fatal rather than silent. The aarch64
-backend calls them; the x86-64 backend still inlines its own copies, which is
-the next thing to fold in.
+backend calls them, and so does the x86-64 one -- which used to inline the
+whole sequence, about twenty instructions, at every rooted temporary. A call
+site is four instructions now (park rax, form the slot address, call, restore),
+and the overflow check exists once in the image instead of once per push.
 
 The underflow check is worth keeping in the shared version: pushes and pops
 have to balance on every path through every function, an imbalance is

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1774,6 +1774,23 @@ leaves the program alone, like every other case the pass does not cover.
 
 With those, every recipe in the cookbook builds on all three targets.
 
+#### `distinct`, and a builtin as a value
+
+`distinct` was a recursive filter, which no backend that compiles a function
+once can take -- a `List<'a>` parameter has no single shape to compile it
+for. A set keeps the first occurrence of each element in order, which is
+exactly what `distinct` answers, so it is `Set#toList(Set#fromList(xs))` now:
+two builtins every backend already has, and no list is built while the
+program runs.
+
+A builtin mentioned rather than called -- `Process#exit != null` -- is a
+value on aarch64 now, and comparing a heap reference with `null` is allowed
+there: the two sides are different types by construction, which is why the
+comparison was refused.
+
+With those, no probe in the corpora and no recipe in the cookbook builds on
+one target and not another.
+
 What is still not lowered: a map that is *only* created and never put into
 keeps every payload type unknown, so asking it about a key is refused --
 there is nothing in it to say what its keys are. A general runtime list is

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1840,11 +1840,22 @@ call. The aarch64 list differs from the barrier's, which is the point of
 asking the backend rather than hard-coding one: x4/x5 carry the arguments
 here and x8 is live where it was not.
 
-So the mutator's side of the collector now reads the same on both: root push
-and pop, colour on store, the load barrier's three stages, and the allocation
-call. What is left is boxing a scalar into its own one-slot object and
-unboxing it -- a `RAW_BYTES` allocation plus a store, and a load -- which is
-the same shape again.
+Boxing finished the inventory. A scalar in a `POINTER_RECORD` slot is a
+one-slot `RAW_BYTES` object, because the mark phase has to be able to walk a
+record without knowing what its fields mean -- that layout is the
+collector's, not one backend's, so `emit_gc_box_scalar` and
+`emit_gc_unbox_scalar` are where it is written. (The x86-64 backend boxes
+through the shared enum lowering's AST rather than a machine-level helper, so
+it does not emit these today; they are here because the *representation* is
+shared, and a backend that needs the sequence should not invent its own.)
+
+So the mutator's side of the collector reads the same on both backends now:
+root push and pop, colour on store, the load barrier's three stages, the
+allocation call, and boxing. What stays per backend is the register
+allocation around them -- which registers are live across a call -- asked for
+through two pairs of trait methods, and the instruction encodings themselves.
+That is the line the goal was after: the collector's rules in one place, the
+machine's conventions in the backend.
 
 Colour-on-store also folded: a heap slot holds a coloured pointer on both
 backends and null stays raw on both, so `emit_gc_colour_pointer` is that rule

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1816,14 +1816,21 @@ whole sequence, about twenty instructions, at every rooted temporary. A call
 site is four instructions now (park rax, form the slot address, call, restore),
 and the overflow check exists once in the image instead of once per push.
 
-The load barrier's fast path followed for x86-64: test the colour, take the
+The load barrier's fast path followed, on both: test the colour, take the
 slow path when it is bad, strip either way. All three are policy rather than
-machinery, and `emit_gc_load_barrier` is where they live now. The aarch64
-backend still emits its own -- not because the policy differs, but because it
-saves ten registers around the call and three of them (x10-x12) have no name
-in the portable register set. Naming them, or giving the shared routine the
-job of preserving them, is what would let that call site fold in too; the
-save list is the platform-specific part, and it is the only part left there.
+machinery, and `emit_gc_load_barrier` is where they live now.
+
+What kept aarch64 out at first is worth recording, because it is the shape of
+the remaining work. Its call site saves eleven registers around the slow
+path, and three of them (x10-x12) have no name in the portable register set --
+which cannot simply grow, since the portable names *are* the x86-64 register
+file and it is full. Expressing the list in portable names silently saved the
+wrong physical registers. So the list stays on the backend's side of the
+trait, behind `save_barrier_registers` / `restore_barrier_registers`: what to
+keep live is genuinely platform-specific, while everything around it is
+shared. That division -- policy in the shared routine, register allocation in
+the backend -- is the one to reach for whenever the next piece looks
+unportable.
 
 Colour-on-store also folded: a heap slot holds a coloured pointer on both
 backends and null stays raw on both, so `emit_gc_colour_pointer` is that rule

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1816,6 +1816,11 @@ whole sequence, about twenty instructions, at every rooted temporary. A call
 site is four instructions now (park rax, form the slot address, call, restore),
 and the overflow check exists once in the image instead of once per push.
 
+Colour-on-store followed: a heap slot holds a coloured pointer on both
+backends and null stays raw on both, so `emit_gc_colour_pointer` is that rule
+written once. It is emitted inline rather than called -- three instructions,
+and every store of a reference needs it.
+
 The underflow check is worth keeping in the shared version: pushes and pops
 have to balance on every path through every function, an imbalance is
 otherwise invisible, and it is what caught `Set#add` rooting its slots on one

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1816,7 +1816,16 @@ whole sequence, about twenty instructions, at every rooted temporary. A call
 site is four instructions now (park rax, form the slot address, call, restore),
 and the overflow check exists once in the image instead of once per push.
 
-Colour-on-store followed: a heap slot holds a coloured pointer on both
+The load barrier's fast path followed for x86-64: test the colour, take the
+slow path when it is bad, strip either way. All three are policy rather than
+machinery, and `emit_gc_load_barrier` is where they live now. The aarch64
+backend still emits its own -- not because the policy differs, but because it
+saves ten registers around the call and three of them (x10-x12) have no name
+in the portable register set. Naming them, or giving the shared routine the
+job of preserving them, is what would let that call site fold in too; the
+save list is the platform-specific part, and it is the only part left there.
+
+Colour-on-store also folded: a heap slot holds a coloured pointer on both
 backends and null stays raw on both, so `emit_gc_colour_pointer` is that rule
 written once. It is emitted inline rather than called -- three instructions,
 and every store of a reference needs it.

--- a/docs/book/src/cookbook/word-count.md
+++ b/docs/book/src/cookbook/word-count.md
@@ -3,10 +3,9 @@
 Read a file, count how many times each word appears, print the
 result. Demonstrates file I/O, string splitting, and `Map<String,
 Int>` from `std.map` — Klassic's automatic GC means none of this
-touches a heap pointer directly. Run it with the evaluator
-(`klassic wc.kl -- <path>`); building `Map#put`/`Map#empty` to a
-native executable is on the native compiler's coverage roadmap, not
-supported yet.
+touches a heap pointer directly. Runs under the evaluator
+(`klassic wc.kl -- <path>`) and builds to a native executable on every
+target.
 
 ```kl
 val args = CommandLine#args()

--- a/stdlib/std/list.kl
+++ b/stdlib/std/list.kl
@@ -58,7 +58,14 @@ def indexOfFrom(xs, x, i) = if(isEmpty(xs)) (0 - 1) else if(head(xs) == x) i els
 def indexOf(xs, x) = indexOfFrom(xs, x, 0)
 
 // Drop later duplicates, keeping each element's first occurrence.
-def distinct(xs) = if(isEmpty(xs)) [] else cons(head(xs))(distinct(filter(tail(xs), (y) => y != head(xs))))
+// Keep the first occurrence of each element, in order -- which is what a set
+// keeps, so this is a set round trip rather than a recursive filter.
+//
+// The recursion it replaces could not be compiled by every native backend: a
+// recursive function has to be compiled once, and a `List<'a>` parameter has
+// no single shape to compile it for. `Set#fromList` and `Set#toList` are
+// builtins on every backend.
+def distinct(xs: List<'a>): List<'a> = Set#toList(Set#fromList(xs))
 
 // ---------- flatten ---------------------------------------------------------
 

--- a/stdlib/std/string.kl
+++ b/stdlib/std/string.kl
@@ -5,6 +5,29 @@ module std.string
 // in dot-notation — no naming conflict with the existing top-level
 // `length` / `trim` / ... builtins.
 
+// Collapse runs of spaces to one, so a split on " " leaves no empty pieces.
+//
+// Written as a loop over the text rather than as a filter over the split
+// pieces: filtering means building a list while the program runs, which not
+// every native backend can do, while replacing inside a string is something
+// they all can. The result is the same list `stdlibFilter` produced.
+// Split text that has already had its whitespace runs collapsed. Text with
+// nothing in it has no words -- `split` would answer with one empty piece,
+// and the filter this replaced dropped it.
+// Both branches split, so the two answers have the same shape wherever a
+// backend cares: splitting nothing on nothing is the empty list.
+def splitWords(s: String): List<String> = if(isEmptyString(s)) split(s, "") else split(s, " ")
+
+def collapseSpaceRuns(s: String): String = {
+  mutable t = s
+  mutable prev = ""
+  mutable go = true
+  while (go) {
+    if (t == prev) { go = false; 0 } else { prev = t; t = replaceAll(t, "  ", " "); 0 }
+  }
+  t
+}
+
 extension (this: String) {
   def isEmpty() = isEmptyString(this)
   def nonEmpty() = if(isEmptyString(this)) false else true
@@ -16,7 +39,7 @@ extension (this: String) {
   // more than one line, and a `words` that only knew about `" "` returned
   // "fox\nthe" as a single word. Written as one expression rather than with an
   // intermediate binding, which is what keeps it foldable in a native build.
-  def words() = stdlibFilter(split(replaceAll(replaceAll(replaceAll(this, "\n", " "), "\t", " "), "\r", " "), " "), (w) => if(isEmptyString(w)) false else true)
+  def words() = splitWords(collapseSpaceRuns(trim(replaceAll(replaceAll(replaceAll(this, "\n", " "), "\t", " "), "\r", " "))))
   def lengthChars() = length(this)
   def reverseChars() = reverse(this)
   def upper() = toUpperCase(this)

--- a/tests/cross-exec/34-words-and-entry-walk.kl
+++ b/tests/cross-exec/34-words-and-entry-walk.kl
@@ -1,0 +1,48 @@
+// Cross-target fixture: splitting text into words, and walking a map's
+// entries -- the two halves of the word counter.
+//
+// `words()` used to need a filter over the pieces a split leaves behind,
+// which means building a list while the program runs; it collapses runs of
+// whitespace in the *text* instead, so the split leaves no empty pieces and
+// no list has to be built. The cases below are the ones that distinguish the
+// two: repeated separators, tabs and newlines, and text that is only
+// whitespace.
+//
+// The entry walk is `foreach (e in m.toPairs())` over a map grown at run
+// time. It becomes a walk over the chain the map was lowered to, with the
+// entry's halves bound directly, so the order it visits is the map's
+// insertion order.
+
+import std.map
+import std.string
+
+println("a b  c".words())
+println("x\ty\nz".words())
+println("".words())
+println("  ".words())
+println("  a  b  ".words())
+println("one".words())
+println("a\n\nb".words())
+assertResult(3)(size("a b  c".words()))
+assertResult(0)(size("  ".words()))
+
+mutable counts = Map#empty()
+foreach (word in "the fox the dog the fox".words()) {
+  counts = Map#put(counts, word, counts.getOrElse(word, 0) + 1)
+}
+println(counts)
+println(Map#size(counts))
+foreach (entry in counts.toPairs()) {
+  println(entry.key + ": " + entry.value)
+}
+assertResult(3)(Map#size(counts))
+assertResult(3)(counts.getOrElse("the", 0))
+
+// A second walk over the same map, to show the first did not consume it.
+mutable total = 0
+foreach (entry in counts.toPairs()) {
+  total = total + entry.value
+}
+println(total)
+assertResult(6)(total)
+println("done")

--- a/tests/cross-exec/35-distinct-and-builtin-values.kl
+++ b/tests/cross-exec/35-distinct-and-builtin-values.kl
@@ -1,0 +1,31 @@
+// Cross-target fixture: `distinct` and a builtin mentioned as a value.
+//
+// `distinct` used to be written as a recursive filter, which no backend that
+// compiles a function once could take: a `List<'a>` parameter has no single
+// shape to compile it for. It is a set round trip now -- a set keeps the
+// first occurrence of each element in order, which is exactly what `distinct`
+// answers -- so it is two builtins every backend already has. The repeated,
+// all-repeated and empty cases are here because those are where a dedupe that
+// kept the *last* occurrence, or sorted, would disagree.
+//
+// The second half asks whether a builtin is there. It is a value, not a call,
+// and comparing a heap reference with `null` compares a pointer with nothing
+// -- two different types by construction, which one backend refused.
+
+import std.list
+
+println([3, 1, 3, 2, 1].distinctItems())
+println(distinct(["a", "b", "a"]))
+println(distinct([]))
+println(distinct([5]))
+println(distinct([1, 1, 1]))
+println(distinct([2, 1]))
+assertResult([3, 1, 2])([3, 1, 3, 2, 1].distinctItems())
+assertResult([2, 1])(distinct([2, 1]))
+assertResult(1)(size(distinct([1, 1, 1])))
+assertResult(0)(size(distinct([])))
+
+println(Process#exit != null)
+println(Time#nowMillis != null)
+assertResult(true)(Process#exit != null)
+println("done")


### PR DESCRIPTION
The two things left after #607 -- `words()` over text only known while
running, and walking a map's entries -- work on all three targets now, and
with them **every recipe in the cookbook builds on every target**.

## `words()` without building a list

`words()` filtered the pieces a split leaves behind, which means building a
list while the program runs: the one thing the x86-64 backend cannot do. It
collapses runs of whitespace in the *text* instead, so the split leaves no
empty pieces and no list has to be built. The answer is the same list for
every input -- checked against the old implementation case by case, including
tabs, newlines, repeated separators, and text that is only whitespace.

Text with nothing in it has no words, which is why `splitWords` splits on the
empty delimiter in that branch: both branches then produce lines, which is
what a backend needs to join them.

## Four string builtins that insisted on compile-time text

`split`, `replace`/`replaceAll`, `trim` and its neighbours take a heap string
now, copying it into a scratch buffer the way the environment-key path
already did -- an extension method's own `this` is a heap string, so this is
what every `std.string` method written as `this.trim()` runs into. A binding
that holds a heap string also takes any other shape of string by lifting it
onto the heap, which is what `t = replaceAll(t, ...)` in a loop produces.

## Walking a lowered map's entries

`foreach (e in m.toPairs())` over a map the previous PR lowered onto a chain
becomes a walk over that chain, with the entry's halves bound directly and
`e.key` / `e.value` rewritten to those bindings. A body that does anything
else with the entry leaves the program alone, like every other case the pass
does not cover.

## Verification

- 58/58 sample programs on all three targets.
- Full suite green (725 tests).
- All six cookbook recipes build on all three targets (measured), including
  word-count, whose caveat in the book is gone.
- New cross-exec fixture (34) covers `words()`'s edge cases and two walks
  over the same map; it runs on real arm64 and Windows in CI and matches the
  evaluator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)