### PR TITLE
Fix the issue sweep: parser, docs, and the system stdlib modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,8 @@ When adding syntax or semantics:
   `%["a":1 "b":2]`, `%(1 2 3)`.
 - String interpolation: `"Hello #{name}"`.
 - `cleanup { ... }` clauses run after the associated expression.
-- `module foo.bar { ... }` plus selective / aliased imports.
+- A module is a whole file, declared by `module foo.bar` on its first line
+  (there is no block form); imports may be selective or aliased.
 - Structural records (`record { x: 1; y: 2 }`) and nominal record declarations
   (`record Point { x: Int; y: Int }`), constructed positionally as `#Point(1, 2)`.
 - Algebraic data types: `enum Option<a> { case Some(value: a); case None }` and

--- a/crates/klassic-eval/src/lib.rs
+++ b/crates/klassic-eval/src/lib.rs
@@ -1263,7 +1263,9 @@ fn eval_expr_inner(
         Expr::Assign { name, value, span } => {
             let evaluated = eval_expr(value, environment, state)?;
             match environment.assign(name, evaluated) {
-                Ok(value) => Ok(value),
+                // Unit, matching the type an assignment is given: it is done
+                // for its effect, not for a value.
+                Ok(_) => Ok(Value::Unit),
                 Err(AssignmentFailure::Undefined) => Err(Diagnostic::runtime(
                     *span,
                     format!("undefined variable `{name}`"),

--- a/crates/klassic-eval/src/ops.rs
+++ b/crates/klassic-eval/src/ops.rs
@@ -249,10 +249,15 @@ fn eval_divide(lhs: Value, rhs: Value, span: Span) -> Result<Value, Diagnostic> 
         (Some(lhs), Some(rhs)) => {
             let (lhs, rhs, kind) = promote_numeric_pair(lhs, rhs);
             let value = match (lhs, rhs, kind) {
+                // Integer division by zero has no answer to give, so it is an
+                // error. Floating-point division does: IEEE 754, which is what
+                // the underlying f32/f64 implement, defines `1.0 / 0.0` as
+                // infinity and `0.0 / 0.0` as NaN. Refusing them meant a
+                // program could reach infinity by multiplying and not by
+                // dividing, so the same quantity behaved differently depending
+                // on how it was written.
                 (_, NumericValue::Int(0), NumericKind::Int)
-                | (_, NumericValue::Long(0), NumericKind::Long)
-                | (_, NumericValue::Float(0.0), NumericKind::Float)
-                | (_, NumericValue::Double(0.0), NumericKind::Double) => {
+                | (_, NumericValue::Long(0), NumericKind::Long) => {
                     return Err(Diagnostic::runtime(span, "division by zero"));
                 }
                 (NumericValue::Int(lhs), NumericValue::Int(rhs), NumericKind::Int) => lhs

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -256,6 +256,10 @@ struct Assembler {
 /// lives on this side of the trait rather than in the shared routine.
 /// The same, around an allocation: x4/x5 carry the arguments, so they are not
 /// in this list, and x8 is (the barrier's field address is not live here).
+/// What the allocation wrapper saves around the routine: the registers this
+/// backend has live across an allocation. Read in one place -- the wrapper --
+/// so no call site can hold a list that drifts from what the routine
+/// actually clobbers.
 const ALLOC_SAVED: [Reg; 10] = [
     Reg::X1,
     Reg::X2,
@@ -269,6 +273,9 @@ const ALLOC_SAVED: [Reg; 10] = [
     Reg::X12,
 ];
 
+/// The same for the load barrier's slow path. Its list differs from the
+/// allocation's: the allocation's own arguments are live where the barrier's
+/// are not.
 const BARRIER_SAVED: [Reg; 11] = [
     Reg::X1,
     Reg::X2,
@@ -1243,30 +1250,6 @@ impl portable_asm::PortableAsm for Assembler {
         self.bind(done);
     }
 
-    /// The registers this backend has live across a barrier's slow path.
-    /// x10-x12 have no name in the portable set, which is why the list is
-    /// here rather than in the shared routine.
-    fn save_barrier_registers(&mut self) {
-        for reg in BARRIER_SAVED {
-            self.push(reg);
-        }
-    }
-    fn restore_barrier_registers(&mut self) {
-        for reg in BARRIER_SAVED.into_iter().rev() {
-            self.pop(reg);
-        }
-    }
-    fn save_alloc_registers(&mut self) {
-        for reg in ALLOC_SAVED {
-            self.push(reg);
-        }
-    }
-    fn restore_alloc_registers(&mut self) {
-        for reg in ALLOC_SAVED.into_iter().rev() {
-            self.pop(reg);
-        }
-    }
-
     fn plat_write_data(&mut self, fd: u64, data: PortDataAddr, len: usize) {
         Assembler::mov_imm64(self, Reg::X0, fd);
         match data {
@@ -2076,6 +2059,12 @@ struct Emitter {
     /// `reserve_gc_state`, whichever comes first -- owns it; the routine
     /// body itself is always emitted with the rest of the GC runtime.
     gc_load_barrier_label: Option<Label>,
+    /// Wrappers around the two GC routines that save what this backend has
+    /// live across them. Emitted once each; the call sites just `bl` here, so
+    /// no site carries a register list of its own and none can drift from
+    /// what the routine actually clobbers.
+    gc_barrier_trampoline_label: Option<Label>,
+    gc_alloc_trampoline_label: Option<Label>,
     /// `__bss` cells for the GC shadow stack (base pointer, top index),
     /// shared by `reserve_gc_state` and the mutator's root pushes.
     shadow_stack_cells: Option<(DataLabel, DataLabel)>,
@@ -4581,27 +4570,9 @@ impl Emitter {
     /// callers park those with `push_rooted` and take them back afterwards,
     /// which also picks up the new address once the collector moves objects.
     fn emit_gc_alloc_call(&mut self) {
-        const SAVED: [Reg; 10] = [
-            Reg::X1,
-            Reg::X2,
-            Reg::X3,
-            Reg::X6,
-            Reg::X7,
-            Reg::X8,
-            Reg::X9,
-            Reg::X10,
-            Reg::X11,
-            Reg::X12,
-        ];
-        let entry = self.gc_alloc_entry_label();
+        let entry = self.alloc_trampoline_label();
         self.asm.push_frame_record(); // the bl clobbers x30
-        for reg in SAVED {
-            self.asm.push(reg);
-        }
         self.asm.branch(entry, BranchKind::Link);
-        for reg in SAVED.into_iter().rev() {
-            self.asm.pop(reg);
-        }
         self.asm.pop_frame_record();
     }
 
@@ -4976,6 +4947,7 @@ impl Emitter {
         self.asm.mov_reg(Reg::X0, Reg::X5);
     }
 
+    /// The routine itself, which the GC emission binds.
     fn load_barrier_label(&mut self) -> Label {
         match self.gc_load_barrier_label {
             Some(label) => label,
@@ -4985,6 +4957,66 @@ impl Emitter {
                 label
             }
         }
+    }
+
+    /// What a barriered read calls: the wrapper that saves this backend's
+    /// live registers around the routine.
+    fn barrier_trampoline_label(&mut self) -> Label {
+        match self.gc_barrier_trampoline_label {
+            Some(label) => label,
+            None => {
+                let label = self.asm.new_label();
+                self.gc_barrier_trampoline_label = Some(label);
+                label
+            }
+        }
+    }
+
+    /// The same for an allocation.
+    fn alloc_trampoline_label(&mut self) -> Label {
+        match self.gc_alloc_trampoline_label {
+            Some(label) => label,
+            None => {
+                let label = self.asm.new_label();
+                self.gc_alloc_trampoline_label = Some(label);
+                label
+            }
+        }
+    }
+
+    /// Emit both wrappers. Each saves the registers this backend has live
+    /// across its routine, calls it, restores, and returns -- so the policy
+    /// lives in one place instead of at every call site, and a register the
+    /// routine clobbers cannot be forgotten at one site and remembered at
+    /// another.
+    fn emit_gc_call_trampolines(&mut self) {
+        let barrier = self.barrier_trampoline_label();
+        let slow = self.load_barrier_label();
+        self.asm.bind(barrier);
+        self.asm.push_frame_record(); // the bl clobbers x30
+        for reg in BARRIER_SAVED {
+            self.asm.push(reg);
+        }
+        self.asm.branch(slow, BranchKind::Link);
+        for reg in BARRIER_SAVED.into_iter().rev() {
+            self.asm.pop(reg);
+        }
+        self.asm.pop_frame_record();
+        self.asm.ret();
+
+        let alloc_wrapper = self.alloc_trampoline_label();
+        let alloc = self.gc_alloc_entry_label();
+        self.asm.bind(alloc_wrapper);
+        self.asm.push_frame_record();
+        for reg in ALLOC_SAVED {
+            self.asm.push(reg);
+        }
+        self.asm.branch(alloc, BranchKind::Link);
+        for reg in ALLOC_SAVED.into_iter().rev() {
+            self.asm.pop(reg);
+        }
+        self.asm.pop_frame_record();
+        self.asm.ret();
     }
 
     /// M7: load a heap *pointer* out of `[base + offset]` through the GC
@@ -5030,10 +5062,12 @@ impl Emitter {
 
     /// The barrier proper: x8 = field address on entry, x0 = the raw
     /// pointer on exit. The test, the call and the strip are the shared
-    /// ones; what this backend adds is the register list above.
+    /// ones; what this backend adds is a wrapper around the slow routine
+    /// that saves the registers it has live there -- once, rather than at
+    /// each of these sites.
     fn emit_gc_load_barriered(&mut self) {
         self.asm.ldr_imm(Reg::X0, Reg::X8, 0);
-        let slow = self.load_barrier_label();
+        let slow = self.barrier_trampoline_label();
         crate::portable_asm::emit_gc_load_barrier(&mut self.asm, slow);
     }
 
@@ -12928,6 +12962,9 @@ pub(crate) fn emit_macho_program(
     // PortableAsm lowering end-to-end, and must encode validly. The go-live
     // (M7) routes the mutator through gc_alloc and adds roots/barriers.
     emitter.emit_gc_runtime(&gc);
+    // The two wrappers that save this backend's live registers around the
+    // routines above, so no call site carries a list of its own.
+    emitter.emit_gc_call_trampolines();
 
     emitter.asm.finish();
     // `bss_len` is 0 for every program today (no codegen reserves GC

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -82,6 +82,14 @@ const DEFAULT_DIR_MODE: u64 = 0o755;
 const GC_EVAC_OFF: bool = false;
 
 const SYS_MMAP: u16 = 197;
+
+/// Darwin `__getcwd(buf, size)`: fills `buf`, answers 0 on success.
+const SYS_GETCWD: u16 = 326;
+
+/// `S_IFDIR` (0o040000) >> 12, the value `st_mode`'s type field takes for a
+/// directory; `S_IFREG` (0o100000) >> 12 for a regular file.
+const S_IFDIR_SHIFTED: u32 = 0o4;
+const S_IFREG_SHIFTED: u32 = 0o10;
 const STDOUT_FD: u64 = 1;
 const STDERR_FD: u64 = 2;
 /// One bump-allocator segment. Exhaustion mmaps a fresh segment (the
@@ -1458,6 +1466,10 @@ fn assignable(actual: ValueType, expected: ValueType) -> bool {
     actual == expected
         // `null` into any reference slot, including one that may hold nothing.
         || (actual == ValueType::Null && is_heap_pointer(expected))
+        // A value that is *sometimes* null fits a slot of what it otherwise
+        // is, for the same reason `null` itself does: `std.cli`'s `option`
+        // answers a String or nothing, and its annotation says String.
+        || matches!(actual, ValueType::Nullable(elem) if elem_value_type(elem) == expected)
         || (actual == ValueType::EmptyList
             && matches!(expected, ValueType::List(_) | ValueType::EmptyList))
         || (actual == ValueType::EmptySet
@@ -1536,6 +1548,49 @@ fn elem_value_type(elem: ListElem) -> ValueType {
 /// The annotation a type would be written as, for the types a type variable
 /// can be solved to from an argument. Anything else answers `None`, which
 /// leaves the variable unsolved rather than guessing.
+/// The fields of a structural record annotation, `{ a: Int; b: String }`, in
+/// the order written. `None` when the text is not one. Splitting is done at
+/// the top nesting level so a field whose own type is a record or a generic
+/// application survives.
+fn split_structural_record_fields(text: &str) -> Option<Vec<(String, String)>> {
+    let trimmed = text.trim();
+    let inner = trimmed.strip_prefix('{')?.strip_suffix('}')?;
+    let mut fields = Vec::new();
+    let mut depth = 0usize;
+    let mut current = String::new();
+    for ch in inner.chars() {
+        match ch {
+            '{' | '<' | '(' | '[' => {
+                depth += 1;
+                current.push(ch);
+            }
+            '}' | '>' | ')' | ']' => {
+                depth = depth.saturating_sub(1);
+                current.push(ch);
+            }
+            ';' | ',' if depth == 0 => {
+                fields.push(std::mem::take(&mut current));
+            }
+            _ => current.push(ch),
+        }
+    }
+    fields.push(current);
+    let mut typed = Vec::new();
+    for field in fields {
+        let field = field.trim();
+        if field.is_empty() {
+            continue;
+        }
+        let (name, annotation) = field.split_once(':')?;
+        let name = name.trim();
+        if name.is_empty() {
+            return None;
+        }
+        typed.push((name.to_string(), annotation.trim().to_string()));
+    }
+    if typed.is_empty() { None } else { Some(typed) }
+}
+
 fn type_annotation_name(ty: ValueType) -> Option<String> {
     Some(
         match ty {
@@ -1974,6 +2029,29 @@ impl Emitter {
         if bare == "Point" {
             let point = self.instantiate_builtin_point();
             return Ok(ValueType::Record(point));
+        }
+        // A structural record written as its fields: `{ year: Int; month: Int }`.
+        // `std.time` returns one of these, and without this the whole module
+        // is refused for a reason that reads as if the backend could not model
+        // an `Int`.
+        if let Some(fields) = split_structural_record_fields(trimmed) {
+            let mut typed = Vec::with_capacity(fields.len());
+            for (field, annotation) in fields {
+                let resolved = self.annotation_type(&annotation, span)?;
+                typed.push((field, resolved));
+            }
+            if let Some(index) = self.records.iter().position(|record| {
+                record.usable && record.name.is_empty() && record.fields == typed
+            }) {
+                return Ok(ValueType::Record(index as u32));
+            }
+            self.records.push(RecordInfo {
+                name: String::new(),
+                fields: typed,
+                lambda_fields: Vec::new(),
+                usable: true,
+            });
+            return Ok(ValueType::Record((self.records.len() - 1) as u32));
         }
         // `#GPoint<Int, Int>`: a generic record named with its arguments. The
         // parameters are substituted into the field types and the result is
@@ -3728,9 +3806,12 @@ impl Emitter {
     /// its own top bits after this shift). A failed stat (e.g. a
     /// missing path) reports `false` rather than aborting, matching
     /// the evaluator's `Path::is_dir()` (M15, issue #538).
-    fn emit_dir_is_directory(&mut self) {
+    /// Whether the path in x0 stats to a file of the given type, where the
+    /// type is `st_mode >> 12` -- `S_IFDIR_SHIFTED` for a directory,
+    /// `S_IFREG_SHIFTED` for a regular file. A path that does not stat at all
+    /// answers false, which is what the evaluator's `is_dir`/`is_file` do.
+    fn emit_dir_stat_mode_is(&mut self, kind: u32) {
         const STAT_BUF_SIZE: u64 = 144;
-        const S_IFDIR_SHIFTED: u32 = 0o4; // S_IFDIR (0o040000) >> 12
 
         self.asm.mov_reg(Reg::X7, Reg::X0); // the path, past the buffer setup
 
@@ -3756,7 +3837,7 @@ impl Emitter {
         self.asm.bind(success);
         self.asm.ldrh_imm(Reg::X0, Reg::X6, 4);
         self.asm.lsr_imm(Reg::X0, Reg::X0, 12);
-        self.asm.cmp_imm(Reg::X0, S_IFDIR_SHIFTED);
+        self.asm.cmp_imm(Reg::X0, kind);
         self.asm.cset(Reg::X0, Cond::Eq);
         self.asm.bind(done);
         self.asm.add_sp_imm(STAT_BUF_SIZE as u32);
@@ -4471,6 +4552,48 @@ impl Emitter {
     /// collector into `__const` looking for a header.
     /// A heap string holding the NUL-terminated bytes at the pointer in x0.
     /// The length is measured first, since a C string does not carry one.
+    /// A heap string from the `x2` bytes at `x9`, which must lie outside the
+    /// heap (rodata or the machine stack) so the allocation cannot move them.
+    fn emit_heap_string_from_bytes(&mut self) {
+        self.asm.push(Reg::X9);
+        self.asm.push(Reg::X2);
+        self.emit_alloc_raw_string(Reg::X2); // x5 = object, x2 preserved
+        self.asm.pop(Reg::X2);
+        self.asm.pop(Reg::X6);
+        self.asm.str_imm(Reg::X2, Reg::X5, 0); // length
+        self.asm.add_reg_imm(Reg::X7, Reg::X5, 8); // destination bytes
+        self.emit_copy_bytes(Reg::X2, Reg::X6, Reg::X7, Reg::X3);
+        self.asm.mov_reg(Reg::X0, Reg::X5);
+    }
+
+    /// An environment-variable name known while compiling, left in the
+    /// (x9 bytes, x10 length) pair `emit_environment_lookup` reads.
+    fn emit_environment_static_key(&mut self, key: &[u8]) {
+        let offset = self.asm.intern_rodata(key);
+        self.asm.load_rodata_address(Reg::X9, offset);
+        self.asm.mov_imm64(Reg::X10, key.len() as u64);
+    }
+
+    /// `Dir#current()`: Darwin's `__getcwd` fills a buffer and answers 0, so
+    /// the length comes from scanning to the terminator rather than from the
+    /// return value. The buffer is transient and lives on the machine stack,
+    /// not in the GC heap, for the same reason the `stat` buffer does: a raw
+    /// header-less block would desynchronise the sweep's block walk.
+    fn emit_dir_current(&mut self) {
+        const PATH_BUF_SIZE: u32 = 4096;
+        self.asm.sub_sp_imm(PATH_BUF_SIZE);
+        self.asm.add_reg_sp_imm(Reg::X0, 0);
+        self.asm.mov_reg(Reg::X6, Reg::X0);
+        self.asm.mov_imm64(Reg::X1, u64::from(PATH_BUF_SIZE));
+        self.asm.mov_imm64(Reg::X16, u64::from(SYS_GETCWD));
+        self.asm.svc_0x80();
+        self.asm
+            .emit_abort_if_syscall_failed(b"klassic: Dir#current failed\n");
+        self.asm.mov_reg(Reg::X0, Reg::X6);
+        self.emit_heap_string_from_cstring();
+        self.asm.add_sp_imm(PATH_BUF_SIZE);
+    }
+
     fn emit_heap_string_from_cstring(&mut self) {
         // x9 = the bytes; x2 = length, counted to the terminator.
         self.asm.mov_reg(Reg::X9, Reg::X0);
@@ -6319,12 +6442,32 @@ impl Emitter {
     /// x19/x20. Preserves x0-x5 because allocation sites have live
     /// String / display builtins, mirroring the C backend's surface.
     /// Returns Ok(None) when `name` is not a builtin.
+    /// The v0.1 prelude spells several builtins without their namespace:
+    /// `getEnv` is `Environment#get`, `args` is `CommandLine#args`, and so
+    /// on. The stdlib modules are written against those short names, so a
+    /// backend that only knows the namespaced spelling refuses `std.env`
+    /// and `std.process` for a reason that has nothing to do with what it
+    /// can emit.
+    fn canonical_builtin_name(name: &str) -> &str {
+        match name {
+            "args" => "CommandLine#args",
+            "exit" => "Process#exit",
+            "stdin" => "StandardInput#all",
+            "stdinLines" => "StandardInput#lines",
+            "env" => "Environment#vars",
+            "getEnv" => "Environment#get",
+            "hasEnv" => "Environment#exists",
+            other => other,
+        }
+    }
+
     fn builtin_call(
         &mut self,
         name: &str,
         arguments: &[Expr],
         span: Span,
     ) -> Result<Option<ValueType>, Diagnostic> {
+        let name = Self::canonical_builtin_name(name);
         match (name, arguments.len()) {
             ("length", 1) => {
                 if self.expression(&arguments[0])? != ValueType::Str {
@@ -8002,7 +8145,12 @@ impl Emitter {
             }
             ("Dir#isDirectory", 1) => {
                 self.emit_path_cstring(&arguments[0])?;
-                self.emit_dir_is_directory();
+                self.emit_dir_stat_mode_is(S_IFDIR_SHIFTED);
+                Ok(Some(ValueType::Bool))
+            }
+            ("Dir#isFile", 1) => {
+                self.emit_path_cstring(&arguments[0])?;
+                self.emit_dir_stat_mode_is(S_IFREG_SHIFTED);
                 Ok(Some(ValueType::Bool))
             }
             ("Dir#move", 2) => {
@@ -8015,6 +8163,44 @@ impl Emitter {
                 self.pop_rooted(Reg::X0);
                 self.emit_dir_move();
                 Ok(Some(ValueType::Unit))
+            }
+            ("Dir#current", 0) => {
+                self.emit_dir_current();
+                Ok(Some(ValueType::Str))
+            }
+            // `HOME` and `TMPDIR` are where the evaluator reads these from,
+            // and `Dir#temp` falls back to `/tmp` the way it does there.
+            ("Dir#home", 0) => {
+                self.emit_environment_static_key(b"HOME");
+                self.emit_environment_lookup();
+                let present = self.asm.new_label();
+                self.asm
+                    .branch(present, BranchKind::CompareNonZero(Reg::X0));
+                self.asm.emit_write_rodata(
+                    STDERR_FD,
+                    b"klassic: failed to get home dir: environment variable HOME is not set\n",
+                );
+                self.asm.emit_exit(1);
+                self.asm.bind(present);
+                self.emit_heap_string_from_cstring();
+                Ok(Some(ValueType::Str))
+            }
+            ("Dir#temp", 0) => {
+                self.emit_environment_static_key(b"TMPDIR");
+                self.emit_environment_lookup();
+                let present = self.asm.new_label();
+                let done = self.asm.new_label();
+                self.asm
+                    .branch(present, BranchKind::CompareNonZero(Reg::X0));
+                let fallback = self.asm.intern_rodata(b"/tmp");
+                self.asm.load_rodata_address(Reg::X9, fallback);
+                self.asm.mov_imm64(Reg::X2, 4);
+                self.emit_heap_string_from_bytes();
+                self.asm.branch(done, BranchKind::Unconditional);
+                self.asm.bind(present);
+                self.emit_heap_string_from_cstring();
+                self.asm.bind(done);
+                Ok(Some(ValueType::Str))
             }
             ("Environment#exists", 1) => {
                 self.emit_environment_key(&arguments[0])?;
@@ -9244,7 +9430,12 @@ impl Emitter {
                 let first_type = arguments
                     .first()
                     .and_then(|argument| self.static_type_under(argument, locals, depth + 1));
-                match name.as_str() {
+                // The prelude's short spellings resolve the same way here as
+                // they do when the call is emitted; predicting a type for
+                // `Environment#get` and not for `getEnv` would refuse a body
+                // the emitter can compile.
+                let name = Self::canonical_builtin_name(name);
+                match name {
                     // head/tail matter more than they look: they are how the
                     // prelude's recursive list functions are written, so
                     // without them a body like `cons(head(xs))(rest)` cannot

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -3092,6 +3092,14 @@ impl Emitter {
                 self.asm.mov_imm64(Reg::X0, *value as u64);
                 Ok(ValueType::Int)
             }
+            // An assignment in expression position: done for its effect, so
+            // it yields unit. Two `match` arms that both end in one therefore
+            // agree, which is what lets a `match` be written for effect.
+            Expr::Assign { .. } => {
+                self.statement(expr)?;
+                self.asm.mov_imm64(Reg::X0, 0);
+                Ok(ValueType::Unit)
+            }
             // `expr cleanup { ... }`: the clause runs after the expression it
             // is attached to, and the expression's value is still the value.
             // A heap result is parked as a root, because the clause can
@@ -11300,6 +11308,12 @@ impl Emitter {
             }
             ValueType::Null => {
                 self.asm.emit_write_rodata(STDOUT_FD, b"null\n");
+                Ok(())
+            }
+            // The evaluator prints unit as `()`, and an assignment is a unit
+            // now, so a program can reach here by printing one.
+            ValueType::Unit => {
+                self.asm.emit_write_rodata(STDOUT_FD, b"()\n");
                 Ok(())
             }
             // `null` or a value: the evaluator prints the word `null` for the

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -1691,6 +1691,17 @@ fn as_pointer_repr(ty: ValueType) -> ValueType {
     }
 }
 
+/// The element type a value can be stored in a map as. Wider than
+/// `list_elem_of` by the nullable case: `Map#get` answers a value or nothing,
+/// and every fold that rebuilds a map feeds that straight back into
+/// `Map#put`. Both are one boxed word.
+fn map_value_elem(ty: ValueType) -> Option<ListElem> {
+    match ty {
+        ValueType::Nullable(elem) => Some(elem),
+        other => list_elem_of(other),
+    }
+}
+
 fn is_lowering_pointer(ty: ValueType) -> bool {
     matches!(ty, ValueType::Ptr | ValueType::LoweredEnum(_))
 }
@@ -4228,7 +4239,7 @@ impl Emitter {
             return Ok(ValueType::Bool);
         }
 
-        let lhs_ty = self.expression(lhs)?;
+        let mut lhs_ty = self.expression(lhs)?;
         // A heap-reference left operand (a string being concatenated, a
         // collection being compared) waits while the right operand is
         // evaluated, which can allocate -- root its slot for that window.
@@ -4308,6 +4319,28 @@ impl Emitter {
             self.pop_rooted(Reg::X0);
         } else {
             self.asm.pop(Reg::X0);
+        }
+        // A value that may be null, used as the value it is: `Map#get` answers
+        // one, and `std.map`'s `mapValues` and `filterValues` do arithmetic on
+        // the result. It arrives boxed, so unboxing it is what makes the two
+        // sides the same type. A genuinely null operand would fault here
+        // rather than being read as zero, which is the same bargain the other
+        // backend already makes.
+        if !matches!(op, BinaryOp::Equal | BinaryOp::NotEqual) {
+            if let ValueType::Nullable(elem) = lhs_ty
+                && is_boxed_scalar(elem_value_type(elem))
+                && rhs_ty == elem_value_type(elem)
+            {
+                self.asm.ldr_imm(Reg::X0, Reg::X0, 0);
+                lhs_ty = elem_value_type(elem);
+            }
+            if let ValueType::Nullable(elem) = rhs_ty
+                && is_boxed_scalar(elem_value_type(elem))
+                && lhs_ty == elem_value_type(elem)
+            {
+                self.asm.ldr_imm(Reg::X1, Reg::X1, 0);
+                rhs_ty = elem_value_type(elem);
+            }
         }
         // Asking whether a heap reference is `null` compares a pointer with
         // nothing, so the two sides are different types by construction.
@@ -7369,7 +7402,11 @@ impl Emitter {
                 self.asm.store_local(Reg::X0, key_slot);
                 self.emit_root_frame_slot(key_slot);
                 let value_ty = self.expression(&arguments[2])?;
-                let Some(value_elem) = list_elem_of(value_ty) else {
+                // `Map#get` answers the value *or nothing*, and rebuilding a
+                // map is written as `Map#put(acc, k, Map#get(m, k))` -- so a
+                // value that may be null is a value of its own element type.
+                // It is already one boxed word either way.
+                let Some(value_elem) = map_value_elem(value_ty) else {
                     return Err(unsupported(arguments[2].span(), "a map value of this type"));
                 };
                 if let Some((_, existing_value)) = existing
@@ -7438,6 +7475,158 @@ impl Emitter {
                 self.asm.branch(reverse, BranchKind::Link);
                 self.close_temp_roots(mark);
                 Ok(Some(ValueType::Map(key_elem, value_elem)))
+            }
+            // `Map#containsValue(m, value)`: a scan of the second half of every
+            // entry, the mirror of `Map#containsKey`'s scan of the first.
+            ("Map#containsValue", 2) | ("containsValue", 2) => {
+                let mark = self.open_temp_roots();
+                let map_ty = self.expression(&arguments[0])?;
+                let value_elem = match map_ty {
+                    ValueType::Map(_, value) => Some(value),
+                    // An empty map holds nothing, so it contains no value.
+                    ValueType::EmptyMap => None,
+                    _ => return Err(unsupported(span, "a map builtin on a non-map")),
+                };
+                let cursor = self.reserve_locals(16);
+                let wanted = cursor + 8;
+                self.asm.store_local(Reg::X0, cursor);
+                self.emit_root_frame_slot(cursor);
+                let candidate_ty = self.expression(&arguments[1])?;
+                let Some(candidate) = list_elem_of(candidate_ty) else {
+                    return Err(unsupported(arguments[1].span(), "a map value of this type"));
+                };
+                if is_boxed_scalar(candidate_ty) {
+                    self.emit_box_scalar();
+                }
+                self.asm.store_local(Reg::X0, wanted);
+                self.emit_root_frame_slot(wanted);
+                let Some(value_elem) = value_elem else {
+                    self.asm.mov_imm64(Reg::X0, 0);
+                    self.close_temp_roots(mark);
+                    return Ok(Some(ValueType::Bool));
+                };
+                if value_elem != candidate {
+                    return Err(unsupported(arguments[1].span(), "mixed map value types"));
+                }
+                let loop_start = self.asm.new_label();
+                let found = self.asm.new_label();
+                let missing = self.asm.new_label();
+                let done = self.asm.new_label();
+                self.asm.bind(loop_start);
+                self.asm.load_local(Reg::X0, cursor);
+                self.asm.branch(missing, BranchKind::CompareZero(Reg::X0));
+                self.emit_gc_load_ptr(Reg::X0, 0); // this entry
+                self.emit_gc_load_ptr(Reg::X0, 8); // its value
+                if is_boxed_scalar(elem_value_type(value_elem)) {
+                    self.emit_unbox_scalar();
+                }
+                self.asm.load_local(Reg::X1, wanted);
+                match value_elem {
+                    ListElem::Str => self.emit_str_eq(),
+                    _ => {
+                        if is_boxed_scalar(elem_value_type(value_elem)) {
+                            self.asm.ldr_imm(Reg::X1, Reg::X1, 0);
+                        }
+                        self.asm.cmp_reg(Reg::X0, Reg::X1);
+                        self.asm.cset(Reg::X0, Cond::Eq);
+                    }
+                }
+                self.asm.branch(found, BranchKind::CompareNonZero(Reg::X0));
+                self.asm.load_local(Reg::X0, cursor);
+                self.emit_gc_load_ptr(Reg::X0, 8);
+                self.asm.store_local(Reg::X0, cursor);
+                self.asm.branch(loop_start, BranchKind::Unconditional);
+                self.asm.bind(found);
+                self.asm.mov_imm64(Reg::X0, 1);
+                self.asm.branch(done, BranchKind::Unconditional);
+                self.asm.bind(missing);
+                self.asm.mov_imm64(Reg::X0, 0);
+                self.asm.bind(done);
+                self.close_temp_roots(mark);
+                Ok(Some(ValueType::Bool))
+            }
+            // `Map#remove(m, key)`: the same walk `Map#put` does, keeping every
+            // entry whose key differs and dropping the one that matches. The
+            // accumulator is built front-to-back and reversed, so insertion
+            // order survives.
+            ("Map#remove", 2) | ("remove", 2) => {
+                let mark = self.open_temp_roots();
+                let map_ty = self.expression(&arguments[0])?;
+                let existing = match map_ty {
+                    ValueType::Map(key, value) => Some((key, value)),
+                    ValueType::EmptyMap => None,
+                    _ => return Err(unsupported(span, "a map builtin on a non-map")),
+                };
+                let cursor = self.reserve_locals(16);
+                let acc = cursor + 8;
+                self.asm.store_local(Reg::X0, cursor);
+                self.emit_root_frame_slot(cursor);
+                self.asm.mov_imm64(Reg::X0, 0);
+                self.asm.store_local(Reg::X0, acc);
+                self.emit_root_frame_slot(acc);
+                let key_ty = self.expression(&arguments[1])?;
+                let Some(key_elem) = list_elem_of(key_ty) else {
+                    return Err(unsupported(arguments[1].span(), "a map key of this type"));
+                };
+                if is_boxed_scalar(key_ty) {
+                    self.emit_box_scalar();
+                }
+                let key_slot = self.reserve_locals(8);
+                self.asm.store_local(Reg::X0, key_slot);
+                self.emit_root_frame_slot(key_slot);
+                let Some((existing_key, existing_value)) = existing else {
+                    // Removing from the empty map is the empty map.
+                    self.asm.mov_imm64(Reg::X0, 0);
+                    self.close_temp_roots(mark);
+                    return Ok(Some(ValueType::EmptyMap));
+                };
+                if existing_key != key_elem {
+                    return Err(unsupported(arguments[1].span(), "mixed map key types"));
+                }
+                let loop_start = self.asm.new_label();
+                let done = self.asm.new_label();
+                let keep = self.asm.new_label();
+                let next = self.asm.new_label();
+                self.asm.bind(loop_start);
+                self.asm.load_local(Reg::X0, cursor);
+                self.asm.branch(done, BranchKind::CompareZero(Reg::X0));
+                self.emit_gc_load_ptr(Reg::X0, 0); // this entry
+                self.push_rooted(Reg::X0);
+                self.emit_gc_load_ptr(Reg::X0, 0); // its key
+                if is_boxed_scalar(elem_value_type(key_elem)) {
+                    self.emit_unbox_scalar();
+                }
+                self.asm.load_local(Reg::X1, key_slot);
+                match key_elem {
+                    ListElem::Str => self.emit_str_eq(),
+                    _ => {
+                        if is_boxed_scalar(elem_value_type(key_elem)) {
+                            self.asm.ldr_imm(Reg::X1, Reg::X1, 0);
+                        }
+                        self.asm.cmp_reg(Reg::X0, Reg::X1);
+                        self.asm.cset(Reg::X0, Cond::Eq);
+                    }
+                }
+                self.asm.branch(keep, BranchKind::CompareZero(Reg::X0));
+                self.pop_rooted(Reg::X1); // the matching entry, dropped
+                self.asm.branch(next, BranchKind::Unconditional);
+                self.asm.bind(keep);
+                self.pop_rooted(Reg::X0);
+                self.push_rooted(Reg::X0);
+                self.asm.load_local(Reg::X0, acc);
+                self.emit_cons_cell();
+                self.asm.store_local(Reg::X0, acc);
+                self.asm.bind(next);
+                self.asm.load_local(Reg::X0, cursor);
+                self.emit_gc_load_ptr(Reg::X0, 8);
+                self.asm.store_local(Reg::X0, cursor);
+                self.asm.branch(loop_start, BranchKind::Unconditional);
+                self.asm.bind(done);
+                self.asm.load_local(Reg::X0, acc);
+                let reverse = self.reverse_label();
+                self.asm.branch(reverse, BranchKind::Link);
+                self.close_temp_roots(mark);
+                Ok(Some(ValueType::Map(existing_key, existing_value)))
             }
             // `Map#keys(m)` / `Map#values(m)`: one half of every entry, in
             // insertion order.
@@ -9890,9 +10079,9 @@ impl Emitter {
                         return Some(ValueType::Int);
                     }
                     "isEmpty" | "contains" | "isEmptyString" | "matches" | "containsKey"
-                    | "Map#containsKey" | "Map#isEmpty" | "Map#containsValue" | "Set#isEmpty"
-                    | "Set#contains" | "startsWith" | "endsWith" | "String#isInt"
-                    | "String#isDouble" => {
+                    | "containsValue" | "Map#containsKey" | "Map#isEmpty" | "Map#containsValue"
+                    | "Set#isEmpty" | "Set#contains" | "startsWith" | "endsWith"
+                    | "String#isInt" | "String#isDouble" => {
                         return Some(ValueType::Bool);
                     }
                     "String#parseInt" => return Some(ValueType::Int),
@@ -9915,6 +10104,19 @@ impl Emitter {
                             Some(ValueType::Set(elem)) | Some(ValueType::List(elem)) => {
                                 Some(ValueType::Set(elem))
                             }
+                            // Adding to the empty set is what fixes its
+                            // element type, and it is how every fold that
+                            // builds a set starts -- `std.set`'s `setFilter`
+                            // folds from `Set#empty()`. The element being
+                            // added is the only thing that says what the set
+                            // holds, so read it from there.
+                            Some(ValueType::EmptySet) if name == "Set#add" => arguments
+                                .get(1)
+                                .and_then(|argument| {
+                                    self.static_type_under(argument, locals, depth + 1)
+                                })
+                                .and_then(list_elem_of)
+                                .map(ValueType::Set),
                             Some(ValueType::EmptySet) | Some(ValueType::EmptyList)
                                 if name == "Set#fromList" =>
                             {
@@ -9980,12 +10182,23 @@ impl Emitter {
                             locals,
                             depth + 1,
                         )?)?;
-                        let value = list_elem_of(self.static_type_under(
+                        // The value may be a lookup, which answers a value or
+                        // nothing: `Map#put(acc, k, Map#get(m, k))` is how
+                        // `filterKeys` and `merge` rebuild a map.
+                        let value = map_value_elem(self.static_type_under(
                             &arguments[2],
                             locals,
                             depth + 1,
                         )?)?;
                         return Some(ValueType::Map(key, value));
+                    }
+                    // Dropping an entry keeps the map's type; an empty map
+                    // stays empty.
+                    "Map#remove" if arguments.len() == 2 => {
+                        return match first_type {
+                            Some(ty @ (ValueType::Map(..) | ValueType::EmptyMap)) => Some(ty),
+                            _ => None,
+                        };
                     }
                     "Map#empty" => return Some(ValueType::EmptyMap),
                     // The enum lowering's allocators. A constructor call like

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -11389,6 +11389,12 @@ impl Emitter {
             | Expr::RecordDeclaration { .. }
             | Expr::EnumDeclaration { .. }
             | Expr::TypeClassDeclaration { .. }
+            // A proof is checked before any backend runs (`analyze_proofs`,
+            // and the --warn-trust / --deny-trust flags act there), so by the
+            // time it reaches codegen it produces no code -- exactly like the
+            // declarations above it.
+            | Expr::AxiomDeclaration { .. }
+            | Expr::TheoremDeclaration { .. }
             | Expr::InstanceDeclaration { .. } => Ok(()),
             Expr::VarDecl {
                 name,

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -2192,6 +2192,35 @@ impl Emitter {
             .find_map(|scope| scope.get(name).copied())
     }
 
+    /// Whether this condition is decided while compiling, and how. Narrow on
+    /// purpose: it answers only for the emptiness of a collection whose type
+    /// says it has no elements, which is the shape a generic helper's base
+    /// case is written in.
+    fn static_condition(&mut self, condition: &Expr) -> Option<bool> {
+        let Expr::Call {
+            callee, arguments, ..
+        } = condition
+        else {
+            return None;
+        };
+        let name = match callee.as_ref() {
+            Expr::Identifier { name, .. } => name.as_str(),
+            _ => return None,
+        };
+        let name = Self::canonical_builtin_name(name);
+        if !matches!(
+            name,
+            "isEmpty" | "Set#isEmpty" | "Map#isEmpty" | "isEmptyString"
+        ) {
+            return None;
+        }
+        let argument = arguments.first()?;
+        match self.static_type_under(argument, &mut Vec::new(), 0)? {
+            ValueType::EmptyList | ValueType::EmptySet | ValueType::EmptyMap => Some(true),
+            _ => None,
+        }
+    }
+
     /// Resolve a type annotation against scalars, list types, lowered
     /// enums, and declared records (`#Point` or `Point`).
     fn annotation_type(&mut self, text: &str, span: Span) -> Result<ValueType, Diagnostic> {
@@ -3709,6 +3738,14 @@ impl Emitter {
                 let Some(else_branch) = else_branch else {
                     return Err(unsupported(*span, "if without else as an expression"));
                 };
+                // A condition settled while compiling takes only its own
+                // branch. The other one is unreachable for *this*
+                // specialisation, and compiling it anyway is what refuses a
+                // generic helper written as `if (isEmpty(xs)) xs else
+                // <something about head(xs)>` when it is called with `[]`.
+                if let Some(taken) = self.static_condition(condition) {
+                    return self.expression(if taken { then_branch } else { else_branch });
+                }
                 let condition_ty = self.expression(condition)?;
                 if condition_ty != ValueType::Bool {
                     return Err(unsupported(condition.span(), "a non-Bool condition"));

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -1314,6 +1314,10 @@ enum ListElem {
     /// An element that is a record, which is a pointer too. A list of them is
     /// what `toPairs()` hands back.
     Record(u32),
+    /// An element that is a *lowered* enum -- one the shared pass erased into
+    /// `__gc_record` calls -- carrying its entry in the lowered-enum table so
+    /// a list of them can be printed. A pointer, like the two above.
+    LoweredEnum(u32),
     /// An element that is itself a list: `depth` levels of list over `base`.
     /// `List<List<Int>>`'s element is `Nested { depth: 1, base: Int }` and
     /// `List<List<List<Int>>>`'s is `depth: 2`.
@@ -1355,7 +1359,10 @@ impl ListElem {
             ListElem::Int => Some(ScalarElem::Int),
             ListElem::Bool => Some(ScalarElem::Bool),
             ListElem::Str => Some(ScalarElem::Str),
-            ListElem::Enum(_) | ListElem::Record(_) | ListElem::Nested { .. } => None,
+            ListElem::Enum(_)
+            | ListElem::Record(_)
+            | ListElem::LoweredEnum(_)
+            | ListElem::Nested { .. } => None,
         }
     }
 
@@ -1733,6 +1740,7 @@ fn elem_value_type(elem: ListElem) -> ValueType {
         ListElem::Str => ValueType::Str,
         ListElem::Enum(shape) => ValueType::Enum(shape),
         ListElem::Record(index) => ValueType::Record(index),
+        ListElem::LoweredEnum(index) => ValueType::LoweredEnum(index),
         ListElem::Nested { .. } => ValueType::List(
             elem.nested_inner()
                 .expect("a nested element is a list of its inner element"),
@@ -1958,6 +1966,7 @@ fn list_elem_of(ty: ValueType) -> Option<ListElem> {
         ValueType::Str => Some(ListElem::Str),
         ValueType::Enum(shape) => Some(ListElem::Enum(shape)),
         ValueType::Record(index) => Some(ListElem::Record(index)),
+        ValueType::LoweredEnum(index) => Some(ListElem::LoweredEnum(index)),
         // A list of lists: one more level over whatever the inner list holds.
         ValueType::List(inner) => Some(match inner.as_scalar() {
             Some(base) => ListElem::Nested { depth: 1, base },
@@ -6464,6 +6473,9 @@ impl Emitter {
             ListElem::Enum(shape) => {
                 self.emit_print_enum_inline(shape, span)?;
             }
+            ListElem::LoweredEnum(index) => {
+                self.emit_print_lowered_enum(index, span)?;
+            }
             ListElem::Record(index) => {
                 self.emit_print_record_inline(index, span)?;
             }
@@ -8840,6 +8852,7 @@ impl Emitter {
             ListElem::Bool => self.emit_bool_to_str(),
             ListElem::Str => {}
             ListElem::Enum(shape) => self.emit_enum_to_str(shape, span)?,
+            ListElem::LoweredEnum(index) => self.emit_lowered_enum_to_str(index, span)?,
             ListElem::Record(_) => {
                 return Err(unsupported(span, "rendering a record element"));
             }
@@ -11557,6 +11570,7 @@ impl Emitter {
                     ListElem::Double
                     | ListElem::Enum(_)
                     | ListElem::Record(_)
+                    | ListElem::LoweredEnum(_)
                     | ListElem::Nested { .. } => {
                         return Err(unsupported(
                             argument.span(),

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -1986,6 +1986,7 @@ struct GenericFunction {
     return_annotation: Option<String>,
 }
 
+#[derive(Clone)]
 struct FunctionInfo {
     label: Label,
     params: Vec<(String, ValueType)>,
@@ -2027,6 +2028,12 @@ struct GenericRecord {
 struct CapturedEnv {
     lambdas: Vec<(String, usize)>,
     dicts: Vec<(String, Vec<(String, usize)>)>,
+    /// Frame slots the lambda closed over, as (name, slot, type). A lambda
+    /// has no runtime representation here -- its body is compiled where it is
+    /// called -- so a value it captured has to be reachable from there. It is,
+    /// because the slot outlives the binding: `val add3 = adder(3)` puts the
+    /// 3 in a slot of the *caller's* frame and the lambda reads it.
+    values: Vec<(String, u32, ValueType)>,
 }
 
 #[derive(Default)]
@@ -10916,10 +10923,88 @@ impl Emitter {
                 .flatten()
                 .map(|(name, fields)| (name.clone(), fields.clone()))
                 .collect(),
+            values: Vec::new(),
         };
         self.lambdas.push((params, body));
         self.lambda_envs.push(env);
         self.lambdas.len() - 1
+    }
+
+    /// A call whose callee's body *is* a lambda: compile each argument into a
+    /// slot of this frame and intern the lambda with those slots as its
+    /// captured environment, so calling it later reads them. Answers `None`
+    /// when the call is not that shape, which is every other call.
+    fn returned_lambda_binding(&mut self, value: &Expr) -> Result<Option<usize>, Diagnostic> {
+        let Expr::Call {
+            callee, arguments, ..
+        } = value
+        else {
+            return Ok(None);
+        };
+        let Expr::Identifier { name, .. } = callee.as_ref() else {
+            return Ok(None);
+        };
+        // A def whose return type this backend cannot model -- `(Int) => Int`
+        // is one -- is kept whole as a generic function and specialised per
+        // call, so that is where a lambda-returning def lives.
+        let Some(generic) = self
+            .generic_functions
+            .iter()
+            .position(|function| function.name == *name)
+        else {
+            return Ok(None);
+        };
+        let function = self.generic_functions[generic].clone();
+        if function.params.len() != arguments.len() {
+            return Ok(None);
+        }
+        // The body, past any wrapping block that only produces it.
+        let mut body = &function.body;
+        while let Expr::Block { expressions, .. } = body {
+            if expressions.len() != 1 {
+                break;
+            }
+            body = &expressions[0];
+        }
+        let Expr::Lambda {
+            params: lambda_params,
+            body: lambda_body,
+            ..
+        } = body
+        else {
+            return Ok(None);
+        };
+        let lambda_params = lambda_params.clone();
+        let lambda_body = lambda_body.as_ref().clone();
+        let mut captured = Vec::with_capacity(arguments.len());
+        for (param, argument) in function.params.iter().zip(arguments) {
+            let ty = self.expression(argument)?;
+            let slot = self.reserve_locals(8);
+            self.asm.store_local(Reg::X0, slot);
+            if is_heap_pointer(ty) {
+                self.emit_root_frame_slot(slot);
+            }
+            captured.push((param.clone(), slot, ty));
+        }
+        Ok(Some(self.intern_lambda_capturing(
+            lambda_params,
+            lambda_body,
+            captured,
+        )))
+    }
+
+    /// Intern a lambda that also closed over frame slots -- what a function
+    /// returning a lambda leaves behind once its arguments are materialised
+    /// into the caller's frame.
+    fn intern_lambda_capturing(
+        &mut self,
+        params: Vec<String>,
+        body: Expr,
+        values: Vec<(String, u32, ValueType)>,
+    ) -> usize {
+        let index = self.intern_lambda(params, body);
+        self.lambda_envs[index].values = values;
+        index
     }
 
     /// The field-to-lambda mapping of an expression that denotes a dictionary
@@ -11021,6 +11106,12 @@ impl Emitter {
                 .last_mut()
                 .expect("emitter dict scope")
                 .insert(name, fields);
+        }
+        for (name, slot, ty) in env.values {
+            self.scopes
+                .last_mut()
+                .expect("emitter scope")
+                .insert(name, (slot, ty));
         }
     }
 
@@ -11752,6 +11843,20 @@ impl Emitter {
                 // are known from the arguments.
                 if let Expr::Lambda { params, body, .. } = value.as_ref() {
                     let index = self.intern_lambda(params.clone(), body.as_ref().clone());
+                    self.lambda_bindings
+                        .last_mut()
+                        .expect("emitter lambda scope")
+                        .insert(name.clone(), index);
+                    return Ok(());
+                }
+                // `val add3 = adder(3)` where `adder` returns a lambda. The
+                // lambda has no runtime representation, so what is bound here
+                // is the lambda *plus* the arguments it closed over, each
+                // materialised into a slot of this frame. Currying and
+                // partial application are ordinary in this language, and
+                // without this a returned lambda could only be called on the
+                // spot.
+                if let Some(index) = self.returned_lambda_binding(value)? {
                     self.lambda_bindings
                         .last_mut()
                         .expect("emitter lambda scope")

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -1406,9 +1406,15 @@ enum ValueType {
     /// A record value: index into the emitter's record table (nominal
     /// declarations and interned structural shapes).
     Record(u32),
-    /// An untyped heap pointer: lowered enum values and the box cells
-    /// the enum desugaring builds around scalars.
+    /// An untyped heap pointer: the box cells the enum desugaring builds
+    /// around scalars, and any lowered enum value whose enum could not be
+    /// named at the point it was built.
     Ptr,
+    /// A *lowered* monomorphic enum value: an index into
+    /// `lowered_enum_table`. The shared lowering erased the declaration and
+    /// left `__gc_record` calls, so the value is a pointer -- this says which
+    /// enum's pointer it is, which is what printing one needs.
+    LoweredEnum(u32),
     Unit,
     /// A generic enum's value: an index into the emitter's shape table, which
     /// records what each variant carries. The shared lowering only erases
@@ -1454,6 +1460,15 @@ fn merge_branch_types(then_ty: ValueType, else_ty: ValueType) -> Option<ValueTyp
         | (other @ ValueType::Set(_), ValueType::EmptySet) => Some(other),
         (ValueType::EmptyMap, other @ ValueType::Map(..))
         | (other @ ValueType::Map(..), ValueType::EmptyMap) => Some(other),
+        // Two lowered enums of different enums, or one against a bare
+        // pointer, join as the pointer they both are: the join carries no
+        // single variant table, so it can no longer be printed, which is
+        // exactly what was true before any of them carried one.
+        (ValueType::LoweredEnum(left), ValueType::LoweredEnum(right)) if left != right => {
+            Some(ValueType::Ptr)
+        }
+        (ValueType::LoweredEnum(_), ValueType::Ptr)
+        | (ValueType::Ptr, ValueType::LoweredEnum(_)) => Some(ValueType::Ptr),
         (left, right) if left == right => Some(left),
         _ => None,
     }
@@ -1464,6 +1479,14 @@ fn merge_branch_types(then_ty: ValueType, else_ty: ValueType) -> Option<ValueTyp
 /// polymorphic empty list into any list slot.
 fn assignable(actual: ValueType, expected: ValueType) -> bool {
     actual == expected
+        // A lowered enum *is* a heap pointer -- naming which enum it is only
+        // adds what printing needs, and must not narrow where the value can
+        // go. Both directions, because the lowering's own helpers are typed
+        // in terms of the bare pointer.
+        || matches!(
+            (actual, expected),
+            (ValueType::LoweredEnum(_), ValueType::Ptr) | (ValueType::Ptr, ValueType::LoweredEnum(_))
+        )
         // `null` into any reference slot, including one that may hold nothing.
         || (actual == ValueType::Null && is_heap_pointer(expected))
         // A value that is *sometimes* null fits a slot of what it otherwise
@@ -1476,6 +1499,153 @@ fn assignable(actual: ValueType, expected: ValueType) -> bool {
             && matches!(expected, ValueType::Set(_) | ValueType::EmptySet))
         || (actual == ValueType::EmptyMap
             && matches!(expected, ValueType::Map(..) | ValueType::EmptyMap))
+}
+
+/// What a lowered monomorphic enum looks like, carried over from the shared
+/// `desugar_enums` pass so this backend can render one.
+///
+/// The lowering erases the declaration and leaves `__gc_record` calls behind,
+/// which is why a value of such an enum arrives here as a bare pointer. The
+/// pass does wrap every construction in `__enum_shape_named(value, "Variant")`
+/// for the x86-64 display path; this backend reads the same marker, which is
+/// what lets it name the enum a pointer belongs to and print it.
+#[derive(Default)]
+pub(crate) struct LoweredEnumTable {
+    /// One entry per lowered enum: its name and its variants in tag order.
+    enums: Vec<LoweredEnumInfo>,
+    /// Variant name -> the enum it belongs to.
+    owner: HashMap<String, usize>,
+}
+
+pub(crate) struct LoweredEnumInfo {
+    /// The enum's own name, so an annotation naming it resolves here.
+    name: String,
+    variants: Vec<LoweredVariant>,
+}
+
+#[derive(Clone)]
+pub(crate) struct LoweredVariant {
+    name: String,
+    /// One entry per payload, in declaration order: how to render it.
+    fields: Vec<LoweredFieldRepr>,
+}
+
+/// How to render one payload of a lowered enum. Deliberately narrower than
+/// the shared `EnumFieldRepr`: everything this backend needs to know is which
+/// of the four printable shapes the eight bytes are.
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) enum LoweredFieldRepr {
+    Int,
+    Bool,
+    Str,
+    /// Another lowered enum, named by the annotation it was declared with so
+    /// the renderer can descend into it. The name is resolved to a table
+    /// index lazily, because a payload can name an enum whose own entry is
+    /// still being built.
+    Enum(String),
+    /// A payload this backend has no rendering for -- a Double, whose
+    /// shortest-round-trip formatter does not exist here.
+    Unrenderable,
+}
+
+impl LoweredFieldRepr {
+    fn from_repr(repr: crate::EnumFieldRepr, annotation: String) -> Self {
+        match repr {
+            crate::EnumFieldRepr::Scalar => Self::Int,
+            crate::EnumFieldRepr::BoolField => Self::Bool,
+            crate::EnumFieldRepr::StringField => Self::Str,
+            crate::EnumFieldRepr::EnumField => Self::Enum(annotation),
+            crate::EnumFieldRepr::DoubleField => Self::Unrenderable,
+        }
+    }
+}
+
+impl LoweredEnumTable {
+    /// Build from the shared lowering's own tables: `variants` gives every
+    /// variant its tag index and its payload reprs, and `variant_owner` says
+    /// which enum each belongs to. Those two are complete and authoritative,
+    /// so the table is exactly what the lowering erased.
+    pub(crate) fn from_shapes(
+        variants: &HashMap<String, crate::EnumVariantInfo>,
+        field_annotations: &HashMap<String, Vec<String>>,
+        variant_owner: &HashMap<String, String>,
+    ) -> Self {
+        let mut table = Self::default();
+        let mut by_name: HashMap<String, usize> = HashMap::new();
+        // Sorted so the table is built the same way on every run; the tag
+        // index below is what actually orders the variants.
+        let mut names: Vec<&String> = variants.keys().collect();
+        names.sort();
+        for variant in names {
+            let Some(owner) = variant_owner.get(variant) else {
+                continue;
+            };
+            let info = &variants[variant];
+            let index = *by_name.entry(owner.clone()).or_insert_with(|| {
+                table.enums.push(LoweredEnumInfo {
+                    name: owner.clone(),
+                    variants: Vec::new(),
+                });
+                table.enums.len() - 1
+            });
+            let entry = &mut table.enums[index];
+            let tag = info.index as usize;
+            if entry.variants.len() <= tag {
+                entry.variants.resize(
+                    tag + 1,
+                    LoweredVariant {
+                        name: String::new(),
+                        fields: Vec::new(),
+                    },
+                );
+            }
+            let annotations = field_annotations.get(variant);
+            entry.variants[tag] = LoweredVariant {
+                name: variant.clone(),
+                fields: info
+                    .fields
+                    .iter()
+                    .enumerate()
+                    .map(|(position, repr)| {
+                        let annotation = annotations
+                            .and_then(|texts| texts.get(position))
+                            .cloned()
+                            .unwrap_or_default();
+                        LoweredFieldRepr::from_repr(*repr, annotation)
+                    })
+                    .collect(),
+            };
+            table.owner.insert(variant.clone(), index);
+        }
+        // An enum with a gap in its tags never existed -- the lowering numbers
+        // variants consecutively -- but a defensive drop keeps a nameless
+        // entry from being printed as one.
+        table
+            .enums
+            .retain(|info| info.variants.iter().all(|variant| !variant.name.is_empty()));
+        table.owner.clear();
+        for (index, info) in table.enums.iter().enumerate() {
+            for variant in &info.variants {
+                table.owner.insert(variant.name.clone(), index);
+            }
+        }
+        table
+    }
+
+    fn info(&self, index: u32) -> &LoweredEnumInfo {
+        &self.enums[index as usize]
+    }
+
+    fn owner_of(&self, variant: &str) -> Option<u32> {
+        self.owner.get(variant).map(|index| *index as u32)
+    }
+
+    fn index_by_name(&self, name: &str) -> Option<u32> {
+        self.enums
+            .iter()
+            .position(|info| info.name == name)
+            .map(|index| index as u32)
+    }
 }
 
 /// One nominal record declaration or interned structural shape:
@@ -1508,6 +1678,23 @@ fn is_boxed_scalar(ty: ValueType) -> bool {
 /// collector must trace? `EmptyList`/`EmptySet` are the nil pointer (0),
 /// which the root scan and the barriers both pass through untouched, so
 /// rooting them is harmless and keeps the classification purely by type.
+/// Whether the enum lowering's `__gc_read`/`__gc_write` primitives accept a
+/// value of this type: a bare heap pointer, or one that also remembers which
+/// lowered enum it is.
+/// A lowered enum seen as the pointer it is. Used where a type is *stored*
+/// (an enum shape's payload, a record's field) rather than used, so that the
+/// added precision never splits one type into two.
+fn as_pointer_repr(ty: ValueType) -> ValueType {
+    match ty {
+        ValueType::LoweredEnum(_) => ValueType::Ptr,
+        other => other,
+    }
+}
+
+fn is_lowering_pointer(ty: ValueType) -> bool {
+    matches!(ty, ValueType::Ptr | ValueType::LoweredEnum(_))
+}
+
 fn is_heap_pointer(ty: ValueType) -> bool {
     matches!(
         ty,
@@ -1523,6 +1710,7 @@ fn is_heap_pointer(ty: ValueType) -> bool {
             | ValueType::Null
             | ValueType::Nullable(_)
             | ValueType::Enum(_)
+            | ValueType::LoweredEnum(_)
     )
 }
 
@@ -1884,9 +2072,14 @@ struct Emitter {
     /// Number of shadow-stack roots pushed in each open scope, so leaving
     /// a scope pops exactly its own.
     scope_root_counts: Vec<usize>,
-    /// Names of enums `desugar_enums` lowered to `__gc_record` shape;
-    /// annotations naming them type as plain heap pointers.
+    /// Names of enums `desugar_enums` lowered to `__gc_record` shape.
     lowered_enums: std::collections::HashSet<String>,
+    /// What each of those enums looks like, so a value of one can be printed
+    /// rather than refused as an untyped pointer.
+    lowered_enum_table: LoweredEnumTable,
+    /// Lowered enums currently being rendered, so one that holds itself is
+    /// refused rather than expanded forever.
+    printing_lowered_enums: Vec<u32>,
     scopes: Vec<HashMap<String, (u32, ValueType)>>,
     /// Lambda bodies interned by `val f = (x) => ...`, and the names bound to
     /// them, scoped like ordinary locals. A lambda has no runtime
@@ -1984,9 +2177,13 @@ impl Emitter {
     fn annotation_type(&mut self, text: &str, span: Span) -> Result<ValueType, Diagnostic> {
         let trimmed = text.trim();
         let bare = trimmed.trim_start_matches('#');
-        // Lowered monomorphic enum values travel as plain heap
-        // pointers.
+        // A lowered monomorphic enum: a heap pointer that remembers which
+        // enum it is, so a parameter or return annotated with one can be
+        // printed rather than refused.
         if self.lowered_enums.contains(bare) {
+            if let Some(index) = self.lowered_enum_table.index_by_name(bare) {
+                return Ok(ValueType::LoweredEnum(index));
+            }
             return Ok(ValueType::Ptr);
         }
         if let Some(index) = self
@@ -2205,7 +2402,13 @@ impl Emitter {
                 // `replace` would rewrite the `a` inside `Char`.
                 let text = substitute_type_params(annotation.trim(), &params, arguments);
                 match self.annotation_type(&text, span) {
-                    Ok(ty) => typed.push(ty),
+                    // A payload that is a lowered enum is stored as the bare
+                    // pointer it is. Which enum it is only matters where the
+                    // value is printed, and letting the distinction into a
+                    // shape would make `Ok(step)` built from an argument and
+                    // `Ok(step)` built from an annotation two different
+                    // shapes of the same instantiation.
+                    Ok(ty) => typed.push(as_pointer_repr(ty)),
                     Err(_) => {
                         self.applied_enum_shapes
                             .remove(&(enum_index, arguments.to_vec()));
@@ -3441,10 +3644,23 @@ impl Emitter {
                 }
                 // `__enum_shape_named(value, "Variant")` and
                 // `__enum_shape_hint(value, id)` are shape aids the shared
-                // enum-lowering pass wraps around values for the x86_64
-                // display/dispatch paths. The aarch64 backend has no use
-                // for the shape, so it compiles the wrapped value
-                // transparently and drops the marker.
+                // enum-lowering pass wraps around every construction of a
+                // lowered enum. The value itself is a bare `__gc_record`
+                // pointer; the marker is the only place its enum is named, so
+                // this is where the pointer picks up a type that can be
+                // printed. `__enum_shape_hint` carries an id rather than a
+                // name and stays transparent.
+                if name == "__enum_shape_named"
+                    && let [value, Expr::String { value: variant, .. }] = arguments.as_slice()
+                {
+                    let compiled = self.expression(value)?;
+                    if compiled == ValueType::Ptr
+                        && let Some(index) = self.lowered_enum_table.owner_of(variant)
+                    {
+                        return Ok(ValueType::LoweredEnum(index));
+                    }
+                    return Ok(compiled);
+                }
                 if (name == "__enum_shape_named" || name == "__enum_shape_hint")
                     && let Some(value) = arguments.first()
                 {
@@ -3598,6 +3814,9 @@ impl Emitter {
                     }
                     ValueType::Enum(shape) => {
                         self.emit_enum_to_str(shape, hole.span())?;
+                    }
+                    ValueType::LoweredEnum(index) => {
+                        self.emit_lowered_enum_to_str(index, hole.span())?;
                     }
                     other => {
                         return Err(unsupported(
@@ -6394,6 +6613,94 @@ impl Emitter {
         Ok(())
     }
 
+    /// Write the *lowered* enum value in x0 as `Variant(field, ...)`, no
+    /// trailing newline. The shared lowering laid it out as a `__gc_record`
+    /// whose slot 0 boxes the variant tag and whose remaining slots box the
+    /// payloads in declaration order, so this is a switch on that tag.
+    ///
+    /// A payload that is itself a pointer -- another enum, a Double -- prints
+    /// as `<value>`: this backend has no shortest-round-trip Double
+    /// formatter, and rendering a nested enum would need the nested enum's
+    /// identity, which the tag alone does not carry.
+    fn emit_print_lowered_enum(&mut self, index: u32, span: Span) -> Result<(), Diagnostic> {
+        if self.printing_lowered_enums.contains(&index) {
+            return Err(unsupported(span, "printing an enum that holds itself"));
+        }
+        self.printing_lowered_enums.push(index);
+        let result = self.emit_print_lowered_enum_variants(index, span);
+        self.printing_lowered_enums.pop();
+        result
+    }
+
+    fn emit_print_lowered_enum_variants(
+        &mut self,
+        index: u32,
+        span: Span,
+    ) -> Result<(), Diagnostic> {
+        let variants: Vec<(String, Vec<LoweredFieldRepr>)> = self
+            .lowered_enum_table
+            .info(index)
+            .variants
+            .iter()
+            .map(|variant| (variant.name.clone(), variant.fields.clone()))
+            .collect();
+        if variants.is_empty() {
+            return Err(unsupported(span, "printing an enum with no variants"));
+        }
+        let end = self.asm.new_label();
+        self.asm.push(Reg::X0); // the value survives the writes below
+        for (tag, (name, fields)) in variants.iter().enumerate() {
+            let next = self.asm.new_label();
+            self.asm.pop(Reg::X0);
+            self.asm.push(Reg::X0);
+            self.emit_gc_load_ptr(Reg::X0, 0); // the boxed tag
+            self.emit_unbox_scalar();
+            self.asm.cmp_imm(Reg::X0, tag as u32);
+            self.asm.branch(next, BranchKind::Conditional(Cond::Ne));
+            self.asm.emit_write_rodata(STDOUT_FD, name.as_bytes());
+            if !fields.is_empty() {
+                self.asm.emit_write_rodata(STDOUT_FD, b"(");
+                for (position, repr) in fields.iter().enumerate() {
+                    if position > 0 {
+                        self.asm.emit_write_rodata(STDOUT_FD, b", ");
+                    }
+                    self.asm.pop(Reg::X0);
+                    self.asm.push(Reg::X0);
+                    self.emit_gc_load_ptr(Reg::X0, (position as u32 + 1) * 8);
+                    match repr {
+                        LoweredFieldRepr::Int => {
+                            self.emit_unbox_scalar();
+                            self.emit_print_elem(ListElem::Int, span)?;
+                        }
+                        LoweredFieldRepr::Bool => {
+                            self.emit_unbox_scalar();
+                            self.emit_print_elem(ListElem::Bool, span)?;
+                        }
+                        LoweredFieldRepr::Str => self.emit_print_elem(ListElem::Str, span)?,
+                        LoweredFieldRepr::Enum(name) => {
+                            let Some(inner) = self.lowered_enum_table.index_by_name(name) else {
+                                return Err(unsupported(
+                                    span,
+                                    "printing an enum payload of this type",
+                                ));
+                            };
+                            self.emit_print_lowered_enum(inner, span)?;
+                        }
+                        LoweredFieldRepr::Unrenderable => {
+                            return Err(unsupported(span, "printing an enum payload of this type"));
+                        }
+                    }
+                }
+                self.asm.emit_write_rodata(STDOUT_FD, b")");
+            }
+            self.asm.branch(end, BranchKind::Unconditional);
+            self.asm.bind(next);
+        }
+        self.asm.bind(end);
+        self.asm.pop(Reg::X0); // discard the saved value
+        Ok(())
+    }
+
     /// println of the list in x0 in the evaluator's format:
     /// `[e1, e2, ...]` (strings unquoted).
     fn emit_println_list(&mut self, elem: ListElem, span: Span) -> Result<(), Diagnostic> {
@@ -7817,7 +8124,10 @@ impl Emitter {
                 Ok(Some(ValueType::Ptr))
             }
             ("__gc_write", 3) => {
-                if self.expression(&arguments[0])? != ValueType::Ptr {
+                // A lowered enum value is one of these pointers wearing the
+                // name of its enum, so the lowering's own reads and writes
+                // take it exactly as they take a bare pointer.
+                if !is_lowering_pointer(self.expression(&arguments[0])?) {
                     return Err(unsupported(span, "__gc_write to a non-pointer"));
                 }
                 self.push_rooted(Reg::X0);
@@ -7842,7 +8152,7 @@ impl Emitter {
                 Ok(Some(ValueType::Unit))
             }
             ("__gc_read", 2) | ("__gc_read_ptr", 2) | ("__gc_read_string", 2) => {
-                if self.expression(&arguments[0])? != ValueType::Ptr {
+                if !is_lowering_pointer(self.expression(&arguments[0])?) {
                     return Err(unsupported(span, &format!("{name} of a non-pointer")));
                 }
                 self.push_rooted(Reg::X0);
@@ -8443,6 +8753,104 @@ impl Emitter {
                             return Err(unsupported(
                                 span,
                                 &format!("rendering an enum payload of type {other:?}"),
+                            ));
+                        }
+                    }
+                    self.asm.mov_reg(Reg::X1, Reg::X0);
+                    self.asm.load_local(Reg::X0, acc);
+                    self.emit_str_concat();
+                    self.asm.store_local(Reg::X0, acc);
+                }
+                self.emit_append_literal(acc, ")");
+            }
+            self.asm.branch(end, BranchKind::Unconditional);
+            self.asm.bind(next);
+        }
+        self.asm.bind(end);
+        self.asm.load_local(Reg::X0, acc);
+        self.close_temp_roots(mark);
+        Ok(())
+    }
+
+    /// The lowered enum value in x0 as a heap string, `Variant(field, ...)`.
+    /// The same switch `emit_print_lowered_enum` writes, building into a
+    /// rooted accumulator instead of writing to stdout, so it can go in a
+    /// string interpolation hole.
+    fn emit_lowered_enum_to_str(&mut self, index: u32, span: Span) -> Result<(), Diagnostic> {
+        if self.printing_lowered_enums.contains(&index) {
+            return Err(unsupported(span, "rendering an enum that holds itself"));
+        }
+        self.printing_lowered_enums.push(index);
+        let result = self.emit_lowered_enum_to_str_variants(index, span);
+        self.printing_lowered_enums.pop();
+        result
+    }
+
+    fn emit_lowered_enum_to_str_variants(
+        &mut self,
+        index: u32,
+        span: Span,
+    ) -> Result<(), Diagnostic> {
+        let variants: Vec<(String, Vec<LoweredFieldRepr>)> = self
+            .lowered_enum_table
+            .info(index)
+            .variants
+            .iter()
+            .map(|variant| (variant.name.clone(), variant.fields.clone()))
+            .collect();
+        if variants.is_empty() {
+            return Err(unsupported(span, "rendering an enum with no variants"));
+        }
+        let mark = self.open_temp_roots();
+        let value = self.reserve_locals(16);
+        let acc = value + 8;
+        self.asm.store_local(Reg::X0, value);
+        self.emit_root_frame_slot(value);
+        let empty = self.asm.intern_string_object("");
+        self.asm.load_rodata_address(Reg::X0, empty);
+        self.emit_heap_string_copy();
+        self.asm.store_local(Reg::X0, acc);
+        self.emit_root_frame_slot(acc);
+        let end = self.asm.new_label();
+        for (tag, (name, fields)) in variants.iter().enumerate() {
+            let next = self.asm.new_label();
+            self.asm.load_local(Reg::X0, value);
+            self.emit_gc_load_ptr(Reg::X0, 0); // the boxed tag
+            self.emit_unbox_scalar();
+            self.asm.cmp_imm(Reg::X0, tag as u32);
+            self.asm.branch(next, BranchKind::Conditional(Cond::Ne));
+            self.emit_append_literal(acc, name);
+            if !fields.is_empty() {
+                self.emit_append_literal(acc, "(");
+                for (position, repr) in fields.iter().enumerate() {
+                    if position > 0 {
+                        self.emit_append_literal(acc, ", ");
+                    }
+                    self.asm.load_local(Reg::X0, value);
+                    self.emit_gc_load_ptr(Reg::X0, (position as u32 + 1) * 8);
+                    match repr {
+                        LoweredFieldRepr::Int => {
+                            self.emit_unbox_scalar();
+                            self.emit_int_to_str();
+                        }
+                        LoweredFieldRepr::Bool => {
+                            self.emit_unbox_scalar();
+                            self.emit_bool_to_str();
+                        }
+                        LoweredFieldRepr::Str => {}
+                        LoweredFieldRepr::Enum(name) => {
+                            let Some(inner) = self.lowered_enum_table.index_by_name(name) else {
+                                return Err(unsupported(
+                                    span,
+                                    "rendering an enum payload of this type",
+                                ));
+                            };
+                            self.emit_lowered_enum_to_str(inner, span)?;
+                        }
+                        LoweredFieldRepr::Unrenderable => {
+                            return Err(unsupported(
+                                span,
+                                "rendering an enum payload of this type",
                             ));
                         }
                     }
@@ -10935,6 +11343,11 @@ impl Emitter {
                 self.asm.bind(end_label);
                 Ok(())
             }
+            ValueType::LoweredEnum(index) => {
+                self.emit_print_lowered_enum(index, argument.span())?;
+                self.asm.emit_write_rodata(STDOUT_FD, b"\n");
+                Ok(())
+            }
             ValueType::Enum(shape) => {
                 self.emit_print_enum_inline(shape, argument.span())?;
                 self.asm.emit_write_rodata(STDOUT_FD, b"\n");
@@ -12127,12 +12540,14 @@ impl Emitter {
 pub(crate) fn emit_macho_program(
     expr: &Expr,
     lowered_enums: std::collections::HashSet<String>,
+    lowered_enum_table: LoweredEnumTable,
     gc_log: bool,
     gc_stress: bool,
     gc_poison: bool,
 ) -> Result<Vec<u8>, Diagnostic> {
     let mut emitter = Emitter {
         lowered_enums,
+        lowered_enum_table,
         gc_log,
         gc_stress,
         gc_poison,

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -6926,6 +6926,7 @@ impl NativeCodeGenerator {
                 value,
                 mutable,
                 span,
+                annotation,
                 ..
             } => {
                 if !mutable && let Some(alias) = self.builtin_alias_from_expr(value) {
@@ -6934,6 +6935,15 @@ impl NativeCodeGenerator {
                     return Ok(NativeValue::Unit);
                 }
                 let compiled = self.compile_expr(value)?;
+                // A binding annotated with a generic enum applied to concrete
+                // types says what its payloads are, even when the value does
+                // not: `val e: Chain<String, Int> = Nil` builds the empty
+                // case, which fixes nothing on its own. Reading the shape off
+                // the annotation is exact -- every type argument is named --
+                // so it is not the partial resolution that is unsound.
+                let annotated_shape = annotation
+                    .as_ref()
+                    .and_then(|annotation| self.generic_enum_annotation_shape(&annotation.text));
                 match compiled {
                     NativeValue::Int
                     | NativeValue::Bool
@@ -6941,6 +6951,9 @@ impl NativeCodeGenerator {
                     | NativeValue::HeapString
                     | NativeValue::RuntimeDouble => {
                         let slot = self.allocate_slot(name.clone(), compiled);
+                        if let Some(shape) = annotated_shape {
+                            self.enum_shapes.insert(slot.id, shape);
+                        }
                         self.asm.store_rbp_slot(slot.offset, Reg::Rax);
                         if static_expr_is_pure(value)
                             && let Some(value) = self.static_value_from_expr(value)

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -41702,9 +41702,7 @@ fn static_numeric_binary_value(
         1 => {
             let lhs = static_value_as_f32(lhs)?;
             let rhs = static_value_as_f32(rhs)?;
-            if matches!(op, BinaryOp::Divide) && rhs == 0.0 {
-                return None;
-            }
+
             let value = match op {
                 BinaryOp::Add => lhs + rhs,
                 BinaryOp::Subtract => lhs - rhs,
@@ -41717,9 +41715,7 @@ fn static_numeric_binary_value(
         2 => {
             let lhs = static_value_as_f64(lhs)?;
             let rhs = static_value_as_f64(rhs)?;
-            if matches!(op, BinaryOp::Divide) && rhs == 0.0 {
-                return None;
-            }
+
             let value = match op {
                 BinaryOp::Add => lhs + rhs,
                 BinaryOp::Subtract => lhs - rhs,

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -7418,6 +7418,16 @@ impl NativeCodeGenerator {
             self.asm.movzx_rax_al();
             return Ok(NativeValue::Bool);
         }
+        // A string compared with `null`. A static or runtime string is a
+        // (data, length) pair in fixed storage, so it is never null and the
+        // answer is settled here; a heap string is a pointer, so the answer is
+        // whether that pointer is zero. Asking is what a caller writes first
+        // after a lookup that may not have found anything.
+        if matches!(op, BinaryOp::Equal | BinaryOp::NotEqual)
+            && let Some(answer) = self.compile_string_null_comparison(lhs_value, op, rhs, span)?
+        {
+            return Ok(answer);
+        }
         if matches!(op, BinaryOp::Equal | BinaryOp::NotEqual)
             && let Some(lhs_string) = self.native_string_ref(lhs_value)
         {
@@ -34479,6 +34489,53 @@ impl NativeCodeGenerator {
     /// scratch buffer pair first. An extension method's `this: String`
     /// parameter arrives as a heap string, so without this every string
     /// builtin written as `this.startsWith(...)` was refused.
+    /// `s == null` / `s != null` where one side is a string. Answers `None`
+    /// when this is not that comparison, so the caller falls through to the
+    /// ordinary string equality.
+    ///
+    /// A static or runtime string is a (data, length) pair in fixed storage,
+    /// so it is never null and the answer is settled while compiling. A heap
+    /// string is a pointer, so the answer is whether that pointer is zero.
+    fn compile_string_null_comparison(
+        &mut self,
+        lhs_value: NativeValue,
+        op: BinaryOp,
+        rhs: &Expr,
+        _span: Span,
+    ) -> Result<Option<NativeValue>, Diagnostic> {
+        if lhs_value == NativeValue::Null {
+            let rhs_value = self.compile_expr(rhs)?;
+            return Ok(self.emit_string_null_answer(rhs_value, op));
+        }
+        if !matches!(rhs, Expr::Null { .. }) {
+            return Ok(None);
+        }
+        Ok(self.emit_string_null_answer(lhs_value, op))
+    }
+
+    /// The answer for a string `value` compared with `null`, with the string
+    /// already in Rax. `None` when `value` is not a string.
+    fn emit_string_null_answer(&mut self, value: NativeValue, op: BinaryOp) -> Option<NativeValue> {
+        match value {
+            NativeValue::StaticString { .. } | NativeValue::RuntimeString { .. } => {
+                self.asm
+                    .mov_imm64(Reg::Rax, u64::from(op == BinaryOp::NotEqual));
+                Some(NativeValue::Bool)
+            }
+            NativeValue::HeapString => {
+                self.asm.cmp_reg_imm8(Reg::Rax, 0);
+                self.asm.setcc_al(if op == BinaryOp::Equal {
+                    Condition::Equal
+                } else {
+                    Condition::NotEqual
+                });
+                self.asm.movzx_rax_al();
+                Some(NativeValue::Bool)
+            }
+            _ => None,
+        }
+    }
+
     fn native_string_ref_or_copy(
         &mut self,
         value: NativeValue,

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -646,7 +646,13 @@ fn compile_internal(
     // are lowered, so the chain lowers with everything else. Only the user's
     // own code is rewritten; the stdlib's map functions keep the builtin map.
     let expr = map_chain::lower_runtime_maps(expr, prelude_offset);
-    let (expr, lowered_enum_names, mono_enum_shapes, mono_enum_variants) = desugar_enums(expr);
+    let (
+        expr,
+        lowered_enum_names,
+        mono_enum_shapes,
+        mono_enum_variants,
+        mono_enum_field_annotations,
+    ) = desugar_enums(expr);
     // Capture the extension-method registry before the desugar erases the
     // `ExtensionDeclaration`s, so codegen can resolve method names that the
     // desugar left ambiguous (declared on more than one type) by the
@@ -686,6 +692,11 @@ fn compile_internal(
         NativeBackend::DirectAarch64 => aarch64::emit_macho_program(
             &expr,
             lowered_enum_names,
+            aarch64::LoweredEnumTable::from_shapes(
+                &mono_enum_variants,
+                &mono_enum_field_annotations,
+                &variant_owner_enum,
+            ),
             config.gc_log,
             config.gc_stress,
             config.gc_poison,
@@ -1923,14 +1934,19 @@ fn collect_enum_decls(expr: &Expr, out: &mut Vec<(String, Vec<String>, Vec<EnumV
     }
 }
 
-fn desugar_enums(
-    expr: Expr,
-) -> (
+/// What `desugar_enums` hands back: the rewritten program, the names of the
+/// enums it lowered, a shape per variant name, a variant table, and each
+/// variant's field annotations as written (which is the only place a payload
+/// that is itself an enum still says *which* enum).
+type DesugaredEnums = (
     Expr,
     HashSet<String>,
     HashMap<String, ConcreteEnumShape>,
     HashMap<String, EnumVariantInfo>,
-) {
+    HashMap<String, Vec<String>>,
+);
+
+fn desugar_enums(expr: Expr) -> DesugaredEnums {
     let mut decls = Vec::new();
     collect_enum_decls(&expr, &mut decls);
 
@@ -1988,6 +2004,7 @@ fn desugar_enums(
     // / wildcard `match` expressions carry no enum dependency and are
     // lowered the same way, which is a net new native capability.
     let mut variants = HashMap::new();
+    let mut variant_field_annotations: HashMap<String, Vec<String>> = HashMap::new();
     for name in &supported {
         for (index, variant) in mono[name].iter().enumerate() {
             let fields = variant
@@ -1998,6 +2015,17 @@ fn desugar_enums(
                         .expect("supported enum field classified")
                 })
                 .collect();
+            // The annotation text alongside the repr: a payload that is
+            // another enum is `EnumField` either way, and rendering one needs
+            // to know *which* enum, which only the text still says.
+            variant_field_annotations.insert(
+                variant.name.clone(),
+                variant
+                    .params
+                    .iter()
+                    .map(|(_, annotation)| annotation.text.trim().to_string())
+                    .collect(),
+            );
             variants.insert(
                 variant.name.clone(),
                 EnumVariantInfo {
@@ -2076,7 +2104,13 @@ fn desugar_enums(
         counter: 0,
     };
     let lowered = lowering.lower(expr);
-    (lowered, lowering.lowered_enums, mono_enum_shapes, variants)
+    (
+        lowered,
+        lowering.lowered_enums,
+        mono_enum_shapes,
+        variants,
+        variant_field_annotations,
+    )
 }
 
 /// Fresh synthetic-name generator shared by the enum lowering and the
@@ -2607,6 +2641,24 @@ impl EnumLowering {
             },
             Expr::SetLiteral { elements, span } => Expr::SetLiteral {
                 elements: elements.into_iter().map(|e| self.lower(e)).collect(),
+                span,
+            },
+            // A hole is an expression like any other: `"#{Some(1)}"` holds a
+            // constructor that has to be lowered, and a `match` written in a
+            // hole has to become the same tag switch it becomes anywhere else.
+            // Without this arm the hole keeps a constructor call no backend
+            // declared, which is what a backend then reports as an unknown
+            // function.
+            Expr::StringInterpolation { parts, span } => Expr::StringInterpolation {
+                parts: parts
+                    .into_iter()
+                    .map(|part| match part {
+                        StringPart::Literal(text) => StringPart::Literal(text),
+                        StringPart::Interpolation(inner) => {
+                            StringPart::Interpolation(Box::new(self.lower(*inner)))
+                        }
+                    })
+                    .collect(),
                 span,
             },
             other => other,

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -7075,6 +7075,10 @@ impl NativeCodeGenerator {
                     )),
                 }
             }
+            // An assignment is done for its effect and yields unit, matching
+            // the type it is given. Two `match` arms that both end in one
+            // therefore agree, which is what let the arms be written for
+            // effect at all.
             Expr::Assign { name, value, span } => {
                 let slot = self.lookup_var(name).ok_or_else(|| {
                     Diagnostic::compile(*span, format!("undefined native variable `{name}`"))
@@ -7097,7 +7101,7 @@ impl NativeCodeGenerator {
                         "runtime-list assignment exceeds 65536 bytes",
                     )?;
                     self.remove_static_value(name);
-                    return Ok(slot.value);
+                    return Ok(NativeValue::Unit);
                 }
                 if native_value_can_be_static_mutable(slot.value) {
                     if self.dynamic_control_depth > 0 && self.mergeable_dynamic_branch_depth == 0 {
@@ -7120,7 +7124,7 @@ impl NativeCodeGenerator {
                     } else {
                         self.remove_static_value(name);
                     }
-                    return Ok(compiled);
+                    return Ok(NativeValue::Unit);
                 }
                 match slot.value {
                     NativeValue::RuntimeString { data, len } => {
@@ -7148,7 +7152,7 @@ impl NativeCodeGenerator {
                             "string assignment exceeds 65536 bytes",
                         );
                         self.remove_static_value(name);
-                        return Ok(slot.value);
+                        return Ok(NativeValue::Unit);
                     }
                     NativeValue::RuntimeLinesList { data, len } => {
                         let compiled = self.compile_expr(value)?;
@@ -7165,7 +7169,7 @@ impl NativeCodeGenerator {
                             "line-list assignment exceeds 65536 bytes",
                         );
                         self.remove_static_value(name);
-                        return Ok(slot.value);
+                        return Ok(NativeValue::Unit);
                     }
                     NativeValue::RuntimeRecord { label } => {
                         let compiled = self.compile_expr(value)?;
@@ -7178,7 +7182,7 @@ impl NativeCodeGenerator {
                             "record assignment exceeds 65536 bytes",
                         )?;
                         self.remove_static_value(name);
-                        return Ok(slot.value);
+                        return Ok(NativeValue::Unit);
                     }
                     _ => {}
                 }
@@ -7240,7 +7244,7 @@ impl NativeCodeGenerator {
                 } else {
                     self.remove_static_value(name);
                 }
-                Ok(compiled)
+                Ok(NativeValue::Unit)
             }
             Expr::Match {
                 scrutinee,

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -12861,12 +12861,15 @@ impl NativeCodeGenerator {
             }
             "indexOf" | "lastIndexOf" => {
                 self.expect_static_arity(name, arguments, 2, span)?;
+                // A heap string is copied into a runtime pair rather than
+                // refused: it is what an annotated `String` parameter holds,
+                // and `std.path` is written entirely in terms of these two.
                 let input = self.compile_expr(&arguments[0])?;
-                let Some(input) = self.native_string_ref(input) else {
+                let Some(input) = self.native_string_ref_or_copy(input, span, name) else {
                     return Err(unsupported(span, &format!("native {name} for non-string")));
                 };
                 let needle = self.compile_expr(&arguments[1])?;
-                let Some(needle) = self.native_string_ref(needle) else {
+                let Some(needle) = self.native_string_ref_or_copy(needle, span, name) else {
                     return Err(unsupported(span, &format!("native {name} for non-string")));
                 };
                 self.emit_native_string_index_of(input, needle, name == "lastIndexOf");
@@ -20660,11 +20663,11 @@ impl NativeCodeGenerator {
             "FileOutput#write"
         };
         self.expect_static_arity(name, arguments, 2, span)?;
-        if self.expr_may_yield_runtime_string(&arguments[0]) {
+        if self.expr_yields_runtime_or_heap_string(&arguments[0]) {
             let path_label = self.compile_runtime_path_argument(&arguments[0], span, name)?;
-            if self.expr_may_yield_runtime_string(&arguments[1]) {
+            if self.expr_yields_runtime_or_heap_string(&arguments[1]) {
                 let content = self.compile_expr(&arguments[1])?;
-                let Some(content) = self.native_string_ref(content) else {
+                let Some(content) = self.native_string_ref_or_copy(content, span, name) else {
                     return Err(unsupported(
                         span,
                         &format!("native {name} for non-string content"),
@@ -20688,9 +20691,9 @@ impl NativeCodeGenerator {
         }
         let path =
             self.static_string_from_argument_preserving_effects(&arguments[0], span, name)?;
-        if self.expr_may_yield_runtime_string(&arguments[1]) {
+        if self.expr_yields_runtime_or_heap_string(&arguments[1]) {
             let content = self.compile_expr(&arguments[1])?;
-            let Some(content) = self.native_string_ref(content) else {
+            let Some(content) = self.native_string_ref_or_copy(content, span, name) else {
                 return Err(unsupported(
                     span,
                     &format!("native {name} for non-string content"),
@@ -20726,7 +20729,7 @@ impl NativeCodeGenerator {
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
         self.expect_static_arity("FileOutput#writeLines", arguments, 2, span)?;
-        if self.expr_may_yield_runtime_string(&arguments[0]) {
+        if self.expr_yields_runtime_or_heap_string(&arguments[0]) {
             let path_label =
                 self.compile_runtime_path_argument(&arguments[0], span, "FileOutput#writeLines")?;
             let content = self.compile_expr(&arguments[1])?;
@@ -20795,7 +20798,7 @@ impl NativeCodeGenerator {
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
         self.expect_static_arity("FileOutput#exists", arguments, 1, span)?;
-        if self.expr_may_yield_runtime_string(&arguments[0]) {
+        if self.expr_yields_runtime_or_heap_string(&arguments[0]) {
             let path_label =
                 self.compile_runtime_path_argument(&arguments[0], span, "FileOutput#exists")?;
             self.emit_runtime_path_exists_label(path_label);
@@ -20830,7 +20833,7 @@ impl NativeCodeGenerator {
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
         self.expect_static_arity("FileOutput#delete", arguments, 1, span)?;
-        if self.expr_may_yield_runtime_string(&arguments[0]) {
+        if self.expr_yields_runtime_or_heap_string(&arguments[0]) {
             let path_label =
                 self.compile_runtime_path_argument(&arguments[0], span, "FileOutput#delete")?;
             self.emit_file_delete_label(path_label, span, "FileOutput#delete");
@@ -21669,7 +21672,7 @@ impl NativeCodeGenerator {
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
         self.expect_static_arity("FileInput#all", arguments, 1, span)?;
-        if self.expr_may_yield_runtime_string(&arguments[0]) {
+        if self.expr_yields_runtime_or_heap_string(&arguments[0]) {
             let path_label =
                 self.compile_runtime_path_argument(&arguments[0], span, "FileInput#all")?;
             return Ok(self.emit_file_read_to_runtime_string_from_path_label(
@@ -21710,7 +21713,7 @@ impl NativeCodeGenerator {
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
         self.expect_static_arity("FileInput#lines", arguments, 1, span)?;
-        if self.expr_may_yield_runtime_string(&arguments[0]) {
+        if self.expr_yields_runtime_or_heap_string(&arguments[0]) {
             let path_label =
                 self.compile_runtime_path_argument(&arguments[0], span, "FileInput#lines")?;
             let content = self.emit_file_read_to_runtime_string_from_path_label(
@@ -22360,7 +22363,7 @@ impl NativeCodeGenerator {
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
         self.expect_static_arity("Dir#exists", arguments, 1, span)?;
-        if self.expr_may_yield_runtime_string(&arguments[0]) {
+        if self.expr_yields_runtime_or_heap_string(&arguments[0]) {
             let path_label =
                 self.compile_runtime_path_argument(&arguments[0], span, "Dir#exists")?;
             self.emit_runtime_path_exists_label(path_label);
@@ -22390,7 +22393,7 @@ impl NativeCodeGenerator {
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
         self.expect_static_arity("Dir#isDirectory", arguments, 1, span)?;
-        if self.expr_may_yield_runtime_string(&arguments[0]) {
+        if self.expr_yields_runtime_or_heap_string(&arguments[0]) {
             let path_label =
                 self.compile_runtime_path_argument(&arguments[0], span, "Dir#isDirectory")?;
             self.emit_runtime_path_type_check_label(path_label, true, span, "Dir#isDirectory");
@@ -22418,7 +22421,7 @@ impl NativeCodeGenerator {
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
         self.expect_static_arity("Dir#isFile", arguments, 1, span)?;
-        if self.expr_may_yield_runtime_string(&arguments[0]) {
+        if self.expr_yields_runtime_or_heap_string(&arguments[0]) {
             let path_label =
                 self.compile_runtime_path_argument(&arguments[0], span, "Dir#isFile")?;
             self.emit_runtime_path_type_check_label(path_label, false, span, "Dir#isFile");
@@ -22445,7 +22448,7 @@ impl NativeCodeGenerator {
     ) -> Result<NativeValue, Diagnostic> {
         let name = if recursive { "Dir#mkdirs" } else { "Dir#mkdir" };
         self.expect_static_arity(name, arguments, 1, span)?;
-        if self.expr_may_yield_runtime_string(&arguments[0]) {
+        if self.expr_yields_runtime_or_heap_string(&arguments[0]) {
             let path_label = self.compile_runtime_path_argument(&arguments[0], span, name)?;
             if recursive {
                 self.emit_dir_mkdirs_label(path_label, span, name);
@@ -22477,7 +22480,7 @@ impl NativeCodeGenerator {
     ) -> Result<NativeValue, Diagnostic> {
         let name = if full { "Dir#listFull" } else { "Dir#list" };
         self.expect_static_arity(name, arguments, 1, span)?;
-        if self.expr_may_yield_runtime_string(&arguments[0]) {
+        if self.expr_yields_runtime_or_heap_string(&arguments[0]) {
             let (path_label, path) =
                 self.compile_runtime_path_argument_ref(&arguments[0], span, name)?;
             return Ok(self.emit_dir_list_path_label(path_label, path, full, span, name));
@@ -22545,7 +22548,7 @@ impl NativeCodeGenerator {
         span: Span,
     ) -> Result<NativeValue, Diagnostic> {
         self.expect_static_arity("Dir#delete", arguments, 1, span)?;
-        if self.expr_may_yield_runtime_string(&arguments[0]) {
+        if self.expr_yields_runtime_or_heap_string(&arguments[0]) {
             let path_label =
                 self.compile_runtime_path_argument(&arguments[0], span, "Dir#delete")?;
             self.emit_dir_delete_label(path_label, span, "Dir#delete");
@@ -27053,7 +27056,10 @@ impl NativeCodeGenerator {
         name: &str,
     ) -> Result<(DataLabel, NativeStringRef), Diagnostic> {
         let value = self.compile_expr(expr)?;
-        let Some(path) = self.native_string_ref(value) else {
+        // A heap string is copied into a runtime pair rather than refused:
+        // that is what an annotated `String` parameter arrives as, and a
+        // path is exactly the place a caller passes one.
+        let Some(path) = self.native_string_ref_or_copy(value, span, name) else {
             return Err(unsupported(
                 span,
                 &format!("native {name} for non-string path"),
@@ -30514,9 +30520,32 @@ impl NativeCodeGenerator {
                 rhs,
                 ..
             } => self.heap_string_yield(lhs, locals) || self.heap_string_yield(rhs, locals),
-            Expr::Call { callee, .. } => match callee.as_ref() {
-                Expr::Identifier { name, .. } => {
-                    heap_string_returning_helper(&self.builtin_name_for_identifier(name))
+            Expr::Call {
+                callee, arguments, ..
+            } => match callee.as_ref() {
+                Expr::Identifier { name, .. }
+                    if heap_string_returning_helper(&self.builtin_name_for_identifier(name)) =>
+                {
+                    true
+                }
+                // A string helper applied to a heap string yields a string
+                // whose contents are only known at run time. Saying "heap"
+                // here is a merge *strategy*, not a claim about the exact
+                // representation: the coercion accepts a static, runtime or
+                // heap string, so predicting heap for either shape is sound
+                // and is what lets `if (c) heapString else substring(...)`
+                // join at all.
+                Expr::Identifier { name, .. }
+                    if runtime_string_returning_helper(&self.builtin_name_for_identifier(name)) =>
+                {
+                    arguments
+                        .first()
+                        .is_some_and(|argument| self.heap_string_yield(argument, locals))
+                }
+                Expr::FieldAccess { target, field, .. }
+                    if runtime_string_returning_helper(field) =>
+                {
+                    self.heap_string_yield(target, locals)
                 }
                 callee => self
                     .callee_return_value_hint(callee)
@@ -30555,6 +30584,32 @@ impl NativeCodeGenerator {
                 (then_value == else_value).then_some(then_value)
             }
             _ => None,
+        }
+    }
+
+    /// Whether a file or directory argument is a string this backend has to
+    /// read at run time. Wider than `expr_may_yield_runtime_string` by one
+    /// case: a heap string, which is what an annotated `String` parameter
+    /// holds. The wider answer is confined to the file and directory
+    /// builtins because their helpers copy a heap string into a runtime pair
+    /// (`native_string_ref_or_copy`), while widening the general predicate
+    /// has been measured to break programs whose other string paths cannot.
+    fn expr_yields_runtime_or_heap_string(&self, expr: &Expr) -> bool {
+        if self.expr_may_yield_runtime_string(expr) {
+            return true;
+        }
+        if matches!(
+            self.native_value_hint_for_expr(expr),
+            Some(NativeValue::HeapString)
+        ) {
+            return true;
+        }
+        match expr {
+            Expr::Identifier { name, .. } => matches!(
+                self.lookup_var(name).map(|slot| slot.value),
+                Some(NativeValue::HeapString)
+            ),
+            _ => false,
         }
     }
 

--- a/crates/klassic-native/src/map_chain.rs
+++ b/crates/klassic-native/src/map_chain.rs
@@ -55,7 +55,6 @@ def klassicMapPut(m: KlassicMapChain<'k, 'v>, key: 'k, value: 'v): KlassicMapCha
         acc = (if (k == key) KlassicMapCons(k, value, acc) else KlassicMapCons(k, v, acc))
         replaced = (if (k == key) true else replaced)
         cur = rest
-        0
       }
     }
   }
@@ -73,7 +72,6 @@ def klassicMapGetOrElse(m: KlassicMapChain<'k, 'v>, key: 'k, fallback: 'v): 'v =
         found = (if (k == key) v else found)
         go = (if (k == key) false else true)
         cur = rest
-        0
       }
     }
   }
@@ -91,7 +89,6 @@ def klassicMapContainsKey(m: KlassicMapChain<'k, 'v>, key: 'k): Boolean = {
         yes = (if (k == key) true else yes)
         go = (if (k == key) false else true)
         cur = rest
-        0
       }
     }
   }
@@ -123,7 +120,6 @@ def klassicMapRender(m: KlassicMapChain<'k, 'v>): String = {
         out = (if (first) (out + k + ": " + v) else (out + ", " + k + ": " + v))
         first = false
         cur = rest
-        0
       }
     }
   }

--- a/crates/klassic-native/src/map_chain.rs
+++ b/crates/klassic-native/src/map_chain.rs
@@ -36,8 +36,8 @@ def klassicMapReverse(m: KlassicMapChain<'k, 'v>): KlassicMapChain<'k, 'v> = {
   mutable go = true
   while (go) {
     cur match {
-      case KlassicMapNil => { go = false; 0 }
-      case KlassicMapCons(k, v, rest) => { acc = KlassicMapCons(k, v, acc); cur = rest; 0 }
+      case KlassicMapNil => { go = false }
+      case KlassicMapCons(k, v, rest) => { acc = KlassicMapCons(k, v, acc); cur = rest }
     }
   }
   acc
@@ -50,7 +50,7 @@ def klassicMapPut(m: KlassicMapChain<'k, 'v>, key: 'k, value: 'v): KlassicMapCha
   mutable go = true
   while (go) {
     cur match {
-      case KlassicMapNil => { go = false; 0 }
+      case KlassicMapNil => { go = false }
       case KlassicMapCons(k, v, rest) => {
         acc = (if (k == key) KlassicMapCons(k, value, acc) else KlassicMapCons(k, v, acc))
         replaced = (if (k == key) true else replaced)
@@ -68,7 +68,7 @@ def klassicMapGetOrElse(m: KlassicMapChain<'k, 'v>, key: 'k, fallback: 'v): 'v =
   mutable go = true
   while (go) {
     cur match {
-      case KlassicMapNil => { go = false; 0 }
+      case KlassicMapNil => { go = false }
       case KlassicMapCons(k, v, rest) => {
         found = (if (k == key) v else found)
         go = (if (k == key) false else true)
@@ -86,7 +86,7 @@ def klassicMapContainsKey(m: KlassicMapChain<'k, 'v>, key: 'k): Boolean = {
   mutable go = true
   while (go) {
     cur match {
-      case KlassicMapNil => { go = false; 0 }
+      case KlassicMapNil => { go = false }
       case KlassicMapCons(k, v, rest) => {
         yes = (if (k == key) true else yes)
         go = (if (k == key) false else true)
@@ -104,8 +104,8 @@ def klassicMapSize(m: KlassicMapChain<'k, 'v>): Int = {
   mutable go = true
   while (go) {
     cur match {
-      case KlassicMapNil => { go = false; 0 }
-      case KlassicMapCons(k, v, rest) => { n = n + 1; cur = rest; 0 }
+      case KlassicMapNil => { go = false }
+      case KlassicMapCons(k, v, rest) => { n = n + 1; cur = rest }
     }
   }
   n
@@ -118,7 +118,7 @@ def klassicMapRender(m: KlassicMapChain<'k, 'v>): String = {
   mutable go = true
   while (go) {
     cur match {
-      case KlassicMapNil => { go = false; 0 }
+      case KlassicMapNil => { go = false }
       case KlassicMapCons(k, v, rest) => {
         out = (if (first) (out + k + ": " + v) else (out + ", " + k + ": " + v))
         first = false

--- a/crates/klassic-native/src/portable_asm.rs
+++ b/crates/klassic-native/src/portable_asm.rs
@@ -141,21 +141,6 @@ pub trait PortableAsm {
     // future ARM-Linux `svc`), so that per-OS emission stays inside the
     // impl and never leaks into the portable GC code that calls them.
     /// Write `len` bytes at data label `data` to file descriptor `fd`.
-    /// Save whatever this backend needs kept across the load barrier's slow
-    /// path, and restore it. The policy around the call is shared; *which
-    /// registers a backend has live there* is the one genuinely
-    /// platform-specific part of it, and three of the aarch64 ones have no
-    /// name in the portable register set. The default is to save nothing,
-    /// which is what a backend whose slow routine already keeps what its
-    /// callers hold wants.
-    fn save_barrier_registers(&mut self) {}
-    fn restore_barrier_registers(&mut self) {}
-
-    /// The same, around an allocation. A different list from the barrier's:
-    /// the allocation's own arguments are live where the barrier's are not.
-    fn save_alloc_registers(&mut self) {}
-    fn restore_alloc_registers(&mut self) {}
-
     fn plat_write_data(&mut self, fd: u64, data: Self::DataLabel, len: usize);
     /// Terminate the process with status `code` (does not return).
     fn plat_exit(&mut self, code: u64);
@@ -457,7 +442,7 @@ pub fn emit_gc_grow_budget<E: PortableAsm>(
 ///
 /// The argument registers are the shared `gc_alloc`'s own -- `V7` the size
 /// and `V6` the tag -- which is why this can be written once. What a backend
-/// needs kept across the call is asked of it, as with the barrier.
+/// needs kept across the call is the routine's own job, as with the barrier.
 pub fn emit_gc_alloc_object<E: PortableAsm>(
     out: &mut E,
     entry: E::TextLabel,
@@ -466,9 +451,7 @@ pub fn emit_gc_alloc_object<E: PortableAsm>(
 ) {
     out.mov_imm64(Reg::V7, payload_bytes);
     out.mov_imm64(Reg::V6, tag);
-    out.save_alloc_registers();
     out.call_label(entry);
-    out.restore_alloc_registers();
 }
 
 /// Box a scalar into its own single-slot `RAW_BYTES` object, scalar in `V0`
@@ -503,15 +486,15 @@ pub fn emit_gc_unbox_scalar<E: PortableAsm>(out: &mut E) {
 ///
 /// The value is in `V0` and the field's address is wherever the slow routine
 /// expects it -- the caller puts it there, since that is the one part of this
-/// that differs. What has to be kept across the call is asked of the backend
-/// (`save_barrier_registers`), because that is the other part.
+/// that differs. Keeping registers across the call is the routine's own job:
+/// a backend that needs any kept passes a label that saves them, calls the
+/// routine and restores, so no call site carries a list that could drift from
+/// what the routine clobbers.
 pub fn emit_gc_load_barrier<E: PortableAsm>(out: &mut E, slow: E::TextLabel) {
     let ok = out.create_text_label();
     out.test_reg_reg(Reg::V0, Reg::BadMask);
     out.jcc_label(Condition::Equal, ok);
-    out.save_barrier_registers();
     out.call_label(slow);
-    out.restore_barrier_registers();
     out.bind_text_label(ok);
     out.and_reg_reg(Reg::V0, Reg::ColorStrip);
 }

--- a/crates/klassic-syntax/src/lib.rs
+++ b/crates/klassic-syntax/src/lib.rs
@@ -410,6 +410,11 @@ struct Token {
 #[derive(Clone, Debug, PartialEq)]
 enum TokenKind {
     Int(i64, IntLiteralKind),
+    /// A decimal integer literal whose digits do not fit an `i64`. The lexer
+    /// keeps the magnitude instead of failing so the parser can fold a
+    /// preceding unary minus into it: `-9223372036854775808` is the one value
+    /// that is only reachable that way. Anywhere else this token is an error.
+    IntOutOfRange(u128, IntLiteralKind),
     Double(f64, FloatLiteralKind),
     String(String),
     // Interpolated string template pieces. A string with `#{...}` holes
@@ -482,6 +487,19 @@ enum TokenKind {
     LBrace,
     RBrace,
     Eof,
+}
+
+/// The magnitude of `i64::MIN`. It is the only out-of-range magnitude a unary
+/// minus can turn into a value, which is why the range check waits for the
+/// sign rather than happening in the lexer.
+const I64_MIN_MAGNITUDE: u128 = 1u128 << 63;
+
+fn negate_out_of_range_literal(magnitude: u128, span: Span) -> Result<i64, Diagnostic> {
+    if magnitude == I64_MIN_MAGNITUDE {
+        Ok(i64::MIN)
+    } else {
+        Err(Diagnostic::parse(span, "integer literal is out of range"))
+    }
 }
 
 pub fn parse_source(source: &SourceFile) -> Result<Expr, Diagnostic> {
@@ -835,15 +853,18 @@ impl<'a> Lexer<'a> {
         };
 
         let text = self.input[start..text_end].replace('_', "");
-        let value = text.parse::<i64>().map_err(|_| {
-            Diagnostic::parse(
-                Span::new(start, text_end),
-                "integer literal is out of range",
-            )
-        })?;
+        // Out of range is not decided here: `-9223372036854775808` reaches the
+        // lexer as digits whose magnitude is one past `i64::MAX`, and only the
+        // parser knows whether a unary minus is about to absorb it. Digits too
+        // large even for the magnitude saturate, which keeps them out of range
+        // under every sign.
+        let kind_token = match text.parse::<i64>() {
+            Ok(value) => TokenKind::Int(value, kind),
+            Err(_) => TokenKind::IntOutOfRange(text.parse::<u128>().unwrap_or(u128::MAX), kind),
+        };
 
         Ok(Token {
-            kind: TokenKind::Int(value, kind),
+            kind: kind_token,
             span: Span::new(start, self.position),
         })
     }
@@ -1090,6 +1111,7 @@ struct Parser {
     /// must be declared before use (forward references already fail), so
     /// the set is complete by the time a `#Name` is reached.
     record_names: std::collections::HashSet<String>,
+    enum_variant_names: std::collections::HashSet<String>,
 }
 
 impl Parser {
@@ -1098,6 +1120,7 @@ impl Parser {
             tokens,
             index: 0,
             record_names: std::collections::HashSet::new(),
+            enum_variant_names: std::collections::HashSet::new(),
         }
     }
 
@@ -1616,6 +1639,10 @@ impl Parser {
                 }
             }
             let (variant_name, variant_span) = self.expect_identifier()?;
+            // Remembered so a pattern can name this constructor even when the
+            // name does not start with an uppercase letter, which is how the
+            // pattern parser otherwise tells a constructor from a binding.
+            self.enum_variant_names.insert(variant_name.clone());
             let params = if matches!(self.peek().kind, TokenKind::LParen) {
                 self.bump();
                 let mut entries = Vec::new();
@@ -1818,6 +1845,13 @@ impl Parser {
                             span: start.merge(int_span),
                         })
                     }
+                    TokenKind::IntOutOfRange(magnitude, _) => {
+                        let int_span = self.bump().span;
+                        Ok(Pattern::LiteralInt {
+                            value: negate_out_of_range_literal(magnitude, int_span)?,
+                            span: start.merge(int_span),
+                        })
+                    }
                     _ => Err(Diagnostic::parse(
                         self.peek().span,
                         "expected integer literal after `-` in pattern",
@@ -1837,12 +1871,16 @@ impl Parser {
                 if name == "_" {
                     return Ok(Pattern::Wildcard { span: head_span });
                 }
+                // A constructor pattern is spelled with a leading capital.
+                // A name that was declared as an enum variant is one whatever
+                // it is spelled like, which is what lets generated code use
+                // the `__`-prefixed convention used for synthesized names.
                 let starts_upper = name
                     .chars()
                     .next()
                     .map(|c| c.is_ascii_uppercase())
                     .unwrap_or(false);
-                if starts_upper {
+                if starts_upper || self.enum_variant_names.contains(&name) {
                     let (args, end_span) = if matches!(self.peek().kind, TokenKind::LParen) {
                         self.bump();
                         let mut args = Vec::new();
@@ -2308,7 +2346,7 @@ impl Parser {
             ));
         };
         self.consume_separators();
-        let rhs = self.parse_assignment()?;
+        let rhs = self.parse_assignment_rhs()?;
         let value = match compound {
             None => rhs,
             Some(op) => Expr::Binary {
@@ -2327,6 +2365,19 @@ impl Parser {
             name,
             value: Box::new(value),
         })
+    }
+
+    /// The right-hand side of an assignment. `if`, `while` and `foreach` are
+    /// expressions everywhere else in the language, so they are expressions
+    /// here too; `parse_assignment` alone descends past the keyword handlers
+    /// and reports "expected an expression" at the `if`.
+    fn parse_assignment_rhs(&mut self) -> Result<Expr, Diagnostic> {
+        match self.peek().kind {
+            TokenKind::If => self.parse_if_expression(),
+            TokenKind::While => self.parse_while_expression(),
+            TokenKind::Foreach => self.parse_foreach_expression(),
+            _ => self.parse_assignment(),
+        }
     }
 
     fn parse_ternary(&mut self) -> Result<Expr, Diagnostic> {
@@ -2456,6 +2507,18 @@ impl Parser {
             }
             TokenKind::Minus => {
                 let token = self.bump().span;
+                // `-9223372036854775808` is one literal, not a negation of a
+                // literal that does not exist.
+                if let TokenKind::IntOutOfRange(magnitude, literal_kind) = self.peek().kind.clone()
+                {
+                    let int_span = self.bump().span;
+                    let value = negate_out_of_range_literal(magnitude, int_span)?;
+                    return Ok(Expr::Int {
+                        value,
+                        kind: literal_kind,
+                        span: token.merge(int_span),
+                    });
+                }
                 let expr = self.parse_unary()?;
                 Ok(Expr::Unary {
                     op: UnaryOp::Minus,
@@ -2796,6 +2859,10 @@ impl Parser {
                     span: token,
                 })
             }
+            TokenKind::IntOutOfRange(..) => Err(Diagnostic::parse(
+                self.peek().span,
+                "integer literal is out of range",
+            )),
             TokenKind::Double(value, kind) => {
                 let token = self.bump().span;
                 Ok(Expr::Double {
@@ -4077,6 +4144,12 @@ fn token_text(kind: &TokenKind) -> String {
             IntLiteralKind::Int => value.to_string(),
             IntLiteralKind::Long => format!("{value}L"),
         },
+        TokenKind::IntOutOfRange(magnitude, kind) => match kind {
+            IntLiteralKind::Byte => format!("{magnitude}BY"),
+            IntLiteralKind::Short => format!("{magnitude}S"),
+            IntLiteralKind::Int => magnitude.to_string(),
+            IntLiteralKind::Long => format!("{magnitude}L"),
+        },
         TokenKind::Double(value, kind) => match kind {
             FloatLiteralKind::Float => format!("{value}F"),
             FloatLiteralKind::Double => value.to_string(),
@@ -4158,6 +4231,7 @@ fn needs_spacing_between(previous: Option<&TokenKind>, next: Option<&TokenKind>)
             kind,
             TokenKind::Identifier(_)
                 | TokenKind::Int(..)
+                | TokenKind::IntOutOfRange(..)
                 | TokenKind::Double(..)
                 | TokenKind::True
                 | TokenKind::False
@@ -4984,5 +5058,58 @@ mod tests {
             }
             other => panic!("unexpected program: {other:?}"),
         }
+    }
+
+    #[test]
+    fn the_most_negative_int_is_a_literal() {
+        // The digits alone are one past `i64::MAX`; the minus is what makes
+        // them a value, so the range check has to wait for it.
+        let file = SourceFile::new("test.kl", "-9223372036854775808");
+        let program = parse_source(&file).expect("program should parse");
+        match program {
+            Expr::Int { value, .. } => assert_eq!(value, i64::MIN),
+            other => panic!("unexpected program: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_larger_magnitude_is_still_out_of_range() {
+        for source in ["9223372036854775808", "-9223372036854775809", "-1e0000000"] {
+            let file = SourceFile::new("test.kl", source);
+            if let Ok(program) = parse_source(&file) {
+                // `-1e0000000` is a float and may parse; the integer cases
+                // must not.
+                assert!(
+                    !matches!(program, Expr::Int { .. }),
+                    "{source} should not be an int literal"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn an_assignment_takes_an_if_on_its_right() {
+        let file = SourceFile::new("test.kl", "mutable x = 1\nx = if (true) 2 else 3");
+        let program = parse_source(&file).expect("program should parse");
+        match program {
+            Expr::Block { expressions, .. } => {
+                assert!(matches!(expressions[1], Expr::Assign { .. }));
+            }
+            other => panic!("unexpected program: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_declared_variant_is_a_constructor_pattern_whatever_its_spelling() {
+        let source = "enum __A { case __N; case __C(x: Int) }\n\
+                      __C(5) match { case __N => 0; case __C(x) => x }";
+        let file = SourceFile::new("test.kl", source);
+        parse_source(&file).expect("program should parse");
+    }
+
+    #[test]
+    fn an_undeclared_underscore_name_is_still_a_binding() {
+        let file = SourceFile::new("test.kl", "1 match { case _Rest => 99 }");
+        parse_source(&file).expect("program should parse");
     }
 }

--- a/crates/klassic-types/src/lib.rs
+++ b/crates/klassic-types/src/lib.rs
@@ -2019,7 +2019,13 @@ impl TypeChecker {
                     ));
                 }
                 let value_type = self.infer_expr(value)?;
-                self.enforce_assignable(binding.ty, value_type, *span)
+                self.enforce_assignable(binding.ty, value_type, *span)?;
+                // An assignment is done for its effect. Giving it the assigned
+                // value's type meant two `match` arms that both end in one
+                // disagreed unless the values happened to share a type, which
+                // forced a throwaway value at the end of every arm written for
+                // effect.
+                Ok(Type::Unit)
             }
             Expr::Unary { op, expr, span } => {
                 let inner = self.infer_expr(expr)?;

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -2019,6 +2019,12 @@ side of a branch.
   literals are static storage and a list of heap values needs the runtime
   representation issue #433 tracks, which is a separate piece of work
   (issue #620, half).
+- aarch64 folds an `if` whose condition is settled while compiling, taking
+  only that branch. `static_condition` answers narrowly -- the emptiness of a
+  collection whose type says it has no elements -- which is the shape a
+  generic helper's base case is written in, and compiling the other branch
+  anyway is what refused `if (isEmpty(xs)) xs else <something about head(xs)>`
+  when it was called with `[]`. x86-64 already did this (issue #616).
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -2025,6 +2025,16 @@ side of a branch.
   generic helper's base case is written in, and compiling the other branch
   anyway is what refused `if (isEmpty(xs)) xs else <something about head(xs)>`
   when it was called with `[]`. x86-64 already did this (issue #616).
+- The GC's two call sites no longer carry register-save lists. aarch64 emits
+  one wrapper per routine -- save `BARRIER_SAVED` / `ALLOC_SAVED`, call the
+  routine, restore, return -- and every barriered read and every allocation
+  `bl`s the wrapper. The four `save_*_registers` / `restore_*_registers` trait
+  hooks are gone from `PortableAsm`, and with them the class of bug where one
+  site's list and the routine's actual clobbers drift apart (which is how the
+  V-register-named list mapped X10-X12 to the wrong physical registers when it
+  was first tried). x86-64 saved nothing at these sites and is unchanged; the
+  fast path -- the colour test and the strip, which is what almost every load
+  executes -- does not change on either (issue #618).
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1997,6 +1997,17 @@ side of a branch.
   native backends share. It was an error, so a program could reach infinity by
   multiplying (`1e300 * 1e300` folded to `inf`) and not by dividing. Integer
   division by zero stays an error: there is no integer infinity (issue #627).
+- aarch64 gained `Map#remove` and `Map#containsValue` (the same chain walk
+  `Map#put` does, and the mirror of `Map#containsKey`'s scan), and the rest of
+  `std.map` / `std.set` came with them by fixing what they had in common: a
+  collection rebuilt by folding from an empty one. `Set#add` on the empty set
+  now takes its element type from the element being added, and a map value is
+  allowed to be `Nullable` -- `Map#put(acc, k, Map#get(m, k))` is how
+  `filterKeys` and `merge` are written, and `Map#get` answers a value *or
+  nothing*. A nullable operand in arithmetic is unboxed to the value it holds,
+  which is what `mapValues`, `filterValues` and `foldMap` do (issue #615).
+  Still unsupported everywhere: `mapKeys`, which goes through
+  `Map#fromPairs`.
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1985,6 +1985,13 @@ side of a branch.
   `test-programs/proof-surface.kl` is the first `.kl` file in the repo using
   either keyword, which is why a whole target refusing them went unnoticed for
   a release (issue #625).
+- An assignment is typed `Unit` and evaluates to unit, on every path: the
+  checker, the evaluator, and both native backends. It used to take the
+  assigned value's type, so two `match` arms that both ended in an assignment
+  disagreed unless the values happened to share a type -- which is why every
+  loop-shaped helper in `map_chain.rs` ended its arms with a throwaway `0`.
+  Those eight are gone. aarch64 also gained an expression-position assignment
+  and printing of unit as `()` (issue #610).
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1925,6 +1925,39 @@ side of a branch.
   ```klassic,norun documents a program that needs arguments or stdin and is
   extracted but not run. Four blocks were missing the `import` line they
   needed when the harness first ran (issue #629).
+- The seven system stdlib modules (`std.env`, `std.cli`, `std.dir`,
+  `std.process`, `std.file`, `std.path`, `std.time`) carry type annotations
+  now. They had none, which each backend then failed on for its own reason:
+  aarch64 could not give a binding a type it never learned ("a call to
+  `__mod_std_env_exists`, whose result type cannot be determined") and x86-64
+  could not tell the string `lastIndexOf` from the list one. Annotating also
+  uncovers what the missing annotations were hiding, which is the rest of this
+  entry (issue #622).
+- An annotated `String` parameter arrives as a heap string, so annotating a
+  definition used to be what stopped a program compiling. Three places on the
+  x86-64 side now take a heap string where they took only a static or runtime
+  one: the file and directory builtins' path and content arguments (through
+  `expr_yields_runtime_or_heap_string` plus `native_string_ref_or_copy`),
+  `indexOf`/`lastIndexOf`, and the `if` merge, which recognises a string
+  helper applied to a heap string as string-yielding and so joins
+  `if (c) heapString else substring(...)`. The general
+  `expr_may_yield_runtime_string` predicate is deliberately *not* widened --
+  that was measured to break programs whose other string paths cannot copy.
+- aarch64 canonicalises the v0.1 prelude spellings (`getEnv` ->
+  `Environment#get`, `args` -> `CommandLine#args`, and five more) in both
+  `builtin_call` and `static_type_under`, so the stdlib modules written
+  against the short names compile there (issue #623). It also gained
+  `Dir#current` (Darwin `__getcwd`, which fills a buffer and answers 0, so the
+  length comes from scanning to the terminator), `Dir#home`, `Dir#temp` and
+  `Dir#isFile`.
+- aarch64's `annotation_type` resolves a structural record written as its
+  fields, `{ year: Int; month: Int }`, interning it the way a record literal
+  interns; `std.time` returns one. `assignable` also accepts a `Nullable(T)`
+  body under a `T` return annotation, which is what `std.cli`'s `option`
+  is -- a String or nothing.
+- `tests/cross-exec/36-stdlib-system-modules.kl` covers all seven modules on
+  all three targets, imported under aliases (three of them declare `exists`,
+  two declare `join`).
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1979,6 +1979,12 @@ side of a branch.
 - The enum lowering now descends into string interpolation. It did not, so
   `"#{Some(1)}"` kept a constructor call no backend had declared -- a shared
   middle-end gap that showed up as an unknown function on aarch64.
+- aarch64 steps over an `axiom` / `theorem` declaration instead of refusing
+  it. Proofs are checked before any backend runs, so a declaration produces no
+  code -- exactly like the other declaration forms already listed beside it.
+  `test-programs/proof-surface.kl` is the first `.kl` file in the repo using
+  either keyword, which is why a whole target refusing them went unnoticed for
+  a release (issue #625).
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -2035,6 +2035,15 @@ side of a branch.
   was first tried). x86-64 saved nothing at these sites and is unchanged; the
   fast path -- the colour test and the strip, which is what almost every load
   executes -- does not change on either (issue #618).
+- A map created by `Map#empty()` and never put into can be asked about a key,
+  its size and its emptiness. Creating one is what triggers the chain
+  lowering, so the chain's helpers have to typecheck for a chain that stays
+  empty -- they did not once an assignment started yielding unit, because the
+  arms of a `match` written for effect no longer agreed with a sibling arm
+  ending in a bare `0`. Covered by
+  `tests/cross-exec/39-empty-map-questions.kl`, kept separate from the
+  grown-map fixtures because the lowering is all-or-nothing per program
+  (issue #614).
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1958,6 +1958,27 @@ side of a branch.
 - `tests/cross-exec/36-stdlib-system-modules.kl` covers all seven modules on
   all three targets, imported under aliases (three of them declare `exists`,
   two declare `join`).
+- aarch64 can print a value of an enum the program declared itself. The
+  shared lowering erases a monomorphic enum into `__gc_record` calls, so such
+  a value arrives as a bare pointer; x86-64 recovered its identity from the
+  `__enum_shape_named(value, "Variant")` marker the lowering leaves behind,
+  and aarch64 dropped the marker. It reads it now, giving the value
+  `ValueType::LoweredEnum(index)` into `LoweredEnumTable` -- built from the
+  lowering's own variant table plus each field's annotation text, which is
+  the only place a payload that is itself an enum still says *which* enum.
+  `emit_print_lowered_enum` / `emit_lowered_enum_to_str` switch on the boxed
+  tag in slot 0 and render the payloads from slots 1.. , descending into a
+  nested enum and refusing (like the generic path) an enum that holds itself
+  (issue #619).
+- `LoweredEnum` and `Ptr` are assignable to each other in both directions and
+  join as `Ptr`, because naming which enum a pointer is must only add what
+  printing needs and never narrow where the value can go. It is also
+  normalised to `Ptr` wherever a type is *stored* -- an enum shape's payload
+  -- so `Ok(step)` built from an argument and `Ok(step)` built from an
+  annotation stay one shape.
+- The enum lowering now descends into string interpolation. It did not, so
+  `"#{Some(1)}"` kept a constructor call no backend had declared -- a shared
+  middle-end gap that showed up as an unknown function on aarch64.
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -2008,6 +2008,17 @@ side of a branch.
   which is what `mapValues`, `filterValues` and `foldMap` do (issue #615).
   Still unsupported everywhere: `mapKeys`, which goes through
   `Map#fromPairs`.
+- x86-64 compares a string with `null`. A static or runtime string is a
+  (data, length) pair in fixed storage, so it is never null and the answer is
+  settled while compiling; a heap string is a pointer, so the answer is
+  whether that pointer is zero. It reported "equality for values with
+  different types", which is the first thing a caller writes after a lookup
+  that may not have found anything (issue #624).
+- aarch64 holds a lowered enum in a list (`ListElem::LoweredEnum`), so
+  `[Sm(1), Nn]` builds and prints there. x86-64 still refuses it: its list
+  literals are static storage and a list of heap values needs the runtime
+  representation issue #433 tracks, which is a separate piece of work
+  (issue #620, half).
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -2053,6 +2053,13 @@ side of a branch.
   Calling the result on the spot always worked; the binding is what ruled out
   currying and partial application (issue #621). A list *of* such lambdas is
   still refused -- a lambda has no value to put in a list.
+- A recursive generic definition compiles on aarch64 (it specialises per
+  argument-type tuple) and, on x86-64, wherever the call can be inlined with a
+  concrete list. `stdlibFilter` in the prelude carries an annotation now,
+  which moves its x86-64 diagnostic from "its result type is neither
+  annotated nor inferable" -- a fixable-sounding complaint that was not the
+  real one -- to "this backend cannot pass `xs` (`List<'a>`) by itself", which
+  is the actual blocker and the one issue #433 tracks (issue #613, half).
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1992,6 +1992,11 @@ side of a branch.
   loop-shaped helper in `map_chain.rs` ended its arms with a throwaway `0`.
   Those eight are gone. aarch64 also gained an expression-position assignment
   and printing of unit as `()` (issue #610).
+- Floating-point division by zero follows IEEE 754 -- `1.0 / 0.0` is infinity
+  and `0.0 / 0.0` is NaN -- in the evaluator and in the static fold both
+  native backends share. It was an error, so a program could reach infinity by
+  multiplying (`1e300 * 1e300` folded to `inf`) and not by dividing. Integer
+  division by zero stays an error: there is no integer infinity (issue #627).
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -1903,6 +1903,28 @@ side of a branch.
   inherits the enclosing builtin's own name (e.g. `map: ...`) rather than
   naming the callback itself — an improvement over no name at all, but not
   fully precise; left as a documented limitation rather than chased further.
+- The lexer no longer decides whether a decimal integer literal is in range:
+  `-9223372036854775808` reaches it as digits one past `i64::MAX`, and only
+  the parser knows whether a unary minus is about to absorb them. Digits that
+  do not fit become `TokenKind::IntOutOfRange(magnitude, kind)`, which the
+  unary-minus arms in both the expression and the pattern parser turn into
+  `i64::MIN` when the magnitude is exactly `1 << 63` and reject otherwise;
+  anywhere else the token is the same "integer literal is out of range" it
+  always was (issue #628).
+- An assignment's right-hand side goes through `parse_assignment_rhs`, which
+  admits the expression keywords `if` / `while` / `foreach` before falling
+  back to `parse_assignment`. `x = if (c) a else b` used to need parentheses
+  because those keywords are handled above `parse_assignment`, so the
+  descent reported "expected an expression" at the `if` (issue #609).
+- The pattern parser now treats a name as a constructor when it was declared
+  as an enum variant, in addition to the existing leading-capital rule, so a
+  variant named with the `__` convention used for synthesized names matches.
+  An undeclared `_`-prefixed name stays a binding (issue #611).
+- `tests/book_examples.rs` extracts every ```klassic block under
+  `docs/book/src` and runs it through the evaluator; an info string of
+  ```klassic,norun documents a program that needs arguments or stdin and is
+  extracted but not run. Four blocks were missing the `import` line they
+  needed when the harness first ran (issue #629).
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -2044,6 +2044,15 @@ side of a branch.
   `tests/cross-exec/39-empty-map-questions.kl`, kept separate from the
   grown-map fixtures because the lowering is all-or-nothing per program
   (issue #614).
+- aarch64 binds a lambda that a *call* produced: `val add3 = adder(3)`. A
+  lambda has no runtime representation there -- its body is compiled where it
+  is called -- so what is bound is the lambda plus the arguments it closed
+  over, each materialised into a slot of the caller's frame and carried in
+  `CapturedEnv::values`. The slots outlive the binding, so the body reads them
+  when the lambda is finally called, and a heap-reference capture is rooted.
+  Calling the result on the spot always worked; the binding is what ruled out
+  currying and partial application (issue #621). A list *of* such lambdas is
+  still refused -- a lambda has no value to put in a list.
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -2060,6 +2060,13 @@ side of a branch.
   annotated nor inferable" -- a fixable-sounding complaint that was not the
   real one -- to "this backend cannot pass `xs` (`List<'a>`) by itself", which
   is the actual blocker and the one issue #433 tracks (issue #613, half).
+- A `val` annotated with a generic enum applied to concrete types gives its
+  binding that shape. `val e: Chain<String, Int> = Nil` builds the empty case,
+  which fixes nothing on its own, so a helper walking it had no idea what its
+  fields hold. Reading the shape off the annotation is exact -- every type
+  argument is named -- so it is not the partial resolution issue #612 is
+  about, which stays refused. Covered by
+  `tests/cross-exec/41-annotated-generic-enum.kl` (issue #612, the safe part).
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/docs/book/src/reference/enums.md
+++ b/docs/book/src/reference/enums.md
@@ -24,6 +24,9 @@ function.
 ## Constructing values
 
 ```klassic
+import std.result
+import std.option
+
 val good = Ok(42)             // Result<Int, _>
 val bad  = Err("nope")        // Result<_, String>
 val maybe = Some("hi")        // Option<String>
@@ -36,6 +39,8 @@ Postfix `match` dispatches on the variant tag and binds the
 positional fields inside each arm body:
 
 ```klassic
+import std.option
+
 def describe(o) = o match {
   case Some(value) => "got " + toString(value)
   case None        => "nothing"

--- a/docs/book/src/reference/stdlib-modules.md
+++ b/docs/book/src/reference/stdlib-modules.md
@@ -403,7 +403,8 @@ import std.dir.{current, home, temp, isDirectory, list}
 
 println(current())            // current working directory
 println(home())               // user's home directory
-println(list("/tmp"))         // directory entries
+println(isDirectory(temp()))  // true
+println(list(temp()))         // directory entries
 ```
 
 ## std.process

--- a/docs/book/src/reference/stdlib-modules.md
+++ b/docs/book/src/reference/stdlib-modules.md
@@ -221,6 +221,8 @@ enum Option<a> {
 Pattern-match on it directly when the helpers don't fit:
 
 ```klassic
+import std.option
+
 val n = some(42) match {
   case Some(v) => v
   case None    => 0
@@ -294,6 +296,8 @@ enum Result<a, e> {
 Direct pattern matching is also available:
 
 ```klassic
+import std.result
+
 val message = ok(42) match {
   case Ok(v)  => "got " + toString(v)
   case Err(m) => "error: " + m
@@ -407,7 +411,7 @@ println(list("/tmp"))         // directory entries
 Wraps `Process#exit`, `CommandLine#args`, and the StandardInput
 helpers under one module-qualified namespace.
 
-```klassic
+```klassic,norun
 import std.process.{args, stdinAll, exitWith}
 
 val files = args()            // CommandLine#args()

--- a/stdlib/prelude.kl
+++ b/stdlib/prelude.kl
@@ -20,7 +20,7 @@ def stdlibTake(xs, n) = if((n <= 0)) [] else if(isEmpty(xs)) [] else cons(head(x
 
 def stdlibDrop(xs, n) = if((n <= 0)) xs else if(isEmpty(xs)) xs else stdlibDrop(tail(xs), n - 1)
 
-def stdlibFilter(xs, p) = if(isEmpty(xs)) [] else if(p(head(xs))) cons(head(xs))(stdlibFilter(tail(xs), p)) else stdlibFilter(tail(xs), p)
+def stdlibFilter(xs: List<'a>, p: ('a) => Boolean): List<'a> = if(isEmpty(xs)) xs else if(p(head(xs))) cons(head(xs))(stdlibFilter(tail(xs), p)) else stdlibFilter(tail(xs), p)
 
 def stdlibFind(xs, p) = if(isEmpty(xs)) null else if(p(head(xs))) head(xs) else stdlibFind(tail(xs), p)
 

--- a/stdlib/std/cli.kl
+++ b/stdlib/std/cli.kl
@@ -6,18 +6,18 @@ module std.cli
 
 // Returns true when `name` appears verbatim in `args` (e.g.
 // `--verbose`).
-def flag(args, name) = if(isEmpty(args)) false else if((head(args) == name)) true else flag(tail(args), name)
+def flag(args: List<String>, name: String): Boolean = if(isEmpty(args)) false else if((head(args) == name)) true else flag(tail(args), name)
 
 // Returns the value associated with the first occurrence of `name`
 // in `args` (`--out OUT` form: the value follows the flag).
 // Returns `null` when the flag is missing or has no value after it.
-def option(args, name) = if(isEmpty(args)) null else if((head(args) == name)) (if(isEmpty(tail(args))) null else head(tail(args))) else option(tail(args), name)
+def option(args: List<String>, name: String): String = if(isEmpty(args)) null else if((head(args) == name)) (if(isEmpty(tail(args))) null else head(tail(args))) else option(tail(args), name)
 
 // Returns the arguments that do not look like `--flag` style flags.
 // This is the bare positional-args helper; it does not try to be
 // clever about pairing flags with values — callers that need the
 // distinction should use `flag(args, name)` / `option(args, name)`
 // on the original arg list directly.
-def isFlagToken(tok) = if((length(tok) < 2)) false else if((substring(tok, 0, 2) == "--")) true else false
+def isFlagToken(tok: String): Boolean = if((length(tok) < 2)) false else if((substring(tok, 0, 2) == "--")) true else false
 
-def positionals(args) = stdlibFilter(args, (tok) => if(isFlagToken(tok)) false else true)
+def positionals(args: List<String>): List<String> = stdlibFilter(args, (tok) => if(isFlagToken(tok)) false else true)

--- a/stdlib/std/dir.kl
+++ b/stdlib/std/dir.kl
@@ -2,28 +2,28 @@ module std.dir
 
 // Directory helpers wrapping the existing `Dir#*` builtins.
 
-def current() = Dir#current()
+def current(): String = Dir#current()
 
-def home() = Dir#home()
+def home(): String = Dir#home()
 
-def temp() = Dir#temp()
+def temp(): String = Dir#temp()
 
-def exists(path) = Dir#exists(path)
+def exists(path: String): Boolean = Dir#exists(path)
 
-def mkdir(path) = Dir#mkdir(path)
+def mkdir(path: String): Unit = Dir#mkdir(path)
 
-def mkdirs(path) = Dir#mkdirs(path)
+def mkdirs(path: String): Unit = Dir#mkdirs(path)
 
-def isDirectory(path) = Dir#isDirectory(path)
+def isDirectory(path: String): Boolean = Dir#isDirectory(path)
 
-def isFile(path) = Dir#isFile(path)
+def isFile(path: String): Boolean = Dir#isFile(path)
 
-def list(path) = Dir#list(path)
+def list(path: String): List<String> = Dir#list(path)
 
-def listFull(path) = Dir#listFull(path)
+def listFull(path: String): List<String> = Dir#listFull(path)
 
-def delete(path) = Dir#delete(path)
+def delete(path: String): Unit = Dir#delete(path)
 
-def copy(src, dst) = Dir#copy(src, dst)
+def copy(src: String, dst: String): Unit = Dir#copy(src, dst)
 
-def move(src, dst) = Dir#move(src, dst)
+def move(src: String, dst: String): Unit = Dir#move(src, dst)

--- a/stdlib/std/env.kl
+++ b/stdlib/std/env.kl
@@ -6,10 +6,10 @@ module std.env
 // aliases `getEnv`, `hasEnv`, `env`) so the dot-import form and the
 // shorter prelude form stay behaviourally identical.
 
-def get(name) = getEnv(name)
+def get(name: String): String = getEnv(name)
 
-def exists(name) = hasEnv(name)
+def exists(name: String): Boolean = hasEnv(name)
 
-def vars() = env()
+def vars(): List<String> = env()
 
-def getOrElse(name, fallback) = if(hasEnv(name)) getEnv(name) else fallback
+def getOrElse(name: String, fallback: String): String = if(hasEnv(name)) getEnv(name) else fallback

--- a/stdlib/std/file.kl
+++ b/stdlib/std/file.kl
@@ -4,16 +4,16 @@ module std.file
 // builtins. Useful when callers prefer module-qualified imports over
 // the hash-prefixed builtin names.
 
-def readAll(path) = FileInput#readAll(path)
+def readAll(path: String): String = FileInput#readAll(path)
 
-def readLines(path) = FileInput#readLines(path)
+def readLines(path: String): List<String> = FileInput#readLines(path)
 
-def write(path, text) = FileOutput#write(path, text)
+def write(path: String, text: String): Unit = FileOutput#write(path, text)
 
-def append(path, text) = FileOutput#append(path, text)
+def append(path: String, text: String): Unit = FileOutput#append(path, text)
 
-def writeLines(path, lines) = FileOutput#writeLines(path, lines)
+def writeLines(path: String, lines: List<String>): Unit = FileOutput#writeLines(path, lines)
 
-def exists(path) = FileOutput#exists(path)
+def exists(path: String): Boolean = FileOutput#exists(path)
 
-def delete(path) = FileOutput#delete(path)
+def delete(path: String): Unit = FileOutput#delete(path)

--- a/stdlib/std/path.kl
+++ b/stdlib/std/path.kl
@@ -5,25 +5,25 @@ module std.path
 // paths land later when the runtime crate gains target-aware path
 // semantics.
 
-def separator() = "/"
+def separator(): String = "/"
 
-def basename(path) = {
+def basename(path: String): String = {
   val slash = lastIndexOf(path, "/")
   if((slash < 0)) path else substring(path, slash + 1, length(path))
 }
 
-def dirname(path) = {
+def dirname(path: String): String = {
   val slash = lastIndexOf(path, "/")
   if((slash < 0)) "" else if((slash == 0)) "/" else substring(path, 0, slash)
 }
 
-def fileExtension(path) = {
+def fileExtension(path: String): String = {
   val name = basename(path)
   val dot = lastIndexOf(name, ".")
   if((dot <= 0)) "" else substring(name, dot, length(name))
 }
 
-def withoutExtension(path) = {
+def withoutExtension(path: String): String = {
   val name = basename(path)
   val dot = lastIndexOf(name, ".")
   if((dot <= 0)) path else {
@@ -32,7 +32,7 @@ def withoutExtension(path) = {
   }
 }
 
-def join(a, b) = {
+def join(a: String, b: String): String = {
   if(isEmptyString(a)) b else if(isEmptyString(b)) a else {
     val tail = at(a, length(a) - 1)
     if((tail == "/")) a + b else a + "/" + b

--- a/stdlib/std/process.kl
+++ b/stdlib/std/process.kl
@@ -4,10 +4,10 @@ module std.process
 // the StandardInput builtins. All members delegate to the existing
 // builtin so error semantics and native coverage are unchanged.
 
-def args() = CommandLine#args()
+def args(): List<String> = CommandLine#args()
 
-def stdinAll() = stdin()
+def stdinAll(): String = stdin()
 
-def stdinLines() = stdinLines()
+def stdinLines(): List<String> = StandardInput#lines()
 
-def exitWith(code) = Process#exit(code)
+def exitWith(code: Int): Unit = Process#exit(code)

--- a/stdlib/std/time.kl
+++ b/stdlib/std/time.kl
@@ -6,24 +6,24 @@ module std.time
 // date conversion is Howard Hinnant's days-to-civil algorithm on
 // integer arithmetic.
 
-def nowMillis() = Time#nowMillis()
+def nowMillis(): Int = Time#nowMillis()
 
-def durationMillis(startMillis, endMillis) = endMillis - startMillis
+def durationMillis(startMillis: Int, endMillis: Int): Int = endMillis - startMillis
 
 // Floor division (b > 0): rounds toward negative infinity, unlike Klassic's
 // truncating `/` which rounds toward zero. For non-negative `a` this is
 // identical to `/`; for negative `a` we subtract 1 whenever there is a
 // non-zero remainder, matching Python's `//` semantics.
-def timeFloorDiv(a, b) = {
+def timeFloorDiv(a: Int, b: Int): Int = {
   val q = a / b
   if (a - q * b != 0 && a < 0) q - 1 else q
 }
 
-def timePad2(n) = if (n < 10) "0#{n}" else "#{n}"
+def timePad2(n: Int): String = if (n < 10) "0#{n}" else "#{n}"
 
-def timePad3(n) = if (n < 10) "00#{n}" else if (n < 100) "0#{n}" else "#{n}"
+def timePad3(n: Int): String = if (n < 10) "00#{n}" else if (n < 100) "0#{n}" else "#{n}"
 
-def timeRenderCivil(z0, hour, minute, second, ms) = {
+def timeRenderCivil(z0: Int, hour: Int, minute: Int, second: Int, ms: Int): String = {
   val z = z0 + 719468
   val era = z / 146097
   val doe = z - era * 146097
@@ -36,7 +36,7 @@ def timeRenderCivil(z0, hour, minute, second, ms) = {
   "#{year}-" + timePad2(month) + "-" + timePad2(day) + "T" + timePad2(hour) + ":" + timePad2(minute) + ":" + timePad2(second) + "." + timePad3(ms) + "Z"
 }
 
-def formatIso(millis) = {
+def formatIso(millis: Int): String = {
   val totalSeconds = timeFloorDiv(millis, 1000)
   val ms = millis - totalSeconds * 1000
   val days = timeFloorDiv(totalSeconds, 86400)
@@ -47,7 +47,7 @@ def formatIso(millis) = {
   timeRenderCivil(days, hour, minute, second, ms)
 }
 
-def nowIso() = formatIso(nowMillis())
+def nowIso(): String = formatIso(nowMillis())
 
 // ---------------------------------------------------------------------------
 // Internal helpers: Hinnant days-to-civil and its inverse
@@ -55,7 +55,7 @@ def nowIso() = formatIso(nowMillis())
 
 // Decompose epoch-days `z0` to a structural civil record {year, month, day}.
 // This is the core of Howard Hinnant's days_to_civil algorithm.
-def timeDaysToCivil(z0) = {
+def timeDaysToCivil(z0: Int): { year: Int; month: Int; day: Int } = {
   val z = z0 + 719468
   val era = z / 146097
   val doe = z - era * 146097
@@ -69,7 +69,7 @@ def timeDaysToCivil(z0) = {
 }
 
 // Hinnant's days_from_civil: convert (year, month, day) to epoch-days.
-def timeDaysFromCivil(year0, month0, day0) = {
+def timeDaysFromCivil(year0: Int, month0: Int, day0: Int): Int = {
   val yr = if (month0 <= 2) year0 - 1 else year0
   val mo = if (month0 <= 2) month0 + 9 else month0 - 3
   val era = if (yr >= 0) yr / 400 else (yr - 399) / 400
@@ -81,7 +81,7 @@ def timeDaysFromCivil(year0, month0, day0) = {
 
 // Decompose epoch milliseconds to a full date-time record
 // { year, month, day, hour, minute, second } (all UTC).
-def timeDecompose(millis) = {
+def timeDecompose(millis: Int): { year: Int; month: Int; day: Int; hour: Int; minute: Int; second: Int } = {
   val totalSeconds = timeFloorDiv(millis, 1000)
   val days = timeFloorDiv(totalSeconds, 86400)
   val secondOfDay = totalSeconds - days * 86400
@@ -97,32 +97,32 @@ def timeDecompose(millis) = {
 // ---------------------------------------------------------------------------
 
 // UTC year from epoch milliseconds.
-def year(millis) = timeDecompose(millis).year
+def year(millis: Int): Int = timeDecompose(millis).year
 
 // UTC month (1–12) from epoch milliseconds.
-def month(millis) = timeDecompose(millis).month
+def month(millis: Int): Int = timeDecompose(millis).month
 
 // UTC day-of-month (1–31) from epoch milliseconds.
-def day(millis) = timeDecompose(millis).day
+def day(millis: Int): Int = timeDecompose(millis).day
 
 // UTC hour (0–23) from epoch milliseconds.
-def hour(millis) = timeDecompose(millis).hour
+def hour(millis: Int): Int = timeDecompose(millis).hour
 
 // UTC minute (0–59) from epoch milliseconds.
-def minute(millis) = timeDecompose(millis).minute
+def minute(millis: Int): Int = timeDecompose(millis).minute
 
 // UTC second (0–59) from epoch milliseconds.
-def second(millis) = timeDecompose(millis).second
+def second(millis: Int): Int = timeDecompose(millis).second
 
 // ---------------------------------------------------------------------------
 // Composite helpers
 // ---------------------------------------------------------------------------
 
 // Decompose epoch millis into { year; month; day; hour; minute; second }.
-def toDate(millis) = timeDecompose(millis)
+def toDate(millis: Int): { year: Int; month: Int; day: Int; hour: Int; minute: Int; second: Int } = timeDecompose(millis)
 
 // Format as "YYYY-MM-DD HH:MM:SS" (space separator, no timezone suffix).
-def formatHuman(millis) = {
+def formatHuman(millis: Int): String = {
   val dt = timeDecompose(millis)
   "#{dt.year}-" + timePad2(dt.month) + "-" + timePad2(dt.day) + " " +
   timePad2(dt.hour) + ":" + timePad2(dt.minute) + ":" + timePad2(dt.second)
@@ -130,7 +130,7 @@ def formatHuman(millis) = {
 
 // Parse "YYYY-MM-DDTHH:MM:SS.mmmZ" back to epoch milliseconds.
 // The trailing Z is required; the millisecond fraction (.mmm) is optional.
-def parseIso(s) = {
+def parseIso(s: String): Int = {
   val tParts = split(s, "T")
   val datePart = head(tParts)
   val timePartZ = head(tail(tParts))

--- a/test-programs/proof-surface.kl
+++ b/test-programs/proof-surface.kl
@@ -1,0 +1,26 @@
+// The proof surface, in a program that also runs.
+//
+// `axiom` and `theorem` are checked before any backend sees them and produce
+// no code, so a build's only job is to step over them. Nothing exercised that
+// -- there was no `.kl` file in the repo using either keyword -- and one
+// target refused every program containing an `axiom` for a whole release
+// without anyone noticing.
+//
+// The flags that act on this surface are `--warn-trust` (report a trusted
+// proof) and `--deny-trust` (refuse one); both are covered by their own tests
+// in tests/cli_smoke.rs. This file is the half that has to keep building and
+// running everywhere.
+
+axiom reflexive(x: Int): { x == x }
+
+axiom addCommutes(x: Int, y: Int): { x + y == y + x }
+
+// Ordinary code beside them, so a build that mishandled a declaration would
+// take the rest of the program down with it.
+def add(x: Int, y: Int): Int = x + y
+
+println(add(2, 3))
+println(add(3, 2))
+println(add(2, 3) == add(3, 2))
+assertResult(5)(add(2, 3))
+println("done")

--- a/tests/book_examples.rs
+++ b/tests/book_examples.rs
@@ -1,0 +1,150 @@
+//! Every Klassic example printed in the Book has to run.
+//!
+//! The Book is the first thing a reader copies from, so a block that does not
+//! run as printed is a defect even when the surrounding prose is right. Four
+//! blocks were once missing the `import` line they needed, which nothing
+//! caught because nothing ran them.
+//!
+//! A block whose info string is ```klassic,norun is extracted but not run --
+//! for programs that need arguments or stdin to mean anything. Every other
+//! block must exit zero under the evaluator.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn klassic_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_klassic")
+}
+
+fn book_src() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("docs")
+        .join("book")
+        .join("src")
+}
+
+/// Every `.md` under the Book's source directory, in a stable order.
+fn markdown_files(root: &Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|ext| ext == "md") {
+                found.push(path);
+            }
+        }
+    }
+    found.sort();
+    found
+}
+
+struct Block {
+    file: String,
+    index: usize,
+    run: bool,
+    source: String,
+}
+
+/// Fenced blocks whose info string starts with `klassic`.
+fn klassic_blocks(text: &str, file: &str) -> Vec<Block> {
+    let mut blocks = Vec::new();
+    let mut lines = text.lines();
+    let mut index = 0;
+    while let Some(line) = lines.next() {
+        let Some(info) = line.strip_prefix("```") else {
+            continue;
+        };
+        let info = info.trim();
+        if info != "klassic" && !info.starts_with("klassic,") {
+            continue;
+        }
+        let mut source = String::new();
+        for body in lines.by_ref() {
+            if body.trim_end() == "```" {
+                break;
+            }
+            source.push_str(body);
+            source.push('\n');
+        }
+        blocks.push(Block {
+            file: file.to_string(),
+            index,
+            run: !info.contains("norun"),
+            source,
+        });
+        index += 1;
+    }
+    blocks
+}
+
+#[test]
+fn every_book_example_runs() {
+    let root = book_src();
+    let mut blocks = Vec::new();
+    for path in markdown_files(&root) {
+        let text = std::fs::read_to_string(&path).expect("book page should be readable");
+        let name = path
+            .strip_prefix(&root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .to_string();
+        blocks.extend(klassic_blocks(&text, &name));
+    }
+
+    assert!(
+        blocks.len() >= 30,
+        "expected the Book to carry Klassic examples, found {}",
+        blocks.len()
+    );
+
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after the epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("klassic-book-examples-{stamp}"));
+    std::fs::create_dir_all(&dir).expect("temp directory should be creatable");
+
+    let mut failures = Vec::new();
+    for block in &blocks {
+        if !block.run {
+            continue;
+        }
+        let stem = block.file.replace(['/', '\\', '.'], "_");
+        let path = dir.join(format!("{stem}_{}.kl", block.index));
+        std::fs::write(&path, &block.source).expect("example should be writable");
+        let output = Command::new(klassic_bin())
+            .arg(&path)
+            .current_dir(&dir)
+            .output()
+            .expect("klassic should run");
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let detail = if stderr.trim().is_empty() {
+                stdout.trim().to_string()
+            } else {
+                stderr.trim().to_string()
+            };
+            failures.push(format!(
+                "{}#{}: {}",
+                block.file,
+                block.index,
+                detail.lines().next().unwrap_or("(no output)")
+            ));
+        }
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+    assert!(
+        failures.is_empty(),
+        "Book examples that do not run as printed:\n{}",
+        failures.join("\n")
+    );
+}

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -179,6 +179,27 @@ fn native_reads_a_file_through_an_annotated_path() {
     );
 }
 
+/// An assignment is done for its effect and yields unit. It used to take the
+/// assigned value's type, so two `match` arms that both ended in one
+/// disagreed unless the values happened to share a type -- which forced a
+/// throwaway value at the end of every arm written for effect.
+#[test]
+fn an_assignment_yields_unit() {
+    let output = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "enum KM { case KMNil; case KMCons(k: Int, rest: KM) }\nmutable cur: KM = KMCons(1, KMNil)\nmutable go = true\nmutable seen = 0\nwhile (go) {\n  cur match {\n    case KMNil => go = false\n    case KMCons(k, rest) => { seen = seen + k; cur = rest }\n  }\n}\nprintln(seen)\nmutable x = 1\nprintln(x = 5)\nprintln(x)",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        output.status.success(),
+        "arms ending in assignments should agree\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "1\n()\n5\n()\n");
+}
+
 /// std.option / std.result richer API via method-style dispatch. The
 /// clean names are restored now that native module namespacing (#449)
 /// makes the free names safe and receiver-type dispatch picks the right

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -108,6 +108,77 @@ fn declared_variants_are_constructor_patterns() {
     assert_eq!(String::from_utf8_lossy(&output.stdout), "5\n99\n()\n");
 }
 
+/// The system stdlib modules carry type annotations, which is what both
+/// native backends needed: aarch64 could not give a binding a type it never
+/// learned, and x86-64 could not tell the string `lastIndexOf` from the list
+/// one. The evaluator inferred through them either way, so this pins the
+/// answers the annotations have to keep producing.
+#[test]
+fn system_stdlib_modules_are_annotated() {
+    let output = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "import std.path as P\nimport std.env as E\nimport std.time as T\nimport std.cli as C\nprintln(P.basename(\"/a/b/c.txt\"))\nprintln(P.dirname(\"/a/b/c.txt\"))\nprintln(P.fileExtension(\"x.tar\"))\nprintln(E.getOrElse(\"KLASSIC_DEFINITELY_NOT_SET\", \"fallback\"))\nprintln(T.formatIso(0))\nprintln(C.option([\"--out\", \"f.txt\"], \"--out\"))",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        output.status.success(),
+        "the annotated modules should evaluate\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "c.txt\n/a/b\n.tar\nfallback\n1970-01-01T00:00:00.000Z\nf.txt\n()\n"
+    );
+}
+
+/// A path or a file's contents that arrives as a *heap* string -- which is
+/// what an annotated `String` parameter holds -- is copied into a runtime
+/// pair rather than refused. Annotating a definition must never be what stops
+/// a program compiling.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_reads_a_file_through_an_annotated_path() {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock should be after the epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("klassic-annotated-path-{stamp}"));
+    fs::create_dir_all(&dir).expect("temp dir should be creatable");
+    let source_path = dir.join("program.kl");
+    let bin_path = dir.join("program");
+    fs::write(
+        &source_path,
+        "def store(path: String, text: String): Unit = FileOutput#write(path, text)\n         def load(path: String): String = FileInput#readAll(path)\n         def stem(path: String): String = {\n           val slash = lastIndexOf(path, \"/\")\n           if((slash < 0)) path else substring(path, slash + 1, length(path))\n         }\n         store(\"annotated.txt\", \"contents\")\n         println(load(\"annotated.txt\"))\n         println(stem(\"/a/b/annotated.txt\"))\n         println(stem(\"bare\"))\n         FileOutput#delete(\"annotated.txt\")\n",
+    )
+    .expect("source should be writable");
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build.status.success(),
+        "an annotated String parameter should still compile\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&bin_path)
+        .current_dir(&dir)
+        .output()
+        .expect("generated program should run");
+    let _ = fs::remove_dir_all(&dir);
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "contents\nannotated.txt\nbare\n"
+    );
+}
+
 /// std.option / std.result richer API via method-style dispatch. The
 /// clean names are restored now that native module namespacing (#449)
 /// makes the free names safe and receiver-type dispatch picks the right

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -30,6 +30,84 @@ fn stdlib_completeness_round_two() {
     );
 }
 
+/// The most negative `Int` is writable as a literal. Its digits alone are one
+/// past `i64::MAX`, so the sign has to reach the range check -- and a larger
+/// magnitude has to stay rejected under either sign.
+#[test]
+fn most_negative_int_literal_round_trips() {
+    let output = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "val low = -9223372036854775808\nprintln(low)\nprintln(low + 1)\nprintln(low match { case -9223372036854775808 => \"min\"; case _ => \"other\" })",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        output.status.success(),
+        "the minimum Int should be a literal\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "-9223372036854775808\n-9223372036854775807\nmin\n()\n"
+    );
+
+    for source in ["9223372036854775808", "-9223372036854775809"] {
+        let rejected = Command::new(klassic_bin())
+            .args(["-e", source])
+            .output()
+            .expect("binary should run");
+        assert!(
+            !rejected.status.success(),
+            "{source} should stay out of range"
+        );
+        assert!(
+            String::from_utf8_lossy(&rejected.stderr).contains("integer literal is out of range"),
+            "{source} should report the range, got:\n{}",
+            String::from_utf8_lossy(&rejected.stderr)
+        );
+    }
+}
+
+/// An `if` is an expression on the right of an assignment, as it is
+/// everywhere else -- no parentheses needed.
+#[test]
+fn assignment_takes_a_branch_on_its_right() {
+    let output = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "mutable x = 1\nx = if (true) 2 else 3\nprintln(x)\nmutable y = 0\ny += if (false) 1 else 10\nprintln(y)",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        output.status.success(),
+        "an if should parse as an assignment's value\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "2\n10\n()\n");
+}
+
+/// A declared enum variant is a constructor in a pattern whatever it is
+/// spelled like, so generated code can use the `__` convention. A name that
+/// was never declared stays a binding.
+#[test]
+fn declared_variants_are_constructor_patterns() {
+    let output = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "enum __A { case __N; case __C(x: Int) }\nprintln(__C(5) match { case __N => 0; case __C(x) => x })\nprintln(1 match { case _Rest => 99 })",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        output.status.success(),
+        "an underscore-prefixed variant should match\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "5\n99\n()\n");
+}
+
 /// std.option / std.result richer API via method-style dispatch. The
 /// clean names are restored now that native module namespacing (#449)
 /// makes the free names safe and receiver-type dispatch picks the right

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -200,6 +200,41 @@ fn an_assignment_yields_unit() {
     assert_eq!(String::from_utf8_lossy(&output.stdout), "1\n()\n5\n()\n");
 }
 
+/// Floating-point division by zero has an answer under IEEE 754, which is
+/// what the underlying f64 implements, so it is no longer an error: a program
+/// could reach infinity by multiplying and not by dividing. Integer division
+/// by zero stays an error -- there is no integer infinity to produce.
+#[test]
+fn float_division_by_zero_follows_ieee() {
+    let output = Command::new(klassic_bin())
+        .args([
+            "-e",
+            "println(1.0 / 0.0)\nprintln(-1.0 / 0.0)\nprintln(0.0 / 0.0)\nprintln(1.0e300 * 1.0e300)",
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        output.status.success(),
+        "float division by zero should have an answer\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "inf\n-inf\nNaN\ninf\n()\n"
+    );
+
+    let integer = Command::new(klassic_bin())
+        .args(["-e", "1 / 0"])
+        .output()
+        .expect("binary should run");
+    assert!(!integer.status.success(), "1 / 0 should stay an error");
+    assert!(
+        String::from_utf8_lossy(&integer.stderr).contains("division by zero"),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&integer.stderr)
+    );
+}
+
 /// std.option / std.result richer API via method-style dispatch. The
 /// clean names are restored now that native module namespacing (#449)
 /// makes the free names safe and receiver-type dispatch picks the right

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -235,6 +235,52 @@ fn float_division_by_zero_follows_ieee() {
     );
 }
 
+/// A string compared with `null`. A static or runtime string is a
+/// (data, length) pair in fixed storage and so is never null; a heap string
+/// is a pointer and the answer is whether it is zero. Asking is the first
+/// thing written after a lookup that may not have found anything, and it did
+/// not compile.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_compares_a_string_with_null() {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock should be after the epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("klassic-string-null-{stamp}"));
+    fs::create_dir_all(&dir).expect("temp dir should be creatable");
+    let source_path = dir.join("program.kl");
+    let bin_path = dir.join("program");
+    fs::write(
+        &source_path,
+        "import std.string\n         val s: String = getEnv(\"PATH\")\n         println(s == null)\n         println(s != null)\n         val t = \"abc\"\n         println(t == null)\n         println(null == t)\n         println(t.toUpperCase() == null)\n",
+    )
+    .expect("source should be writable");
+
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build.status.success(),
+        "comparing a string with null should compile\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&bin_path)
+        .output()
+        .expect("generated program should run");
+    let _ = fs::remove_dir_all(&dir);
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "false\ntrue\nfalse\nfalse\nfalse\n"
+    );
+}
+
 /// std.option / std.result richer API via method-style dispatch. The
 /// clean names are restored now that native module namespacing (#449)
 /// makes the free names safe and receiver-type dispatch picks the right

--- a/tests/cross-exec/36-stdlib-system-modules.kl
+++ b/tests/cross-exec/36-stdlib-system-modules.kl
@@ -1,0 +1,89 @@
+// Cross-target fixture: the stdlib modules that wrap the system builtins.
+//
+// `std.env`, `std.dir`, `std.file`, `std.path`, `std.process`, `std.time` and
+// `std.cli` were written without type annotations. The evaluator infers
+// through them and both native backends then failed for their own reason --
+// aarch64 could not give a binding a type it never learned, and x86-64 could
+// not tell the string `lastIndexOf` from the list one. Neither reason was
+// visible in the diagnostic, which named a synthesized `__mod_std_*` function.
+//
+// The modules carry annotations now, which is what makes the calls below
+// compile; the annotations in turn make each parameter arrive as a *heap*
+// string, so this fixture is also the coverage for reading a path, a file's
+// contents and a substring out of one.
+//
+// Every module is imported under an alias. Three of them declare `exists` and
+// two declare `join`, so the alias is what says which one a call means -- and
+// it exercises the aliased-import path on every target at the same time.
+//
+// Every value printed here has to be the same on all three targets, so the
+// program asks about shapes rather than about this machine: whether a path
+// helper split a string where expected, not what the current directory is.
+
+import std.env as E
+import std.dir as D
+import std.file as F
+import std.path as P
+import std.process as R
+import std.time as T
+import std.cli as C
+
+// Paths, entirely in terms of annotated String parameters.
+println(P.basename("/a/b/c.txt"))
+println(P.basename("plain"))
+println(P.dirname("/a/b/c.txt"))
+println(P.dirname("plain"))
+println(P.fileExtension("/a/b/c.txt"))
+println(P.fileExtension("noext"))
+println(P.withoutExtension("/a/b/c.txt"))
+println(P.join("/a", "b"))
+println(P.join("", "b"))
+println(P.separator())
+assertResult("c.txt")(P.basename("/a/b/c.txt"))
+assertResult("/a/b")(P.dirname("/a/b/c.txt"))
+
+// A file written and read back through the module, i.e. through a heap-string
+// path and a heap-string content.
+F.write("cross-exec-system.txt", "one")
+F.append("cross-exec-system.txt", "-two")
+println(F.readAll("cross-exec-system.txt"))
+println(F.exists("cross-exec-system.txt"))
+F.writeLines("cross-exec-system-lines.txt", ["a", "b"])
+println(F.readLines("cross-exec-system-lines.txt"))
+assertResult("one-two")(F.readAll("cross-exec-system.txt"))
+F.delete("cross-exec-system.txt")
+F.delete("cross-exec-system-lines.txt")
+println(F.exists("cross-exec-system.txt"))
+
+// A directory this program makes itself, so the answers do not depend on the
+// machine it runs on.
+D.mkdir("cross-exec-system-dir")
+println(D.isDirectory("cross-exec-system-dir"))
+println(D.isFile("cross-exec-system-dir"))
+D.delete("cross-exec-system-dir")
+
+// The environment, asked about a variable this program knows is absent.
+println(E.exists("KLASSIC_DEFINITELY_NOT_SET"))
+println(E.getOrElse("KLASSIC_DEFINITELY_NOT_SET", "fallback"))
+assertResult("fallback")(E.getOrElse("KLASSIC_DEFINITELY_NOT_SET", "fallback"))
+
+// The system directories: their contents differ per machine, so only their
+// shape is asserted.
+println(isEmptyString(D.current()))
+println(isEmptyString(D.home()))
+println(isEmptyString(D.temp()))
+
+// Arguments, with none passed.
+println(size(R.args()))
+println(C.flag(["-v", "x"], "-v"))
+println(C.flag(["x"], "-v"))
+println(C.option(["--out", "f.txt"], "--out"))
+
+// Time arithmetic on a fixed instant, so the output is the same everywhere.
+println(T.formatIso(0))
+println(T.formatHuman(951868800000))
+println(T.parseIso("2000-03-01T00:00:00.000Z"))
+println(T.durationMillis(1000, 4000))
+println(T.nowMillis() > 0)
+assertResult(951868800000)(T.parseIso("2000-03-01T00:00:00.000Z"))
+println("done")

--- a/tests/cross-exec/37-user-enum-values.kl
+++ b/tests/cross-exec/37-user-enum-values.kl
@@ -1,0 +1,99 @@
+// Cross-target fixture: printing an enum the program declares itself.
+//
+// The shared lowering erases a monomorphic enum into `__gc_record` calls, so
+// a value of one arrives at a backend as a bare pointer with nothing saying
+// which enum it is. x86-64 recovered that from the `__enum_shape_named`
+// marker the lowering leaves behind; aarch64 dropped the marker and refused
+// to print the pointer. Both read it now.
+//
+// `Option` and `Result` are here beside the user enums on purpose: they are
+// generic, so they are *not* lowered and travel a different path. A change
+// that fixed one and broke the other would show up as a difference between
+// the two halves of this file.
+//
+// A hole in a string is its own path: the enum lowering did not descend into
+// interpolation, so `"#{Some(1)}"` kept a constructor call no backend had
+// declared.
+//
+// An enum that holds *itself* is matched here but not printed: rendering one
+// would have to expand without bound at compile time, so both backends refuse
+// it, and a fixture has to stay within what they accept on every target.
+
+import std.option
+import std.result
+
+enum Colour { case Red; case Green; case Blue }
+enum Shape { case Circle(radius: Int); case Rect(w: Int, h: Int) }
+enum Tagged { case Named(name: String); case Flagged(on: Boolean); case Blank }
+enum Chain { case Nil; case Cons(head: Int, tail: Chain) }
+// A payload that is another enum, and not this one, so rendering it descends
+// exactly once.
+enum Wrapper { case Wrapping(inner: Colour); case Empty }
+
+// A nullary variant, a one-field variant, and a many-field one.
+println(Red)
+println(Green)
+println(Blue)
+println(Circle(3))
+println(Rect(2, 5))
+println(Named("klassic"))
+println(Flagged(true))
+println(Flagged(false))
+println(Blank)
+assertResult("Rect(2, 5)")("#{Rect(2, 5)}")
+assertResult("Blank")("#{Blank}")
+
+// Through a binding, and through an annotated one.
+val c = Circle(7)
+val tagged: Tagged = Named("bound")
+println(c)
+println(tagged)
+println("shape=#{c} tag=#{tagged}")
+
+// A payload that is a different enum renders by descending into it.
+println(Wrapping(Red))
+println(Wrapping(Blue))
+println(Empty)
+assertResult("Wrapping(Green)")("#{Wrapping(Green)}")
+
+// Matching still works on every one of them, which is what the lowering was
+// there to make possible in the first place.
+def area(s: Shape): Int = s match {
+  case Circle(r) => r * r * 3
+  case Rect(w, h) => w * h
+}
+println(area(Circle(3)))
+println(area(Rect(2, 5)))
+assertResult(27)(area(Circle(3)))
+
+def describe(t: Tagged): String = t match {
+  case Named(n) => "named " + n
+  case Flagged(f) => "flagged " + f
+  case Blank => "blank"
+}
+println(describe(Named("x")))
+println(describe(Flagged(true)))
+println(describe(Blank))
+
+// A recursive enum, matched rather than printed. The value is built inside
+// the call so the recursion does not read a top-level binding, which one
+// backend refuses.
+def depth(c: Chain, acc: Int): Int = c match {
+  case Nil => acc
+  case Cons(h, t) => depth(t, acc + 1)
+}
+println(depth(Cons(1, Cons(2, Nil)), 0))
+assertResult(2)(depth(Cons(1, Cons(2, Nil)), 0))
+
+// The generic half: not lowered, and printed by the other path.
+val some: Option<Int> = Some(4)
+val none: Option<Int> = None
+val ok: Result<Int, String> = Ok(9)
+val bad: Result<Int, String> = Err("nope")
+println(some)
+println(none)
+println(ok)
+println(bad)
+println("opt=#{some} res=#{bad}")
+assertResult("Some(4)")("#{some}")
+println("done")

--- a/tests/cross-exec/38-map-and-set-methods.kl
+++ b/tests/cross-exec/38-map-and-set-methods.kl
@@ -1,0 +1,63 @@
+// Cross-target fixture: the map and set methods that were arm64-only gaps.
+//
+// `remove` and `containsValue` were simply not implemented there. The rest --
+// `merge`, `filterKeys`, `filterValues`, `mapValues`, `setFilter`, `setMap` --
+// failed for one shared reason each backend expressed differently: every fold
+// that rebuilds a collection is written as `Map#put(acc, k, Map#get(m, k))` or
+// `Set#add(acc, x)` starting from an empty one, and the inference could not
+// carry a type through either. A lookup answers a value *or nothing*, and the
+// empty set's element type is fixed by the first thing added to it.
+//
+// Insertion order is the observable part of both types, so every case below
+// would disagree with the evaluator under an implementation that reordered.
+//
+// Not here, and still a gap on every target: `mapKeys`, which goes through
+// `Map#fromPairs`.
+
+import std.map
+import std.set
+
+val m = %["a": 1 "b": 2 "c": 3]
+
+// Dropping an entry, including one that is not there.
+println(m.remove("b"))
+println(m.remove("zz"))
+val dropped = m.remove("a")
+println(dropped.remove("c"))
+assertResult(2)(Map#size(dropped))
+
+// Asking about a value rather than a key.
+println(m.containsValue(2))
+println(m.containsValue(9))
+println(%[].containsValue(1))
+assertResult(true)(m.containsValue(3))
+
+// The folds that rebuild a map.
+println(m.merge(%["d": 4]))
+println(m.merge(%["a": 9]))
+println(m.filterKeys((k) => k == "a"))
+println(m.filterValues((v) => v > 1))
+println(m.mapValues((v) => v * 10))
+println(m.toPairs())
+println(m.foldMap(0)((acc, k, v) => acc + v))
+assertResult(6)(m.foldMap(0)((acc, k, v) => acc + v))
+val merged = m.merge(%["d": 4])
+assertResult(4)(Map#size(merged))
+
+// The same shape over a set.
+val s = %(1, 2, 3)
+println(s.setFilter((x) => x > 1))
+println(s.setFilter((x) => x > 9))
+println(s.setMap((x) => x * 2))
+println(s.setFold(0)((acc, x) => acc + x))
+assertResult(6)(s.setFold(0)((acc, x) => acc + x))
+
+// A map and a set of strings, so the comparisons go through the string path
+// rather than the scalar one.
+val words = %["one": "first" "two": "second"]
+println(words.remove("one"))
+println(words.containsValue("second"))
+println(words.containsValue("third"))
+val names = %("alpha", "beta")
+println(names.setFilter((n) => n == "beta"))
+println("done")

--- a/tests/cross-exec/39-empty-map-questions.kl
+++ b/tests/cross-exec/39-empty-map-questions.kl
@@ -1,0 +1,29 @@
+// Cross-target fixture: a map that is created and never put into.
+//
+// Creating one is what triggers the chain lowering, not growing it, so the
+// chain's helpers have to typecheck for a chain that stays empty. They did
+// not: two arms of the same `match` disagreed once an assignment started
+// yielding unit, and the whole program was refused for a type error inside
+// injected code the user never wrote.
+//
+// Asking such a map about a key is the other half. Nothing fixes its key or
+// value type, so it used to be refused for want of one -- but the answer does
+// not need a type: a map with no entries contains nothing.
+//
+// A map that *is* grown lives in fixtures 31-35. Keeping the two apart is
+// deliberate: the lowering is all-or-nothing per program, so a program with
+// both a grown map and an untouched one puts the untouched one on a path
+// neither case exercises alone.
+
+import std.map
+
+mutable never = Map#empty()
+println(Map#size(never))
+println(never.containsKey("a"))
+println(never.containsKey("zz"))
+println(never)
+println(Map#isEmpty(never))
+assertResult(0)(Map#size(never))
+assertResult(false)(never.containsKey("a"))
+
+println("done")

--- a/tests/cross-exec/40-returned-lambdas.kl
+++ b/tests/cross-exec/40-returned-lambdas.kl
@@ -1,0 +1,54 @@
+// Cross-target fixture: a function that returns a function.
+//
+// A lambda has no runtime representation in the aarch64 backend -- its body
+// is compiled where it is called -- so binding one that a *call* produced
+// meant binding the lambda together with the arguments it closed over. Those
+// go into slots of the caller's frame, which outlive the binding, and the
+// lambda reads them when it is finally called.
+//
+// Calling the result on the spot always worked; it is the binding that did
+// not, which rules out currying and partial application -- ordinary things to
+// write in this language.
+
+def adder(n: Int): (Int) => Int = (x) => x + n
+def prefixer(p: String): (String) => String = (s) => p + s
+def scaler(a: Int, b: Int): (Int) => Int = (x) => x * a + b
+
+// On the spot.
+println(adder(3)(4))
+println(prefixer("<")("x"))
+println(scaler(2, 1)(5))
+
+// Bound first, then called -- the case that did not compile.
+val add3 = adder(3)
+println(add3(4))
+println(add3(0))
+println(add3(-3))
+assertResult(7)(add3(4))
+
+val angle = prefixer("<<")
+println(angle("a"))
+println(angle(""))
+assertResult("<<a")(angle("a"))
+
+val twicePlusOne = scaler(2, 1)
+println(twicePlusOne(5))
+println(twicePlusOne(0))
+assertResult(11)(twicePlusOne(5))
+
+// Captured from a value that is only known while running, so the capture is a
+// slot rather than a constant folded in.
+mutable k = 0
+k = k + 4
+val addK = adder(k)
+println(addK(1))
+assertResult(5)(addK(1))
+
+// Two bindings of the same function keep their own captures.
+val addOne = adder(1)
+val addTen = adder(10)
+println(addOne(100))
+println(addTen(100))
+assertResult(101)(addOne(100))
+assertResult(110)(addTen(100))
+println("done")

--- a/tests/cross-exec/41-annotated-generic-enum.kl
+++ b/tests/cross-exec/41-annotated-generic-enum.kl
@@ -1,0 +1,62 @@
+// Cross-target fixture: a generic enum whose payloads only the annotation
+// names.
+//
+// A value built from the *empty* case fixes nothing -- `Nil` carries no
+// payloads -- so a helper walking it had no idea what its fields hold, and
+// reading a key out of one was refused for want of a type. The binding's own
+// annotation names every type argument, which is exact rather than a partial
+// guess, so it is what the value's shape is read from.
+
+enum Chain<'k, 'v> {
+  case Nil
+  case Cons(key: 'k, value: 'v, rest: Chain<'k, 'v>)
+}
+
+def hasKey(c: Chain<'k, 'v>, key: 'k): Boolean = {
+  mutable cur = c
+  mutable yes = false
+  mutable go = true
+  while (go) {
+    cur match {
+      case Nil => go = false
+      case Cons(k, v, rest) => { yes = (if (k == key) true else yes); cur = rest }
+    }
+  }
+  yes
+}
+
+def sizeOfChain(c: Chain<'k, 'v>): Int = {
+  mutable cur = c
+  mutable n = 0
+  mutable go = true
+  while (go) {
+    cur match {
+      case Nil => go = false
+      case Cons(k, v, rest) => { n = n + 1; cur = rest }
+    }
+  }
+  n
+}
+
+// A chain that says what it holds only through the annotation.
+val empty: Chain<String, Int> = Nil
+println(hasKey(empty, "a"))
+println(sizeOfChain(empty))
+assertResult(false)(hasKey(empty, "a"))
+
+// One built up from it, where the constructions fix the payloads themselves.
+val one: Chain<String, Int> = Cons("a", 1, Nil)
+val two: Chain<String, Int> = Cons("b", 2, one)
+println(hasKey(two, "a"))
+println(hasKey(two, "b"))
+println(hasKey(two, "zz"))
+println(sizeOfChain(two))
+assertResult(2)(sizeOfChain(two))
+
+// The other way round: Int keys and String values, so a shape read from the
+// annotation cannot be right by accident.
+val flipped: Chain<Int, String> = Cons(1, "one", Nil)
+println(hasKey(flipped, 1))
+println(hasKey(flipped, 9))
+println(sizeOfChain(flipped))
+println("done")

--- a/tests/sample_programs.rs
+++ b/tests/sample_programs.rs
@@ -43,6 +43,7 @@ fn sample_programs() -> Vec<&'static str> {
         "monad-with-newlines.kl",
         "mutable.kl",
         "numeric-literals.kl",
+        "proof-surface.kl",
         "record.kl",
         "reduce_syntax.kl",
         "set-literal.kl",


### PR DESCRIPTION
First batch from the #609-#630 sweep. Seven issues, each with a test and a
line in `docs/architecture-rust.md`.

**Parser and docs** (#628, #609, #611, #629, #630)

- The most negative `Int` is writable. Its digits are one past `i64::MAX`,
  so the range check waits for the sign instead of firing in the lexer; a
  larger magnitude stays rejected under either sign.
- An assignment takes an `if` / `while` / `foreach` on its right without
  parentheses.
- A declared enum variant is a constructor in a pattern whatever it is
  spelled like, so the `__` convention for synthesized names works. An
  undeclared `_`-prefixed name stays a binding.
- The Book's 40 code blocks now run in CI (`tests/book_examples.rs`); the
  four that were missing an `import` got one. Verified the harness fails by
  removing an import and watching it go red.
- CLAUDE.md described a block `module foo.bar { ... }` syntax the parser
  rejects.

**The system stdlib modules** (#622, #623)

`std.env`, `std.cli`, `std.dir`, `std.process`, `std.file`, `std.path` and
`std.time` had no type annotations. Annotating them is the fix, and it
uncovered what the missing annotations were hiding:

- x86-64 refused a heap string -- what an annotated `String` parameter
  holds -- as a path, as file content, to `indexOf`/`lastIndexOf`, and on
  either side of an `if`. All four copy it into a runtime pair now. The
  general runtime-string predicate is deliberately unchanged: widening that
  has been measured to break programs whose other string paths cannot copy.
- aarch64 did not know the v0.1 prelude spellings (`getEnv`, `args`, ...),
  which is exactly what the modules are written against, and lacked
  `Dir#current` / `home` / `temp` / `isFile`.
- aarch64 could not read a structural record annotation (`std.time` returns
  one) and rejected a sometimes-null body under a reference return
  annotation (`std.cli`'s `option` is one).

**Verification**

- 733 tests green.
- 58 sample programs build on all three targets, unchanged.
- New `tests/cross-exec/36-stdlib-system-modules.kl` exercises all seven
  modules through aliased imports -- three declare `exists`, two declare
  `join` -- and runs on real arm64 and Windows in CI.

The aarch64 additions (`Dir#current` through Darwin's `__getcwd`, the
prelude aliases) cannot be executed on the development host, so the macOS
legs of CI are what verifies them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)