### PR TITLE
Round two (c): a type variable inside an annotation, and a map in a list

### DIFF
--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -1301,6 +1301,10 @@ enum ListElem {
     /// `__gc_record` calls -- carrying its entry in the lowered-enum table so
     /// a list of them can be printed. A pointer, like the two above.
     LoweredEnum(u32),
+    /// An element that is a map: a cons chain of two-slot entries, which is
+    /// the same pointer a set or a list element already is. A list of them is
+    /// what grouping produces.
+    Map(ScalarElem, ScalarElem),
     /// An element that is itself a list: `depth` levels of list over `base`.
     /// `List<List<Int>>`'s element is `Nested { depth: 1, base: Int }` and
     /// `List<List<List<Int>>>`'s is `depth: 2`.
@@ -1345,6 +1349,7 @@ impl ListElem {
             ListElem::Enum(_)
             | ListElem::Record(_)
             | ListElem::LoweredEnum(_)
+            | ListElem::Map(..)
             | ListElem::Nested { .. } => None,
         }
     }
@@ -1765,6 +1770,7 @@ fn elem_value_type(elem: ListElem) -> ValueType {
         ListElem::Enum(shape) => ValueType::Enum(shape),
         ListElem::Record(index) => ValueType::Record(index),
         ListElem::LoweredEnum(index) => ValueType::LoweredEnum(index),
+        ListElem::Map(key, value) => ValueType::Map(key.as_elem(), value.as_elem()),
         ListElem::Nested { .. } => ValueType::List(
             elem.nested_inner()
                 .expect("a nested element is a list of its inner element"),
@@ -1991,6 +1997,10 @@ fn list_elem_of(ty: ValueType) -> Option<ListElem> {
         ValueType::Enum(shape) => Some(ListElem::Enum(shape)),
         ValueType::Record(index) => Some(ListElem::Record(index)),
         ValueType::LoweredEnum(index) => Some(ListElem::LoweredEnum(index)),
+        // Only a map over scalars: `ListElem` is `Copy`, so a nested key or
+        // value type has nowhere to live -- the same reason `Nested` carries a
+        // depth rather than a boxed element.
+        ValueType::Map(key, value) => Some(ListElem::Map(key.as_scalar()?, value.as_scalar()?)),
         // A list of lists: one more level over whatever the inner list holds.
         ValueType::List(inner) => Some(match inner.as_scalar() {
             Some(base) => ListElem::Nested { depth: 1, base },
@@ -6612,6 +6622,13 @@ impl Emitter {
             ListElem::LoweredEnum(index) => {
                 self.emit_print_lowered_enum(index, span)?;
             }
+            // A map *element* would need the map renderer without its
+            // trailing newline, which `emit_println_map` does not separate
+            // out. Holding one in a list works; printing the list does not
+            // yet.
+            ListElem::Map(..) => {
+                return Err(unsupported(span, "printing a map element"));
+            }
             ListElem::Record(index) => {
                 self.emit_print_record_inline(index, span)?;
             }
@@ -9033,6 +9050,9 @@ impl Emitter {
             ListElem::Str => {}
             ListElem::Enum(shape) => self.emit_enum_to_str(shape, span)?,
             ListElem::LoweredEnum(index) => self.emit_lowered_enum_to_str(index, span)?,
+            ListElem::Map(..) => {
+                return Err(unsupported(span, "rendering a map element"));
+            }
             ListElem::Record(_) => {
                 return Err(unsupported(span, "rendering a record element"));
             }
@@ -10549,7 +10569,7 @@ impl Emitter {
             name,
             params,
             body,
-            declared_return,
+            mut declared_return,
             param_annotations,
             return_annotation,
         } = self.generic_functions[generic].clone();
@@ -10632,14 +10652,36 @@ impl Emitter {
                 continue;
             };
             let text = annotation.trim();
-            if !text.starts_with('\'') {
+            if text.starts_with('\'') {
+                let Some(name) = type_annotation_name(*ty) else {
+                    continue;
+                };
+                if !bindings.iter().any(|(known, _)| known == text) {
+                    bindings.push((text.to_string(), name));
+                }
                 continue;
             }
-            let Some(name) = type_annotation_name(*ty) else {
-                continue;
-            };
-            if !bindings.iter().any(|(known, _)| known == text) {
-                bindings.push((text.to_string(), name));
+            // A variable *inside* a larger annotation: `xs: List<'a>` against
+            // a `List<Int>` argument says `'a` is `Int`. Only the one-level
+            // application is read, which is what the stdlib's own signatures
+            // are written in, and it is what lets a return type mentioning
+            // the same variable be resolved below.
+            if let Some((head, args)) = split_type_arguments(text)
+                && args.len() == 1
+                && args[0].trim().starts_with('\'')
+            {
+                let solved = match (head, *ty) {
+                    ("List", ValueType::List(elem)) | ("Set", ValueType::Set(elem)) => {
+                        type_annotation_name(elem_value_type(elem))
+                    }
+                    _ => None,
+                };
+                let variable = args[0].trim().to_string();
+                if let Some(name) = solved
+                    && !bindings.iter().any(|(known, _)| *known == variable)
+                {
+                    bindings.push((variable, name));
+                }
             }
         }
         if !bindings.is_empty() {
@@ -10666,6 +10708,22 @@ impl Emitter {
                 if let Ok(resolved @ ValueType::Enum(_)) = self.annotation_type(&applied, span) {
                     value_params[position].1 = resolved;
                     argument_types[position] = resolved;
+                }
+            }
+            // The *return* annotation gets the same substitution. A return
+            // that mentions a type variable inside a larger type --
+            // `List<{ item: 'a; index: Int }>`, which is what
+            // `std.list`'s `zipWithIndex` answers -- cannot be resolved as
+            // written, and the body then disagreed with a return type the
+            // backend had given up on.
+            if declared_return.is_none()
+                && let Some(annotation) = return_annotation.as_ref()
+            {
+                let applied = substitute_type_params(annotation, &variables, &solutions);
+                if applied != *annotation
+                    && let Ok(resolved) = self.annotation_type(&applied, span)
+                {
+                    declared_return = Some(resolved);
                 }
             }
         }
@@ -11883,6 +11941,9 @@ impl Emitter {
                     self.emit_unbox_scalar();
                 }
                 match elem {
+                    ListElem::Map(..) => {
+                        return Err(unsupported(argument.span(), "printing a nullable map"));
+                    }
                     ListElem::Int => self.asm.emit_print_int_line(),
                     ListElem::Str => self.emit_println_str(),
                     ListElem::Bool => {

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -2156,6 +2156,18 @@ side of a branch.
   are where the newest work lands, so they are the most likely to carry a
   fresh rooting mistake, and a mis-rooted pointer only shows up when a
   collection fires at the wrong moment (issue #653).
+- A generic definition's type variables are solved from a variable *inside* a
+  parameter's annotation, not only from one that is the whole annotation:
+  `xs: List<'a>` against a `List<Int>` argument says `'a` is `Int`. The
+  solutions are then substituted into the *return* annotation too, so a return
+  like `List<{ item: 'a; index: Int }>` -- `std.list`'s `zipWithIndex` --
+  resolves instead of being given up on, which the body then disagreed with
+  (issue #649).
+- aarch64 holds a map in a list (`ListElem::Map`, over scalar key and value
+  types, since `ListElem` is `Copy`). Printing such a list is still refused:
+  it would need the map renderer without its trailing newline, which
+  `emit_println_map` does not separate out (issue #635, holding but not
+  printing).
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/stdlib/std/list.kl
+++ b/stdlib/std/list.kl
@@ -90,13 +90,13 @@ def dropWhile(xs: List<'a>, p: ('a) => Boolean): List<'a> =
 
 // Helper: pair each element with its index starting at `i`.
 // Returns a list of records { item: a; index: Int }.
-def zipWithIndexFrom(xs, i) =
+def zipWithIndexFrom(xs: List<'a>, i: Int): List<{ item: 'a; index: Int }> =
   if(isEmpty(xs)) []
   else cons(record { item: head(xs); index: i })(zipWithIndexFrom(tail(xs), i + 1))
 
 // Pair each element with its zero-based index.
 // Returns List<{ item: a; index: Int }>.
-def zipWithIndex(xs) = zipWithIndexFrom(xs, 0)
+def zipWithIndex(xs: List<'a>): List<{ item: 'a; index: Int }> = zipWithIndexFrom(xs, 0)
 
 // ---------- maxBy / minBy ---------------------------------------------------
 

--- a/tests/cross-exec/44-stdlib-free-functions.kl
+++ b/tests/cross-exec/44-stdlib-free-functions.kl
@@ -43,6 +43,7 @@ println(dropWhile([1, 2, 3], (x) => x < 3))
 println(chunk([1, 2, 3, 4, 5], 2))
 println(slice([1, 2, 3, 4], 1, 3))
 println(flatten([[1, 2], [3]]))
+println(zipWithIndex([1, 2]))
 println(contains([1, 2], 2))
 assertResult([2, 3])(filter([1, 2, 3], (x) => x > 1))
 


### PR DESCRIPTION
Third batch from the #632-#655 sweep.

**A type variable inside an annotation** (#649)

A generic definition's type variables were solved only from a parameter whose
annotation *is* the variable (`key: 'k`). One nested inside a larger type --
`xs: List<'a>` -- was not, so a return mentioning the same variable could not
be resolved either, and the body then disagreed with a return type the backend
had given up on.

`std.list`'s `zipWithIndex` is the case: it answers
`List<{ item: 'a; index: Int }>`, which is now resolved from the argument.

**A map in a list** (#635, partly)

`ListElem::Map` over scalar key and value types, so `[%["a": 1], %["b": 2]]`
builds on aarch64. Printing such a list is still refused and the fixture says
so: it would need the map renderer without its trailing newline, which
`emit_println_map` does not separate out.

**Verification**

- 743 tests green; clippy and fmt clean.
- 59 sample programs on all three targets; 44 cross-exec fixtures compared
  against the evaluator, all three targets building every one -- and, since
  #657, every fixture also runs under `--gc-stress --gc-poison` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)