### PR TITLE
Round two (d): print a map that is an element

### DIFF
--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -6433,6 +6433,19 @@ impl Emitter {
         value: ListElem,
         span: Span,
     ) -> Result<(), Diagnostic> {
+        self.emit_print_map(key, value, span)?;
+        self.asm.emit_write_rodata(STDOUT_FD, b"\n");
+        Ok(())
+    }
+
+    /// The same rendering without the trailing newline, so a map can be an
+    /// element of something else -- a list of maps is what grouping produces.
+    fn emit_print_map(
+        &mut self,
+        key: ListElem,
+        value: ListElem,
+        span: Span,
+    ) -> Result<(), Diagnostic> {
         let loop_start = self.asm.new_label();
         let close = self.asm.new_label();
         self.push_rooted(Reg::X0); // cursor
@@ -6466,7 +6479,7 @@ impl Emitter {
         self.asm.branch(loop_start, BranchKind::Unconditional);
         self.asm.bind(close);
         self.pop_rooted(Reg::X3); // discard the cursor
-        self.asm.emit_write_rodata(STDOUT_FD, b"]\n");
+        self.asm.emit_write_rodata(STDOUT_FD, b"]");
         Ok(())
     }
 
@@ -6622,12 +6635,8 @@ impl Emitter {
             ListElem::LoweredEnum(index) => {
                 self.emit_print_lowered_enum(index, span)?;
             }
-            // A map *element* would need the map renderer without its
-            // trailing newline, which `emit_println_map` does not separate
-            // out. Holding one in a list works; printing the list does not
-            // yet.
-            ListElem::Map(..) => {
-                return Err(unsupported(span, "printing a map element"));
+            ListElem::Map(key, value) => {
+                self.emit_print_map(key.as_elem(), value.as_elem(), span)?;
             }
             ListElem::Record(index) => {
                 self.emit_print_record_inline(index, span)?;

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -2168,6 +2168,11 @@ side of a branch.
   it would need the map renderer without its trailing newline, which
   `emit_println_map` does not separate out (issue #635, holding but not
   printing).
+- aarch64 prints a map that is an element of something else. `emit_print_map`
+  is the renderer without the trailing newline and `emit_println_map` is it
+  plus the newline, so a list of maps -- what grouping produces -- renders at
+  both levels. A list of *sets* is still refused there for the same reason
+  maps were: `ListElem` has no entry for one (issue #635).
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/tests/cross-exec/45-collections-of-collections.kl
+++ b/tests/cross-exec/45-collections-of-collections.kl
@@ -1,0 +1,38 @@
+// Cross-target fixture: collections holding other collections.
+//
+// A list of lists and a list of records already worked everywhere; a list of
+// *maps* did not -- `ListElem` had no entry for one, though a map there is a
+// cons chain of two-slot entries, the same pointer a set or a list element
+// already is. Printing one needed the map renderer without its trailing
+// newline, which was not separated out.
+//
+// The nesting is what makes this worth a fixture: each renderer has to be
+// reachable from inside another, and the separators have to come out right at
+// every level.
+
+import std.map
+
+// A list of maps, printed whole and walked.
+val ms = [%["a": 1], %["b": 2 "c": 3]]
+println(ms)
+println(size(ms))
+println(head(ms))
+assertResult(2)(size(ms))
+
+// A list of lists, which already worked -- here so a change that fixes maps
+// by breaking them cannot pass. A list of *sets* is still refused on arm64
+// (`ListElem` has no entry for one either), which is the same shape of gap
+// maps just came out of.
+println([[1, 2], [3]])
+println([[[1]], [[2, 3]]])
+
+// A map whose values are lists, printed whole.
+val byKey = %["evens": [2, 4] "odds": [1, 3]]
+println(byKey)
+println(Map#size(byKey))
+assertResult(2)(Map#size(byKey))
+
+// A list of maps of strings, so the element rendering goes through the string
+// path rather than the scalar one at both levels.
+println([%["k": "v"], %["x": "y"]])
+println("done")


### PR DESCRIPTION
Fourth batch from the sweep, completing #635.

`emit_print_map` is the map renderer without the trailing newline and
`emit_println_map` is it plus the newline, so a list of maps -- what grouping
produces -- renders at both levels. Holding one landed in #658; printing it
needed the split.

A list of *sets* is still refused on aarch64, for the same reason maps were:
`ListElem` has no entry for one. `tests/cross-exec/45-collections-of-collections.kl`
says so rather than leaving it implied.

**Verification**: 743 tests, 59 sample programs on all three targets, 45
cross-exec fixtures compared against the evaluator and stressed under
`--gc-stress --gc-poison` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)