### PR TITLE
Render a Double known only at run time, on both backends

### DIFF
--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -2144,6 +2144,14 @@ struct Emitter {
     /// Label of `gc_alloc`, shared between the mutator's allocation sites
     /// and the GC runtime that defines it.
     gc_alloc_label: Option<Label>,
+    /// Whether declining this program hands it to the portable C backend
+    /// rather than failing the build. It decides what to do with a Double
+    /// whose value is not known until run time: the emitted formatter is
+    /// exact for whole numbers and short binary fractions and traps on the
+    /// rest, which beats not building at all but loses to a C build that
+    /// renders every Double. So when a fallback exists, decline; when it does
+    /// not, render what can be rendered.
+    fallback_backend_available: bool,
     /// `--gc-log` / `--gc-stress` / `--gc-poison`, threaded in from the CLI.
     gc_log: bool,
     gc_stress: bool,
@@ -3929,7 +3937,7 @@ impl Emitter {
                 match self.expression(hole)? {
                     ValueType::Str => {}
                     ValueType::Int => self.emit_int_to_str(),
-                    ValueType::Double => self.emit_double_to_str(),
+                    ValueType::Double => self.emit_double_to_str(hole.span())?,
                     ValueType::Bool => self.emit_bool_to_str(),
                     // A collection renders into the hole the way `println`
                     // renders it, through the same builder.
@@ -6123,7 +6131,8 @@ impl Emitter {
     /// Write the Double whose bits are in x0 to stdout, no newline.
     /// The scratch buffer lives on the machine stack, so nothing about it
     /// needs the collector's attention.
-    fn emit_print_double(&mut self) {
+    fn emit_print_double(&mut self, span: Span) -> Result<(), Diagnostic> {
+        self.refuse_partial_double_rendering(span)?;
         self.asm.sub_sp_imm(DOUBLE_BUFFER_BYTES);
         self.asm.add_reg_sp_imm(Reg::X12, 0);
         self.emit_runtime_double_ascii(Reg::X12);
@@ -6131,13 +6140,15 @@ impl Emitter {
         self.asm.mov_imm64(Reg::X16, u64::from(SYS_WRITE));
         self.asm.svc_0x80();
         self.asm.add_sp_imm(DOUBLE_BUFFER_BYTES);
+        Ok(())
     }
 
     /// `toString` of the Double in x0 -> fresh string object in x0. The
     /// Double sibling of `emit_int_to_str`, and copied out of the stack
     /// buffer the same way, so the allocation that follows cannot disturb
     /// the bytes it is about to copy.
-    fn emit_double_to_str(&mut self) {
+    fn emit_double_to_str(&mut self, span: Span) -> Result<(), Diagnostic> {
+        self.refuse_partial_double_rendering(span)?;
         self.asm.sub_sp_imm(DOUBLE_BUFFER_BYTES);
         self.asm.add_reg_sp_imm(Reg::X12, 0);
         self.emit_runtime_double_ascii(Reg::X12);
@@ -6147,6 +6158,27 @@ impl Emitter {
         self.emit_copy_bytes(Reg::X2, Reg::X1, Reg::X7, Reg::X3);
         self.asm.mov_reg(Reg::X0, Reg::X5);
         self.asm.add_sp_imm(DOUBLE_BUFFER_BYTES);
+        Ok(())
+    }
+
+    /// Decline a Double this backend can only sometimes render, when the
+    /// driver will hand the program to a backend that always can.
+    ///
+    /// The formatter below is exact for whole numbers and for binary
+    /// fractions with a short decimal expansion, and traps at run time on the
+    /// rest. A trap is the right answer when the alternative is refusing to
+    /// build -- which is what an explicit `--target` build faces. It is the
+    /// wrong answer when the alternative is the portable C backend, which
+    /// renders every Double: there, declining costs a slower build and
+    /// trapping costs a working program.
+    fn refuse_partial_double_rendering(&self, span: Span) -> Result<(), Diagnostic> {
+        if self.fallback_backend_available {
+            return Err(unsupported(
+                span,
+                "printing a Double whose value is not known at build time",
+            ));
+        }
+        Ok(())
     }
 
     /// A whole-number Double: its integer digits followed by `.0`. The
@@ -6950,7 +6982,7 @@ exact decimal expansion is too long, or it is NaN/Infinity\n",
     fn emit_print_elem(&mut self, elem: ListElem, span: Span) -> Result<(), Diagnostic> {
         match elem {
             ListElem::Double => {
-                self.emit_print_double();
+                self.emit_print_double(span)?;
             }
             ListElem::Enum(shape) => {
                 self.emit_print_enum_inline(shape, span)?;
@@ -7340,7 +7372,7 @@ exact decimal expansion is too long, or it is NaN/Infinity\n",
             ("toString", 1) => {
                 match self.expression(&arguments[0])? {
                     ValueType::Int => self.emit_int_to_str(),
-                    ValueType::Double => self.emit_double_to_str(),
+                    ValueType::Double => self.emit_double_to_str(arguments[0].span())?,
                     ValueType::Bool => self.emit_bool_to_str(),
                     ValueType::Str => {}
                     other => {
@@ -9410,7 +9442,7 @@ exact decimal expansion is too long, or it is NaN/Infinity\n",
                     .expect("a nested element is a list of its inner element");
                 self.emit_list_to_str(inner, "[", "]", span)?;
             }
-            ListElem::Double => self.emit_double_to_str(),
+            ListElem::Double => self.emit_double_to_str(span)?,
         }
         self.asm.mov_reg(Reg::X1, Reg::X0);
         self.asm.load_local(Reg::X0, acc);
@@ -9498,7 +9530,7 @@ exact decimal expansion is too long, or it is NaN/Infinity\n",
                     }
                     match field_ty {
                         ValueType::Int => self.emit_int_to_str(),
-                        ValueType::Double => self.emit_double_to_str(),
+                        ValueType::Double => self.emit_double_to_str(span)?,
                         ValueType::Bool => self.emit_bool_to_str(),
                         ValueType::Str => {}
                         ValueType::Enum(inner) => self.emit_enum_to_str(inner, span)?,
@@ -9610,7 +9642,7 @@ exact decimal expansion is too long, or it is NaN/Infinity\n",
                         }
                         LoweredFieldRepr::Double => {
                             self.emit_unbox_scalar();
-                            self.emit_double_to_str();
+                            self.emit_double_to_str(span)?;
                         }
                     }
                     self.asm.mov_reg(Reg::X1, Reg::X0);
@@ -12220,7 +12252,7 @@ exact decimal expansion is too long, or it is NaN/Infinity\n",
                 Ok(())
             }
             ValueType::Double => {
-                self.emit_print_double();
+                self.emit_print_double(argument.span())?;
                 self.asm.emit_write_rodata(STDOUT_FD, b"\n");
                 Ok(())
             }
@@ -13553,6 +13585,7 @@ pub(crate) fn emit_macho_program(
     gc_log: bool,
     gc_stress: bool,
     gc_poison: bool,
+    fallback_backend_available: bool,
 ) -> Result<Vec<u8>, Diagnostic> {
     let mut emitter = Emitter {
         lowered_enums,
@@ -13560,6 +13593,7 @@ pub(crate) fn emit_macho_program(
         gc_log,
         gc_stress,
         gc_poison,
+        fallback_backend_available,
         ..Emitter::default()
     };
     emitter.scopes.push(HashMap::new());

--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -86,6 +86,15 @@ const SYS_MMAP: u16 = 197;
 /// Darwin `__getcwd(buf, size)`: fills `buf`, answers 0 on success.
 const SYS_GETCWD: u16 = 326;
 
+/// Bytes reserved on the machine stack for one rendered Double. The front
+/// `DOUBLE_NUMERATOR_BYTES` hold the exact-fraction path's numerator digits
+/// and the rest holds the assembled text, whose longest form is a sign, a
+/// `0.`, and the 27 fractional digits the `k <= 27` bound allows.
+const DOUBLE_BUFFER_BYTES: u32 = 96;
+/// How much of that buffer the numerator's digits get. One that fits an i64
+/// has at most 19.
+const DOUBLE_NUMERATOR_BYTES: u32 = 24;
+
 /// `S_IFDIR` (0o040000) >> 12, the value `st_mode`'s type field takes for a
 /// directory; `S_IFREG` (0o100000) >> 12 for a regular file.
 const S_IFDIR_SHIFTED: u32 = 0o4;
@@ -190,6 +199,10 @@ enum Cond {
     Hi = 8,
     /// After `fcmp`: less-or-equal, unordered fails — the float `<=`.
     Ls = 9,
+    /// Overflow set. After `fcmp` this is precisely "unordered", i.e. either
+    /// operand was NaN -- which is how a Double renderer tells NaN from a
+    /// value that merely compares unequal.
+    Vs = 6,
     Ge = 10,
     Lt = 11,
     Gt = 12,
@@ -1538,9 +1551,8 @@ pub(crate) enum LoweredFieldRepr {
     /// index lazily, because a payload can name an enum whose own entry is
     /// still being built.
     Enum(String),
-    /// A payload this backend has no rendering for -- a Double, whose
-    /// shortest-round-trip formatter does not exist here.
-    Unrenderable,
+    /// An IEEE double, boxed like any other scalar.
+    Double,
 }
 
 impl LoweredFieldRepr {
@@ -1550,7 +1562,7 @@ impl LoweredFieldRepr {
             crate::EnumFieldRepr::BoolField => Self::Bool,
             crate::EnumFieldRepr::StringField => Self::Str,
             crate::EnumFieldRepr::EnumField => Self::Enum(annotation),
-            crate::EnumFieldRepr::DoubleField => Self::Unrenderable,
+            crate::EnumFieldRepr::DoubleField => Self::Double,
         }
     }
 }
@@ -3917,6 +3929,7 @@ impl Emitter {
                 match self.expression(hole)? {
                     ValueType::Str => {}
                     ValueType::Int => self.emit_int_to_str(),
+                    ValueType::Double => self.emit_double_to_str(),
                     ValueType::Bool => self.emit_bool_to_str(),
                     // A collection renders into the hole the way `println`
                     // renders it, through the same builder.
@@ -6107,6 +6120,319 @@ impl Emitter {
         self.asm.add_sp_imm(32);
     }
 
+    /// Write the Double whose bits are in x0 to stdout, no newline.
+    /// The scratch buffer lives on the machine stack, so nothing about it
+    /// needs the collector's attention.
+    fn emit_print_double(&mut self) {
+        self.asm.sub_sp_imm(DOUBLE_BUFFER_BYTES);
+        self.asm.add_reg_sp_imm(Reg::X12, 0);
+        self.emit_runtime_double_ascii(Reg::X12);
+        self.asm.mov_imm64(Reg::X0, STDOUT_FD);
+        self.asm.mov_imm64(Reg::X16, u64::from(SYS_WRITE));
+        self.asm.svc_0x80();
+        self.asm.add_sp_imm(DOUBLE_BUFFER_BYTES);
+    }
+
+    /// `toString` of the Double in x0 -> fresh string object in x0. The
+    /// Double sibling of `emit_int_to_str`, and copied out of the stack
+    /// buffer the same way, so the allocation that follows cannot disturb
+    /// the bytes it is about to copy.
+    fn emit_double_to_str(&mut self) {
+        self.asm.sub_sp_imm(DOUBLE_BUFFER_BYTES);
+        self.asm.add_reg_sp_imm(Reg::X12, 0);
+        self.emit_runtime_double_ascii(Reg::X12);
+        self.emit_alloc_raw_string(Reg::X2);
+        self.asm.str_imm(Reg::X2, Reg::X5, 0);
+        self.asm.add_reg_imm(Reg::X7, Reg::X5, 8);
+        self.emit_copy_bytes(Reg::X2, Reg::X1, Reg::X7, Reg::X3);
+        self.asm.mov_reg(Reg::X0, Reg::X5);
+        self.asm.add_sp_imm(DOUBLE_BUFFER_BYTES);
+    }
+
+    /// A whole-number Double: its integer digits followed by `.0`. The
+    /// truncated value is already in x0 (`fcvtzs` put it there), and the
+    /// digits are filled backwards from the buffer's end so the leading
+    /// position is wherever the loop stopped.
+    fn emit_double_whole_digits(&mut self, buffer: Reg) {
+        // Leave room at the end for the two `.0` bytes.
+        self.asm
+            .add_reg_imm(Reg::X1, buffer, DOUBLE_BUFFER_BYTES - 2);
+        self.emit_signed_digits_backwards(Reg::X0, Reg::X1);
+        // `.0`, contiguous with the ones digit the loop just wrote.
+        self.asm
+            .add_reg_imm(Reg::X3, buffer, DOUBLE_BUFFER_BYTES - 2);
+        self.asm.mov_imm64(Reg::X4, u64::from(b'.'));
+        self.asm.strb_post_increment(Reg::X4, Reg::X3);
+        self.asm.mov_imm64(Reg::X4, u64::from(b'0'));
+        self.asm.strb_post_increment(Reg::X4, Reg::X3);
+        // x1 = first byte, x2 = length.
+        self.asm.add_reg_imm(Reg::X2, buffer, DOUBLE_BUFFER_BYTES);
+        self.asm.sub_reg(Reg::X2, Reg::X2, Reg::X1);
+    }
+
+    /// A fraction, written out exactly. Every finite double is `M * 2^E`, and
+    /// for a fraction `E` is negative -- so with `k = -E` the value is
+    /// `M * 5^k / 10^k`, an integer numerator over a power of ten.
+    ///
+    /// Two bounds decide whether that numerator can be used. It has to fit an
+    /// i64, which is what `k <= 27` and the per-multiply overflow check
+    /// enforce. And it has to be the same text Rust's shortest-round-trip
+    /// formatter would print, which is what `D <= 15` enforces: a decimal with
+    /// at most `DBL_DIG` significant digits round-trips through a double
+    /// injectively, so no shorter alternative exists for it, while past that
+    /// the exact expansion is measurably longer than what the evaluator
+    /// prints. Either bound missed jumps to `overflow`.
+    fn emit_double_fraction_digits(&mut self, buffer: Reg, overflow: Label) {
+        // E0 = biased exponent - 1075, i.e. the exponent of the mantissa read
+        // as a 53-bit integer.
+        self.asm.lsr_imm(Reg::X0, Reg::X9, 52);
+        self.asm.mov_imm64(Reg::X4, 0x7ff);
+        self.asm.and_reg(Reg::X0, Reg::X0, Reg::X4);
+        self.asm.mov_imm64(Reg::X4, 1075);
+        self.asm.sub_reg(Reg::X8, Reg::X0, Reg::X4); // x8 = E0
+
+        // M0 = mantissa | (1 << 52). Reading a subnormal as if it were
+        // normalised overstates it, but a subnormal needs far more than the
+        // bound below allows either way, so it lands in `overflow` regardless.
+        self.asm.mov_imm64(Reg::X4, (1u64 << 52) - 1);
+        self.asm.and_reg(Reg::X0, Reg::X9, Reg::X4);
+        self.asm.mov_imm64(Reg::X4, 1u64 << 52);
+        self.asm.orr_reg(Reg::X0, Reg::X0, Reg::X4);
+
+        // Strip trailing zero bits: M0 = M1 * 2^t with M1 odd. The implicit
+        // leading bit is always set, so this stops within 53 turns.
+        self.asm.mov_imm64(Reg::X10, 0); // t
+        let tz_loop = self.asm.new_label();
+        let tz_done = self.asm.new_label();
+        self.asm.bind(tz_loop);
+        self.asm.mov_imm64(Reg::X4, 1);
+        self.asm.and_reg(Reg::X5, Reg::X0, Reg::X4);
+        self.asm
+            .branch(tz_done, BranchKind::CompareNonZero(Reg::X5));
+        self.asm.lsr_imm(Reg::X0, Reg::X0, 1);
+        self.asm.add_reg_imm(Reg::X10, Reg::X10, 1);
+        self.asm.branch(tz_loop, BranchKind::Unconditional);
+        self.asm.bind(tz_done);
+
+        // k = -(E0 + t). A whole number too large for the fast path, and an
+        // infinity, both land at `k <= 0` here rather than needing a test of
+        // their own.
+        self.asm.add_reg(Reg::X8, Reg::X8, Reg::X10);
+        self.asm.mov_imm64(Reg::X11, 0);
+        self.asm.sub_reg(Reg::X11, Reg::X11, Reg::X8); // x11 = k
+        self.asm.cmp_imm(Reg::X11, 0);
+        self.asm.branch(overflow, BranchKind::Conditional(Cond::Le));
+        self.asm.cmp_imm(Reg::X11, 27);
+        self.asm.branch(overflow, BranchKind::Conditional(Cond::Gt));
+
+        // N = M1 * 5^k. AArch64's multiply sets no flags, so the check is the
+        // pre-condition instead: `n * 5` fits a signed 64-bit value exactly
+        // when `n <= i64::MAX / 5`.
+        self.asm.mov_reg(Reg::X10, Reg::X11); // counter
+        let mul_loop = self.asm.new_label();
+        let mul_done = self.asm.new_label();
+        self.asm.bind(mul_loop);
+        self.asm.branch(mul_done, BranchKind::CompareZero(Reg::X10));
+        self.asm.mov_imm64(Reg::X4, (i64::MAX / 5) as u64);
+        self.asm.cmp_reg(Reg::X0, Reg::X4);
+        self.asm.branch(overflow, BranchKind::Conditional(Cond::Gt));
+        self.asm.mov_imm64(Reg::X4, 5);
+        self.asm.mul_reg(Reg::X0, Reg::X0, Reg::X4);
+        self.asm.sub_reg_imm(Reg::X10, Reg::X10, 1);
+        self.asm.branch(mul_loop, BranchKind::Unconditional);
+        self.asm.bind(mul_done);
+
+        // N's digits, most-significant first, filled backwards into the front
+        // of the buffer. The assembled text goes into the back half, so the
+        // two never overlap.
+        self.asm
+            .add_reg_imm(Reg::X1, buffer, DOUBLE_NUMERATOR_BYTES);
+        self.asm.mov_imm64(Reg::X6, 0); // D
+        let n_loop = self.asm.new_label();
+        self.asm.bind(n_loop);
+        self.asm.mov_imm64(Reg::X3, 10);
+        self.asm.sdiv_reg(Reg::X4, Reg::X0, Reg::X3);
+        self.asm.msub_reg(Reg::X2, Reg::X4, Reg::X3, Reg::X0);
+        self.asm.add_reg_imm(Reg::X2, Reg::X2, u32::from(b'0'));
+        self.asm.store_byte_pre_decrement(Reg::X2, Reg::X1);
+        self.asm.add_reg_imm(Reg::X6, Reg::X6, 1);
+        self.asm.mov_reg(Reg::X0, Reg::X4);
+        self.asm.branch(n_loop, BranchKind::CompareNonZero(Reg::X0));
+        self.asm.cmp_imm(Reg::X6, 15);
+        self.asm.branch(overflow, BranchKind::Conditional(Cond::Gt));
+        // x1 -> N's most significant digit, x6 = D, x11 = k.
+
+        // Assemble "[-]<int>.<frac>" forwards into the back half.
+        self.asm
+            .add_reg_imm(Reg::X3, buffer, DOUBLE_NUMERATOR_BYTES); // start
+        self.asm.mov_reg(Reg::X2, Reg::X3); // write cursor
+        let no_sign = self.asm.new_label();
+        self.asm.lsr_imm(Reg::X4, Reg::X9, 63);
+        self.asm.branch(no_sign, BranchKind::CompareZero(Reg::X4));
+        self.asm.mov_imm64(Reg::X5, u64::from(b'-'));
+        self.asm.strb_post_increment(Reg::X5, Reg::X2);
+        self.asm.bind(no_sign);
+
+        let frac_only = self.asm.new_label();
+        let assembled = self.asm.new_label();
+        self.asm.cmp_reg(Reg::X6, Reg::X11);
+        self.asm
+            .branch(frac_only, BranchKind::Conditional(Cond::Le));
+
+        // D > k: the first D-k digits are the integer part.
+        self.asm.sub_reg(Reg::X7, Reg::X6, Reg::X11);
+        self.emit_copy_digit_run(Reg::X1, Reg::X2, Reg::X7);
+        self.asm.add_reg(Reg::X2, Reg::X2, Reg::X7);
+        self.asm.add_reg(Reg::X1, Reg::X1, Reg::X7);
+        self.asm.mov_imm64(Reg::X4, u64::from(b'.'));
+        self.asm.strb_post_increment(Reg::X4, Reg::X2);
+        self.emit_copy_digit_run(Reg::X1, Reg::X2, Reg::X11);
+        self.asm.add_reg(Reg::X2, Reg::X2, Reg::X11);
+        self.asm.branch(assembled, BranchKind::Unconditional);
+
+        // D <= k: no integer digit, and k-D leading zeros after the point.
+        self.asm.bind(frac_only);
+        self.asm.mov_imm64(Reg::X4, u64::from(b'0'));
+        self.asm.strb_post_increment(Reg::X4, Reg::X2);
+        self.asm.mov_imm64(Reg::X4, u64::from(b'.'));
+        self.asm.strb_post_increment(Reg::X4, Reg::X2);
+        self.asm.sub_reg(Reg::X7, Reg::X11, Reg::X6);
+        let pad_loop = self.asm.new_label();
+        let pad_done = self.asm.new_label();
+        self.asm.mov_imm64(Reg::X5, 0);
+        self.asm.bind(pad_loop);
+        self.asm.cmp_reg(Reg::X5, Reg::X7);
+        self.asm.branch(pad_done, BranchKind::Conditional(Cond::Eq));
+        self.asm.mov_imm64(Reg::X4, u64::from(b'0'));
+        self.asm.strb_reg_offset(Reg::X4, Reg::X2, Reg::X5);
+        self.asm.add_reg_imm(Reg::X5, Reg::X5, 1);
+        self.asm.branch(pad_loop, BranchKind::Unconditional);
+        self.asm.bind(pad_done);
+        self.asm.add_reg(Reg::X2, Reg::X2, Reg::X7);
+        self.emit_copy_digit_run(Reg::X1, Reg::X2, Reg::X6);
+        self.asm.add_reg(Reg::X2, Reg::X2, Reg::X6);
+
+        self.asm.bind(assembled);
+        self.asm.sub_reg(Reg::X2, Reg::X2, Reg::X3); // length
+        self.asm.mov_reg(Reg::X1, Reg::X3); // first byte
+    }
+
+    /// Copy `count` bytes from `src` to `dst` without moving either pointer;
+    /// the three assembly steps each advance their own cursor afterwards.
+    /// Clobbers x4 and x5.
+    fn emit_copy_digit_run(&mut self, src: Reg, dst: Reg, count: Reg) {
+        let loop_start = self.asm.new_label();
+        let done = self.asm.new_label();
+        self.asm.mov_imm64(Reg::X5, 0);
+        self.asm.bind(loop_start);
+        self.asm.cmp_reg(Reg::X5, count);
+        self.asm.branch(done, BranchKind::Conditional(Cond::Eq));
+        self.asm.ldrb_reg_offset(Reg::X4, src, Reg::X5);
+        self.asm.strb_reg_offset(Reg::X4, dst, Reg::X5);
+        self.asm.add_reg_imm(Reg::X5, Reg::X5, 1);
+        self.asm.branch(loop_start, BranchKind::Unconditional);
+        self.asm.bind(done);
+    }
+
+    /// The refusal the two overflow paths share. x86-64 renders exactly the
+    /// same set of Doubles and errors on the rest, so this backend errors on
+    /// the rest too -- printing `NaN` or `inf` here where the other target
+    /// stops would be a silent disagreement between two builds of one
+    /// program, which is worse than either answer.
+    fn emit_double_format_error(&mut self) {
+        self.asm.emit_write_rodata(
+            STDERR_FD,
+            b"klassic: native Double formatting supports only whole numbers (e.g. 3.0) \
+and exact binary fractions with a short decimal expansion (e.g. 2.5); this value's \
+exact decimal expansion is too long, or it is NaN/Infinity\n",
+        );
+        self.asm.emit_exit(1);
+    }
+
+    /// The signed integer in `value`, written backwards from `cursor` (which
+    /// is decremented past each byte). Mirrors `emit_int_digits`, but over a
+    /// caller-chosen buffer rather than the stack frame.
+    fn emit_signed_digits_backwards(&mut self, value: Reg, cursor: Reg) {
+        self.asm.mov_reg(Reg::X0, value);
+        self.asm.cmp_imm(Reg::X0, 0);
+        self.asm.cset(Reg::X5, Cond::Lt);
+        let non_negative = self.asm.new_label();
+        self.asm
+            .branch(non_negative, BranchKind::Conditional(Cond::Ge));
+        self.asm.neg_x0();
+        self.asm.bind(non_negative);
+        let digit_loop = self.asm.new_label();
+        self.asm.bind(digit_loop);
+        self.asm.mov_imm64(Reg::X3, 10);
+        self.asm.sdiv_reg(Reg::X4, Reg::X0, Reg::X3);
+        self.asm.msub_reg(Reg::X2, Reg::X4, Reg::X3, Reg::X0);
+        self.asm.add_reg_imm(Reg::X2, Reg::X2, u32::from(b'0'));
+        self.asm.store_byte_pre_decrement(Reg::X2, cursor);
+        self.asm.mov_reg(Reg::X0, Reg::X4);
+        self.asm
+            .branch(digit_loop, BranchKind::CompareNonZero(Reg::X0));
+        let no_sign = self.asm.new_label();
+        self.asm.branch(no_sign, BranchKind::CompareZero(Reg::X5));
+        self.asm.mov_imm64(Reg::X3, u64::from(b'-'));
+        self.asm.store_byte_pre_decrement(Reg::X3, cursor);
+        self.asm.bind(no_sign);
+    }
+
+    /// Render the Double whose raw bits are in x0 into a 48-byte buffer on
+    /// the machine stack, leaving the first byte's address in x1 and the
+    /// length in x2. Clobbers x0-x11 and d0-d2; the caller reserves and
+    /// releases the stack space.
+    ///
+    /// The format is the evaluator's, which x86-64 also produces: a whole
+    /// number keeps one trailing decimal (`4.0`), and a fraction is written
+    /// out exactly rather than rounded, because every finite double *is* an
+    /// exact decimal -- `M / 2^k` is `M * 5^k / 10^k`.
+    ///
+    /// Three cases, in the order they are tested:
+    ///
+    /// * not a number, or too large for the exact path -- refused at run time
+    ///   rather than approximated, which is what x86-64 does with the same
+    ///   values;
+    /// * a whole number, which is the integer digits plus `.0`;
+    /// * a fraction, recovered from the bit pattern as `M1 * 5^k` scaled by
+    ///   `10^-k`, with `k` bounded so the numerator fits an i64.
+    fn emit_runtime_double_ascii(&mut self, buffer: Reg) {
+        // x9 keeps the raw bits: the FP round-trip below destroys x0, and the
+        // fraction path needs the pattern again.
+        self.asm.mov_reg(Reg::X9, Reg::X0);
+        self.asm.fmov_d_from_x(0, Reg::X0);
+        self.asm.fcvtzs_x_from_d(Reg::X0, 0);
+        self.asm.scvtf_d_from_x(1, Reg::X0);
+        self.asm.fcmp_d(0, 1);
+
+        let whole = self.asm.new_label();
+        let fraction = self.asm.new_label();
+        let special = self.asm.new_label();
+        let done = self.asm.new_label();
+
+        // An unordered compare (either side NaN) sets V, which `Vs` reads;
+        // it has to be tested before equality, since an unordered `fcmp`
+        // leaves Z set as well.
+        self.asm.branch(special, BranchKind::Conditional(Cond::Vs));
+        self.asm.branch(whole, BranchKind::Conditional(Cond::Eq));
+        self.asm.branch(fraction, BranchKind::Unconditional);
+
+        // ---- whole number: "<digits>.0" ----
+        self.asm.bind(whole);
+        self.emit_double_whole_digits(buffer);
+        self.asm.branch(done, BranchKind::Unconditional);
+
+        // ---- exact fraction ----
+        self.asm.bind(fraction);
+        self.emit_double_fraction_digits(buffer, special);
+        self.asm.branch(done, BranchKind::Unconditional);
+
+        // ---- NaN, the infinities, and anything past the exact bounds ----
+        self.asm.bind(special);
+        self.emit_double_format_error();
+        self.asm.bind(done);
+    }
+
     /// `toString` of the Bool in x0 → interned "true"/"false" object.
     fn emit_bool_to_str(&mut self) {
         let false_label = self.asm.new_label();
@@ -6623,11 +6949,8 @@ impl Emitter {
     /// x0-x5/x16.
     fn emit_print_elem(&mut self, elem: ListElem, span: Span) -> Result<(), Diagnostic> {
         match elem {
-            // Rendering a Double needs the shortest-round-trip formatter this
-            // backend does not have yet; arithmetic and comparison on Doubles
-            // (including inside a list) work regardless.
             ListElem::Double => {
-                return Err(unsupported(span, "printing a Double element"));
+                self.emit_print_double();
             }
             ListElem::Enum(shape) => {
                 self.emit_print_enum_inline(shape, span)?;
@@ -6906,8 +7229,9 @@ impl Emitter {
                             };
                             self.emit_print_lowered_enum(inner, span)?;
                         }
-                        LoweredFieldRepr::Unrenderable => {
-                            return Err(unsupported(span, "printing an enum payload of this type"));
+                        LoweredFieldRepr::Double => {
+                            self.emit_unbox_scalar();
+                            self.emit_print_elem(ListElem::Double, span)?;
                         }
                     }
                 }
@@ -7016,6 +7340,7 @@ impl Emitter {
             ("toString", 1) => {
                 match self.expression(&arguments[0])? {
                     ValueType::Int => self.emit_int_to_str(),
+                    ValueType::Double => self.emit_double_to_str(),
                     ValueType::Bool => self.emit_bool_to_str(),
                     ValueType::Str => {}
                     other => {
@@ -8598,6 +8923,18 @@ impl Emitter {
                 }
                 Ok(Some(ValueType::Str))
             }
+            // The lowering wraps a Double enum payload in this so the x86-64
+            // partial evaluator turns a *literal* argument into real bits
+            // before storing it. Nothing here is folded -- a Double is always
+            // already bits in a register -- so the coercion is the identity,
+            // and only the type is worth checking.
+            ("__runtime_double", 1) => {
+                let ty = self.expression(&arguments[0])?;
+                if ty != ValueType::Double {
+                    return Err(unsupported(span, "__runtime_double of a non-Double"));
+                }
+                Ok(Some(ValueType::Double))
+            }
             // ---- numeric builtins ----
             // Doubles travel as their raw bits in a general register, so each
             // of these moves through d0 and back. `abs` is the only one that
@@ -9073,9 +9410,7 @@ impl Emitter {
                     .expect("a nested element is a list of its inner element");
                 self.emit_list_to_str(inner, "[", "]", span)?;
             }
-            // Guarded by the callers, which reject a Double element before
-            // building any text (see emit_print_elem).
-            ListElem::Double => return Err(unsupported(span, "rendering a Double element")),
+            ListElem::Double => self.emit_double_to_str(),
         }
         self.asm.mov_reg(Reg::X1, Reg::X0);
         self.asm.load_local(Reg::X0, acc);
@@ -9163,6 +9498,7 @@ impl Emitter {
                     }
                     match field_ty {
                         ValueType::Int => self.emit_int_to_str(),
+                        ValueType::Double => self.emit_double_to_str(),
                         ValueType::Bool => self.emit_bool_to_str(),
                         ValueType::Str => {}
                         ValueType::Enum(inner) => self.emit_enum_to_str(inner, span)?,
@@ -9272,11 +9608,9 @@ impl Emitter {
                             };
                             self.emit_lowered_enum_to_str(inner, span)?;
                         }
-                        LoweredFieldRepr::Unrenderable => {
-                            return Err(unsupported(
-                                span,
-                                "rendering an enum payload of this type",
-                            ));
+                        LoweredFieldRepr::Double => {
+                            self.emit_unbox_scalar();
+                            self.emit_double_to_str();
                         }
                     }
                     self.asm.mov_reg(Reg::X1, Reg::X0);
@@ -10445,6 +10779,7 @@ impl Emitter {
                     "__gc_record" | "__gc_alloc" | "__gc_string" => {
                         return Some(ValueType::Ptr);
                     }
+                    "__runtime_double" => return Some(ValueType::Double),
                     "__match_fail" => return Some(ValueType::Never),
                     "toString" | "substring" | "trim" | "toUpperCase" | "toLowerCase"
                     | "reverse" | "join" | "replaceAll" | "replace" | "repeat" | "at"
@@ -11884,6 +12219,11 @@ impl Emitter {
                 self.asm.emit_print_int_line();
                 Ok(())
             }
+            ValueType::Double => {
+                self.emit_print_double();
+                self.asm.emit_write_rodata(STDOUT_FD, b"\n");
+                Ok(())
+            }
             ValueType::Str => {
                 self.emit_println_str();
                 Ok(())
@@ -11968,9 +12308,9 @@ impl Emitter {
                     }
                     // Everything `emit_print_elem` can already render: a
                     // lookup answers a value or nothing, and the value half is
-                    // an ordinary element. Only a Double is left out, because
-                    // this backend has no run-time formatter for one.
-                    ListElem::Enum(_)
+                    // an ordinary element.
+                    ListElem::Double
+                    | ListElem::Enum(_)
                     | ListElem::Record(_)
                     | ListElem::LoweredEnum(_)
                     | ListElem::Nested { .. } => {
@@ -11981,12 +12321,6 @@ impl Emitter {
                         self.asm.emit_write_rodata(STDOUT_FD, b"null\n");
                         self.asm.bind(end_label);
                         return Ok(());
-                    }
-                    ListElem::Double => {
-                        return Err(unsupported(
-                            argument.span(),
-                            &format!("printing a nullable {}", elem_display_name(elem)),
-                        ));
                     }
                 }
                 self.asm.branch(end_label, BranchKind::Unconditional);

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -12261,7 +12261,16 @@ impl NativeCodeGenerator {
     }
 
     fn compiled_literal_value_from_native(&mut self, value: NativeValue) -> CompiledLiteralValue {
-        if matches!(value, NativeValue::Int | NativeValue::Bool) {
+        // A `Native` element carries no storage -- it means "the value is in
+        // Rax", which stops being true as soon as the next element compiles.
+        // Anything that lives in Rax therefore has to be spilled here. A
+        // `RuntimeDouble` is its raw bits in Rax exactly like an `Int`, and
+        // leaving it out made `[aDouble]` render from a long-dead Rax: the
+        // list printed `[null]`, compiled clean and exited zero.
+        if matches!(
+            value,
+            NativeValue::Int | NativeValue::Bool | NativeValue::RuntimeDouble
+        ) {
             let slot = self.asm.data_label_with_i64s(&[0]);
             self.emit_store_rax_to_data_slot(slot);
             CompiledLiteralValue::Scalar { value, slot }
@@ -13469,6 +13478,17 @@ impl NativeCodeGenerator {
                         span,
                         overflow_message,
                     ),
+                    // The slot holds a Double's raw bits, which is what the
+                    // decimal formatter reads out of Rax. Without this arm a
+                    // list of Doubles printed as `[null, null]` -- a compiled,
+                    // zero-exit, wrong answer.
+                    NativeValue::RuntimeDouble => self
+                        .emit_append_whole_runtime_double_to_runtime_buffer_offset_label(
+                            data,
+                            offset,
+                            span,
+                            overflow_message,
+                        ),
                     _ => self.emit_append_text_to_runtime_buffer(
                         data,
                         offset,
@@ -13723,6 +13743,13 @@ impl NativeCodeGenerator {
             }
             "abs" => {
                 let value = self.compile_expr(&arguments[0])?;
+                // A Double's magnitude is the same bits with the sign cleared,
+                // which needs no SSE and no branch.
+                if value == NativeValue::RuntimeDouble {
+                    self.asm.mov_imm64(Reg::Rbx, 0x7fff_ffff_ffff_ffff);
+                    self.asm.and_reg_reg(Reg::Rax, Reg::Rbx);
+                    return Ok(NativeValue::RuntimeDouble);
+                }
                 if value != NativeValue::Int {
                     return Err(unsupported(span, "native abs for non-Int"));
                 }
@@ -13740,6 +13767,36 @@ impl NativeCodeGenerator {
                 self.asm.bind_text_label(ok);
                 self.asm.bind_text_label(done);
                 Ok(NativeValue::Int)
+            }
+            // The Double-valued helpers, for a value only known at run time.
+            // A `RuntimeDouble` is its raw bits in Rax, so each of these is a
+            // trip through Xmm0 and back -- except `abs`, which only has to
+            // clear the sign bit and can stay in the GPR.
+            "double" => {
+                let value = self.compile_expr(&arguments[0])?;
+                match value {
+                    NativeValue::Int => {
+                        self.asm.cvtsi2sd(XmmReg::Xmm0, Reg::Rax);
+                        self.asm.movq_gpr_from_xmm(Reg::Rax, XmmReg::Xmm0);
+                        Ok(NativeValue::RuntimeDouble)
+                    }
+                    NativeValue::RuntimeDouble => Ok(NativeValue::RuntimeDouble),
+                    _ => Err(unsupported(span, "native double of this value type")),
+                }
+            }
+            // The evaluator's `sqrt` is Double-valued for an Int argument too.
+            "sqrt" => {
+                let value = self.compile_expr(&arguments[0])?;
+                match value {
+                    NativeValue::Int => self.asm.cvtsi2sd(XmmReg::Xmm0, Reg::Rax),
+                    NativeValue::RuntimeDouble => {
+                        self.asm.movq_xmm_from_gpr(XmmReg::Xmm0, Reg::Rax)
+                    }
+                    _ => return Err(unsupported(span, "native sqrt of this value type")),
+                }
+                self.asm.sqrtsd(XmmReg::Xmm0, XmmReg::Xmm0);
+                self.asm.movq_gpr_from_xmm(Reg::Rax, XmmReg::Xmm0);
+                Ok(NativeValue::RuntimeDouble)
             }
             _ => Err(unsupported(
                 span,
@@ -26913,6 +26970,17 @@ impl NativeCodeGenerator {
                         span,
                         overflow_message,
                     ),
+                    // The slot holds a Double's raw bits, which is what the
+                    // decimal formatter reads out of Rax. Without this arm a
+                    // list of Doubles printed as `[null, null]` -- a compiled,
+                    // zero-exit, wrong answer.
+                    NativeValue::RuntimeDouble => self
+                        .emit_append_whole_runtime_double_to_runtime_buffer_offset_label(
+                            data,
+                            offset,
+                            span,
+                            overflow_message,
+                        ),
                     _ => self.emit_append_text_to_runtime_buffer(
                         data,
                         offset,
@@ -26956,6 +27024,17 @@ impl NativeCodeGenerator {
                 span,
                 overflow_message,
             ),
+            // Reads Rax, on the same terms as the `Int` arm above: a value
+            // that lives only in Rax is spilled to a slot before it can be
+            // rendered later (see `compiled_literal_value_from_native`), so
+            // reaching here means Rax is still the value.
+            NativeValue::RuntimeDouble => self
+                .emit_append_whole_runtime_double_to_runtime_buffer_offset_label(
+                    data,
+                    offset,
+                    span,
+                    overflow_message,
+                ),
             NativeValue::RuntimeLinesList { data: lines, len } => {
                 let rendered = self.emit_runtime_lines_list_to_runtime_string(
                     NativeStringRef {
@@ -42678,6 +42757,13 @@ impl Assembler {
         self.byte(0x66);
         self.bytes(&[0x0f, 0x2e]);
         self.modrm(lhs as u8, rhs as u8);
+    }
+
+    /// `SQRTSD xmm1, xmm2` (F2 0F 51 /r): `dst = sqrt(src)`.
+    fn sqrtsd(&mut self, dst: XmmReg, src: XmmReg) {
+        self.byte(0xf2);
+        self.bytes(&[0x0f, 0x51]);
+        self.modrm(dst as u8, src as u8);
     }
 
     /// `ADDSD xmm1, xmm2` (F2 0F 58 /r): `dst = dst + src`.

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -31,6 +31,18 @@ pub struct NativeCompilerConfig {
     /// color, so the load-barrier slow path runs on every load and any
     /// unbarriered dereference faults on a non-canonical address.
     pub gc_poison: bool,
+    /// Whether the driver will retry through the portable C backend if this
+    /// build reports a `Diagnostic` -- true for the aarch64 host default,
+    /// false for an explicit `--target` and for the ELF/PE backends.
+    ///
+    /// A backend that can only *partly* implement a construct has to know
+    /// this. Rendering a run-time Double is the case: the emitted formatter
+    /// covers whole numbers and short exact fractions and traps on the rest,
+    /// which is the best answer available when the alternative is not
+    /// building at all -- and strictly worse than declining when the
+    /// alternative is a C build that renders every Double. Declining at build
+    /// time degrades; trapping at run time does not.
+    pub fallback_backend_available: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -700,6 +712,7 @@ fn compile_internal(
             config.gc_log,
             config.gc_stress,
             config.gc_poison,
+            config.fallback_backend_available,
         )
         .map_err(|diagnostic| NativeCompileError::with_view(source, user_view, diagnostic)),
     }
@@ -43268,6 +43281,47 @@ mod tests {
         let bytes = compile_source_for_target("<test>", "println(1)", config)
             .expect("program should compile for linux x86_64");
         assert_eq!(&bytes[..4], b"\x7fELF");
+    }
+
+    /// A Double this backend can only sometimes render is declined when the
+    /// driver has a fallback that always can, and emitted when it does not.
+    /// Getting this backwards turns a program that used to build and print
+    /// through the C backend into one that builds and traps at run time.
+    #[test]
+    fn aarch64_declines_a_partial_double_only_when_a_fallback_exists() {
+        let program = "def area(r: Double): Double = r * r * 3.14159\nprintln(area(2.0))\n";
+        let with_fallback = NativeCompilerConfig {
+            target: NativeTarget::MacosAarch64,
+            fallback_backend_available: true,
+            ..NativeCompilerConfig::default()
+        };
+        let declined = compile_source_for_target("<test>", program, with_fallback)
+            .expect_err("a partial Double renderer must defer to the C backend");
+        assert!(
+            format!("{declined}").contains("Double whose value is not known at build time"),
+            "the diagnostic should name what was declined: {declined}"
+        );
+
+        let without_fallback = NativeCompilerConfig {
+            target: NativeTarget::MacosAarch64,
+            fallback_backend_available: false,
+            ..NativeCompilerConfig::default()
+        };
+        compile_source_for_target("<test>", program, without_fallback)
+            .expect("an explicit --target build has no fallback, so it renders what it can");
+    }
+
+    /// A Double the folder can answer never reaches the run-time renderer, so
+    /// the host default keeps compiling it directly.
+    #[test]
+    fn aarch64_still_builds_a_folded_double_with_a_fallback_available() {
+        let config = NativeCompilerConfig {
+            target: NativeTarget::MacosAarch64,
+            fallback_backend_available: true,
+            ..NativeCompilerConfig::default()
+        };
+        compile_source_for_target("<test>", "println(1.5)\nprintln(2.0 + 0.5)\n", config)
+            .expect("a folded Double is formatted at build time, not by the emitted code");
     }
 
     #[test]

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -2173,6 +2173,26 @@ side of a branch.
   plus the newline, so a list of maps -- what grouping produces -- renders at
   both levels. A list of *sets* is still refused there for the same reason
   maps were: `ListElem` has no entry for one (issue #635).
+- aarch64 renders a Double whose value is only known at run time. It follows
+  the shape x86-64 already had: a whole number is its digits plus `.0`, and a
+  fraction is recovered exactly from the bit pattern as `M1 * 5^k` scaled by
+  `10^-k`, bounded so the numerator fits an i64 and so the exact expansion is
+  short enough (fifteen significant digits) to be the same text Rust's
+  shortest-round-trip formatter produces. Anything outside that -- NaN, an
+  infinity, or a longer expansion -- is refused at run time with the same
+  message x86-64 uses, rather than approximated: two builds of one program
+  disagreeing quietly is worse than either answer. The renderer reaches
+  `println`, list/set/map elements, interpolation holes, `toString`, record
+  fields and both kinds of enum payload (issue #644).
+- x86-64 makes a Double at run time: `double` of a run-time Int, and `sqrt` /
+  `abs` of a run-time Double. Before this the backend could only fold a Double
+  it already knew, so its own decimal formatter was unreachable.
+- x86-64 gives a run-time Double in a collection literal a spill slot.
+  `compiled_literal_value_from_native` spilled `Int` and `Bool` -- the values
+  that live in Rax -- but not a `RuntimeDouble`, which lives in Rax the same
+  way. A list of them therefore rendered from a register the next element had
+  already overwritten, and printed `[null, null]` while compiling clean and
+  exiting zero. This was unreachable until run-time Doubles existed.
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -2184,6 +2184,13 @@ side of a branch.
   disagreeing quietly is worse than either answer. The renderer reaches
   `println`, list/set/map elements, interpolation holes, `toString`, record
   fields and both kinds of enum payload (issue #644).
+- That renderer is emitted only when declining would fail the build. On the
+  aarch64 host default the driver retries through the portable C backend, which
+  renders *every* Double, so a partial renderer there would trade a working
+  program for a run-time trap; `NativeCompilerConfig::fallback_backend_available`
+  says which situation the build is in, and the backend declines when a
+  fallback exists. A Double the folder can answer never reaches the renderer at
+  all, so the host default keeps compiling those directly.
 - x86-64 makes a Double at run time: `double` of a run-time Int, and `sqrt` /
   `abs` of a run-time Double. Before this the backend could only fold a Double
   it already knew, so its own decimal formatter was unreachable.

--- a/docs/spec-matrix.md
+++ b/docs/spec-matrix.md
@@ -130,7 +130,8 @@ The repository contains a Rust-native language implementation with:
   zero-argument literal or lambda-value `stopwatch` via Linux `clock_gettime`, Int numeric
   helpers (`abs`, `int`, `floor`, `ceil`), static Double/Float literals and
   numeric helper folding (`double`, `sqrt`,
-  `abs`, `floor`, `ceil`) with Float preserving f32 rounding/display and
+  `abs`, `floor`, `ceil`) plus their run-time forms (`double` of a run-time
+  Int, `sqrt` / `abs` of a run-time Double) with Float preserving f32 rounding/display and
   effectful block-prefix arguments preserved before static numeric recovery, static
   Int-list `foreach`, static Int list literals
   with constant arithmetic and bitwise elements, generic static list arenas,

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,6 +167,12 @@ fn run(command: ParsedCommand) -> Result<(), u8> {
                 gc_log: command.config.gc_log,
                 gc_stress: command.config.gc_stress,
                 gc_poison: command.config.gc_poison,
+                // Kept in step with the fallback branch below: a backend that
+                // has to choose between a partial implementation and
+                // declining needs to know which of the two the driver will
+                // turn into a working program.
+                fallback_backend_available: !command.config.explicit_target
+                    && target.backend() == NativeBackend::DirectAarch64,
             };
             let user_modules = user_modules_for(&input, &text)?;
             let bytes = match compile_source_with_prelude_and_modules_for_target(

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -29286,3 +29286,69 @@ fn build_target_aarch64_apple_darwin_gc_evacuation_moves_objects() {
         "evacuation should move live objects out of sparse regions: {stderr}"
     );
 }
+
+/// The Double paths this backend renders and x86-64 still refuses at build
+/// time, so they cannot live in tests/cross-exec/46-runtime-doubles.kl: a
+/// Double through `toString`, inside a record, and inside a *generic* enum
+/// (which the shared lowering leaves as constructor calls rather than
+/// records). Each value is derived from `size(args())` so the compile-time
+/// folder cannot answer it and the run-time formatter has to.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn build_target_aarch64_apple_darwin_renders_runtime_doubles() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_arm_double_{stamp}.kl"));
+    let bin_path = dir.join(format!("klassic_arm_double_{stamp}.bin"));
+    let program = "import std.process as R\n\
+         enum Opt<a> { case Sm(v: a); case Nn }\n\
+         record Pt { x: Double; y: Double }\n\
+         def q(n: Int, d: Int): Double = double(n) / double(d)\n\
+         val k = size(R.args())\n\
+         val a = q(3 + k, 8)\n\
+         val b = q(-5 + k, 16)\n\
+         println(toString(a))\n\
+         val opt: Opt<Double> = Sm(b)\n\
+         println(opt)\n\
+         val point = #Pt(a, b)\n\
+         println(point)\n\
+         println([point])\n\
+         assertResult(0.375)(a)\n\
+         println(\"done\")\n";
+    fs::write(&source_path, program).expect("temp source file should write");
+    let build = Command::new(klassic_bin())
+        .args([
+            "--target",
+            "aarch64-apple-darwin",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build.status.success(),
+        "runtime-Double build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&bin_path)
+        .output()
+        .expect("generated Mach-O should execute");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&bin_path);
+    assert!(
+        run.status.success(),
+        "runtime-Double run exited with {:?}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "0.375\nSm(-0.3125)\n#Pt(0.375, -0.3125)\n[#Pt(0.375, -0.3125)]\ndone\n",
+        "every renderer must agree with the evaluator"
+    );
+}

--- a/tests/cross-exec/46-runtime-doubles.kl
+++ b/tests/cross-exec/46-runtime-doubles.kl
@@ -1,0 +1,67 @@
+// Cross-target fixture: Doubles whose value is only known at run time.
+//
+// Both native backends fold a Double they can see the value of, so
+// `println(1.5)` proved nothing about either one -- the text came out of
+// Rust's formatter at build time. Everything below is computed from
+// `size(args())`, which is zero but not knowably zero, so each value
+// reaches the backend's own decimal formatter.
+//
+// That formatter renders exactly the set the two backends agree on: a
+// whole number as `<digits>.0`, and a binary fraction whose exact decimal
+// expansion is short enough to be the same text the evaluator prints. A
+// value outside it (`1/5`, or an expansion past fifteen significant
+// digits) is refused at run time on both, so none appears here.
+//
+// A Double inside a record, inside a generic enum, or through `toString`
+// is still refused at build time by x86-64, so those live in the
+// aarch64-only test in tests/cli_smoke.rs rather than here.
+
+import std.process as R
+
+enum Boxed { case Num(v: Double); case Nothing }
+
+def q(n: Int, d: Int): Double = double(n) / double(d)
+def w(n: Int): Double = double(n)
+
+val k = size(R.args())
+
+// Whole numbers, including the sign and the wide end of the range.
+println(w(0 + k))
+println(w(1 + k))
+println(w(-1 + k))
+println(w(1000000 + k))
+println(w(-999999999999999 + k))
+
+// Fractions with an integer part and without one -- the two halves of the
+// assembly step, since a value below one has to grow a leading `0`, and a
+// short numerator has to grow leading zeros after the point.
+println(q(3 + k, 8))
+println(q(-3 + k, 8))
+println(q(123 + k, 64))
+println(q(1 + k, 1024))
+println(q(-1 + k, 32))
+println(q(1 + k, 131072))
+
+val a = q(3 + k, 8)
+val b = q(-5 + k, 16)
+
+// The same values through every renderer that is not `println` of a bare
+// Double. A collection element is the one that used to be wrong rather
+// than refused: with no spill slot of its own it rendered from a
+// long-dead register and printed `[null, null]`.
+println([a b])
+println(%(a b))
+println(%[1: a 2: b])
+println("a=#{a} b=#{b}")
+
+// A Double carried by an enum the shared pass lowers into records.
+val boxed: Boxed = Num(a)
+println(boxed)
+println("boxed=#{boxed}")
+
+// Arithmetic that produces a fresh Double rather than moving one around.
+println(sqrt(w(4 + k)))
+println(abs(q(-9 + k, 4)))
+println(a + b)
+println(a * w(2 + k))
+println("done")

--- a/tools/run-macho-aarch64.py
+++ b/tools/run-macho-aarch64.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Run an aarch64 Mach-O built by klassic on a machine that is not one.
+
+    klassic --target aarch64-apple-darwin build prog.kl -o prog.macho
+    python3 tools/run-macho-aarch64.py prog.macho
+
+Development happens on Linux x86-64, where the aarch64 backend can be built
+but not executed, so until now its only real test was a macOS CI runner --
+every semantic bug in it (a missing barrier, a wrong root, a decimal
+formatter that disagrees with the evaluator) was invisible until a push.
+This maps the Mach-O's segments into a unicorn ARM64 instance and emulates
+the small set of Darwin syscalls the backend emits, which is enough to run
+the programs under tests/cross-exec/ and diff them against the evaluator
+locally.
+
+Requires `pip install unicorn`. It is a development aid, not part of the
+test suite: CI still runs the real thing on real arm64 hardware, which is
+the only authority. Known gaps -- syscalls outside the list below, and any
+program whose answer depends on the host being macOS."""
+import struct, sys, os
+from unicorn import *
+from unicorn.arm64_const import *
+
+STACK_BASE = 0x0000_7000_0000_0000
+STACK_SIZE = 8 * 1024 * 1024
+MMAP_BASE  = 0x0000_2000_0000_0000
+
+SYS_EXIT, SYS_READ, SYS_WRITE, SYS_OPEN, SYS_CLOSE = 1, 3, 4, 5, 6
+SYS_UNLINK, SYS_GETPID, SYS_GETTIMEOFDAY = 10, 20, 116
+SYS_MMAP, SYS_MUNMAP, SYS_ACCESS, SYS_RENAME = 197, 73, 33, 128
+SYS_MKDIR, SYS_RMDIR, SYS_GETCWD, SYS_FSTATAT64 = 136, 137, 326, 470
+
+# Darwin's open(2) flag values, which are not Linux's.
+DARWIN_O = {0x0001: os.O_WRONLY, 0x0002: os.O_RDWR, 0x0008: os.O_APPEND,
+            0x0200: os.O_CREAT, 0x0400: os.O_TRUNC, 0x0800: os.O_EXCL}
+ENVIRON = [b'PATH=/usr/bin:/bin', b'HOME=/emu', b'TMPDIR=/tmp']
+# Any instant comfortably past the constants the fixtures compare against.
+NOW_SECONDS = 1_750_000_000
+
+def cstring(uc, addr):
+    out = bytearray()
+    while True:
+        byte = uc.mem_read(addr + len(out), 1)[0]
+        if byte == 0:
+            return bytes(out).decode('utf-8', 'surrogateescape')
+        out.append(byte)
+
+
+def load(path):
+    d = open(path, 'rb').read()
+    ncmds = struct.unpack_from('<I', d, 16)[0]
+    segs, entry = [], None
+    off = 32
+    for _ in range(ncmds):
+        cmd, cmdsize = struct.unpack_from('<2I', d, off)
+        if cmd == 0x19:  # LC_SEGMENT_64
+            name = d[off+8:off+24].rstrip(b'\0').decode()
+            vmaddr, vmsize, fileoff, filesize = struct.unpack_from('<4Q', d, off+24)
+            segs.append((name, vmaddr, vmsize, fileoff, filesize))
+        elif cmd == 0x80000028:  # LC_MAIN
+            entry = struct.unpack_from('<Q', d, off+8)[0]
+        off += cmdsize
+    return d, segs, entry
+
+def run(path, argv=None, trace=False):
+    d, segs, entryoff = load(path)
+    uc = Uc(UC_ARCH_ARM64, UC_MODE_ARM)
+    text_base = None
+    for name, vmaddr, vmsize, fileoff, filesize in segs:
+        if name == '__PAGEZERO' or vmsize == 0:
+            continue
+        size = (vmsize + 0xfff) & ~0xfff
+        uc.mem_map(vmaddr, size)
+        if filesize:
+            uc.mem_write(vmaddr, d[fileoff:fileoff+filesize])
+        if name == '__TEXT':
+            text_base = vmaddr
+    uc.mem_map(STACK_BASE, STACK_SIZE)
+
+    state = {'brk': MMAP_BASE, 'exit': None, 'out': [], 'err': []}
+
+    def svc(uc, intno, user):
+        num = uc.reg_read(UC_ARM64_REG_X16)
+        nzcv = uc.reg_read(UC_ARM64_REG_NZCV)
+        def ok(value):
+            uc.reg_write(UC_ARM64_REG_X0, value & 0xffffffffffffffff)
+            uc.reg_write(UC_ARM64_REG_NZCV, nzcv & ~(1 << 29))   # carry clear
+        def fail(errno):
+            uc.reg_write(UC_ARM64_REG_X0, errno)
+            uc.reg_write(UC_ARM64_REG_NZCV, nzcv | (1 << 29))    # carry set
+        if num == SYS_EXIT:
+            state['exit'] = uc.reg_read(UC_ARM64_REG_X0) & 0xff
+            uc.emu_stop()
+        elif num == SYS_WRITE:
+            fd = uc.reg_read(UC_ARM64_REG_X0)
+            buf = uc.reg_read(UC_ARM64_REG_X1)
+            n = uc.reg_read(UC_ARM64_REG_X2)
+            data = bytes(uc.mem_read(buf, n)) if n else b''
+            if fd in (1, 2):
+                (state['out'] if fd == 1 else state['err']).append(data)
+                ok(n)
+            else:
+                try:
+                    ok(os.write(fd, data))
+                except OSError as e:
+                    fail(e.errno)
+        elif num == SYS_MMAP:
+            length = uc.reg_read(UC_ARM64_REG_X1)
+            length = (length + 0xffff) & ~0xffff
+            addr = state['brk']
+            uc.mem_map(addr, length)
+            state['brk'] = addr + length
+            ok(addr)
+        elif num == SYS_MUNMAP:
+            ok(0)
+        elif num == SYS_GETPID:
+            ok(4242)
+        elif num == SYS_GETTIMEOFDAY:
+            tv = uc.reg_read(UC_ARM64_REG_X0)
+            if tv:
+                uc.mem_write(tv, struct.pack('<qq', NOW_SECONDS, 0))
+            ok(0)
+        elif num == SYS_GETCWD:
+            buf = uc.reg_read(UC_ARM64_REG_X0)
+            cwd = os.getcwd().encode() + b'\0'
+            uc.mem_write(buf, cwd)
+            ok(len(cwd))
+        elif num == SYS_OPEN:
+            path = cstring(uc, uc.reg_read(UC_ARM64_REG_X0))
+            raw = uc.reg_read(UC_ARM64_REG_X1)
+            flags = os.O_RDONLY
+            for bit, mapped in DARWIN_O.items():
+                if raw & bit:
+                    flags |= mapped
+            try:
+                ok(os.open(path, flags, 0o644))
+            except OSError as e:
+                fail(e.errno)
+        elif num == SYS_CLOSE:
+            try:
+                os.close(uc.reg_read(UC_ARM64_REG_X0))
+                ok(0)
+            except OSError as e:
+                fail(e.errno)
+        elif num == SYS_READ:
+            fd = uc.reg_read(UC_ARM64_REG_X0)
+            buf = uc.reg_read(UC_ARM64_REG_X1)
+            n = uc.reg_read(UC_ARM64_REG_X2)
+            try:
+                chunk = os.read(fd, n)
+                if chunk:
+                    uc.mem_write(buf, chunk)
+                ok(len(chunk))
+            except OSError as e:
+                fail(e.errno)
+        elif num in (SYS_UNLINK, SYS_RMDIR, SYS_MKDIR, SYS_ACCESS):
+            path = cstring(uc, uc.reg_read(UC_ARM64_REG_X0))
+            try:
+                if num == SYS_UNLINK:
+                    os.unlink(path)
+                elif num == SYS_RMDIR:
+                    os.rmdir(path)
+                elif num == SYS_MKDIR:
+                    os.mkdir(path, 0o755)
+                else:
+                    os.stat(path)
+                ok(0)
+            except OSError as e:
+                fail(e.errno)
+        elif num == SYS_RENAME:
+            src = cstring(uc, uc.reg_read(UC_ARM64_REG_X0))
+            dst = cstring(uc, uc.reg_read(UC_ARM64_REG_X1))
+            try:
+                os.rename(src, dst)
+                ok(0)
+            except OSError as e:
+                fail(e.errno)
+        elif num == SYS_FSTATAT64:
+            path = cstring(uc, uc.reg_read(UC_ARM64_REG_X1))
+            buf = uc.reg_read(UC_ARM64_REG_X2)
+            try:
+                st = os.stat(path)
+            except OSError as e:
+                fail(e.errno)
+            else:
+                # Only st_mode is read back, as a halfword at offset 4.
+                uc.mem_write(buf, b'\0' * 144)
+                uc.mem_write(buf + 4, struct.pack('<H', st.st_mode & 0xffff))
+                ok(0)
+        else:
+            state['err'].append(f'[emu] unhandled syscall {num}\n'.encode())
+            fail(45)
+
+    uc.hook_add(UC_HOOK_INTR, svc)
+    if trace:
+        def code(uc, address, size, user):
+            print(f'{address:#x}', file=sys.stderr)
+        uc.hook_add(UC_HOOK_CODE, code)
+
+    # Darwin LC_MAIN entry: x0=argc, x1=argv, x2=envp, x3=apple, with the
+    # three vectors laid out end to end, each NULL-terminated.
+    argv = argv or [b'/prog']
+    sp = STACK_BASE + STACK_SIZE - 0x1000
+    def push_string(text):
+        nonlocal sp
+        sp -= len(text) + 1
+        uc.mem_write(sp, text + b'\0')
+        return sp
+    argv_ptrs = [push_string(a) for a in argv]
+    env_ptrs = [push_string(e) for e in ENVIRON]
+    apple_ptrs = [push_string(argv[0])]
+    sp &= ~0xf
+    vector = (argv_ptrs + [0]) + (env_ptrs + [0]) + (apple_ptrs + [0])
+    sp -= 8 * len(vector)
+    sp &= ~0xf
+    uc.mem_write(sp, b''.join(struct.pack('<Q', p) for p in vector))
+    argv_addr = sp
+    env_addr = argv_addr + 8 * (len(argv_ptrs) + 1)
+    apple_addr = env_addr + 8 * (len(env_ptrs) + 1)
+    sp = (sp - 0x100) & ~0xf
+    uc.reg_write(UC_ARM64_REG_SP, sp)
+    uc.reg_write(UC_ARM64_REG_X0, len(argv_ptrs))
+    uc.reg_write(UC_ARM64_REG_X1, argv_addr)
+    uc.reg_write(UC_ARM64_REG_X2, env_addr)
+    uc.reg_write(UC_ARM64_REG_X3, apple_addr)
+
+    try:
+        uc.emu_start(text_base + entryoff, 0, 0, 0)
+    except UcError as e:
+        pc = uc.reg_read(UC_ARM64_REG_PC)
+        state['err'].append(f'[emu] {e} at pc={pc:#x}\n'.encode())
+        state['exit'] = 139
+    sys.stdout.buffer.write(b''.join(state['out']))
+    sys.stdout.buffer.flush()
+    sys.stderr.buffer.write(b''.join(state['err']))
+    sys.stderr.buffer.flush()
+    return state['exit'] if state['exit'] is not None else 0
+
+if __name__ == '__main__':
+    args = [a for a in sys.argv[1:] if a != '--trace']
+    sys.exit(run(args[0], [a.encode() for a in args] or None, '--trace' in sys.argv))


### PR DESCRIPTION
Closes #644. Closes #660.

## aarch64: render a run-time Double

The backend could compute with Doubles but not print one. `println(1.5)`
worked because the value was folded and formatted by Rust at build time;
anything the folder could not answer was refused.

This ports the shape x86-64 already had. A whole number is its integer
digits plus `.0`. A fraction is recovered exactly from the bit pattern --
every finite double is `M1 * 2^E1` with `M1` odd, so with `k = -E1` the
value is `M1 * 5^k` over `10^k` -- under two bounds:

* `k <= 27` plus a per-multiply overflow check, so the numerator fits an
  i64. AArch64's multiply sets no flags, so the check is the precondition
  `n <= i64::MAX / 5` rather than x86-64's `imul` + OF test.
* at most fifteen significant digits, so the exact expansion is provably
  the same text Rust's shortest-round-trip formatter produces.

Anything outside that -- NaN, an infinity, a longer expansion -- is
**refused at run time rather than approximated**, because x86-64 refuses
exactly the same set. An earlier draft printed `NaN` / `inf` here; that was
backed out, because two builds of one program quietly disagreeing is worse
than either answer.

The renderer reaches `println`, list/set/map elements, interpolation holes,
`toString`, record fields, and both a generic enum's payload and a lowered
one's.

## …but only where declining would fail the build

Real arm64 CI caught what local verification could not. On the **aarch64
host default** the driver retries a declined build through the portable C
backend, which renders *every* Double -- so a renderer that builds and then
traps at run time turns a working program into a broken one:

```klassic
def area(r: Double): Double = r * r * 3.14159
println(area(2.0))
```

    before   declined -> C fallback -> 12.56636
    after    direct build -> run-time trap        <- regression

Declining degrades; trapping does not. But an explicit
`--target aarch64-apple-darwin` build has **no** fallback, so there the
partial renderer is the difference between a program that mostly works and
one that cannot be built at all.

So the backend is told which situation it is in.
`NativeCompilerConfig::fallback_backend_available` is set by the driver from
the same condition its fallback branch uses, and the Double renderer
declines when it is true. A Double the folder can answer never reaches the
renderer, so the host default keeps compiling those directly and loses
nothing it had. The ELF and PE backends have no fallback, so the hazard does
not exist there.

## x86-64: make a run-time Double, and give one a slot

The backend could only fold a Double it already knew, so its own decimal
formatter was **unreachable**: `double(n)` for a run-time `n` was refused,
and nothing else produced one. This adds the run-time forms of `double`,
`sqrt` and `abs`.

That made a latent defect reachable, so it is fixed in the same PR (#660).
A `CompiledLiteralValue::Native` carries no storage; it only means "the
value is in Rax right now", which is why the values that live in Rax --
`Int` and `Bool` -- are spilled to a data slot when a collection literal
compiles them. A `RuntimeDouble` is its raw bits in Rax in exactly the same
way and was not in that set, so `[aDouble, another]` rendered from a
register the second element had already overwritten:

    evaluator   [0.375, -0.3125]
    x86-64      [null, null]        <- compiled clean, exited zero

Spilling it like the others fixes it. The remaining Double paths on this
backend -- `toString`, a record field, a generic enum's payload -- still
refuse at build time rather than answer.

## A local aarch64 runner

Development happens on Linux x86-64, where the aarch64 backend can be built
but not executed, so its every semantic bug was invisible until a push
reached a macOS runner -- the risk the GC-port plan named as its largest.
`tools/run-macho-aarch64.py` maps a built Mach-O into a unicorn ARM64
instance and emulates the Darwin syscalls the backend emits, which is enough
to run most of `tests/cross-exec/` against the evaluator locally. It is a
development aid; CI on real hardware stays the authority -- as the
fallback regression above shows, it is not a substitute for one.

## Verification

* `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` green.
* All 54 sample programs build for all three targets and match the
  evaluator on x86-64.
* All 46 `tests/cross-exec/` fixtures build for all three targets; x86-64
  matches the evaluator both plain and under `--gc-stress --gc-poison`;
  44 of 46 also match under the aarch64 emulator (the other two use threads
  and host-dependent state, which the emulator does not do).
* A 196-value Double corpus plus a boundary corpus, run under the aarch64
  emulator: every value inside the supported set matches the evaluator
  exactly, and every value outside it is refused rather than approximated.
* New fixture `tests/cross-exec/46-runtime-doubles.kl`, a macOS-gated
  `cli_smoke` test for the paths only aarch64 renders, and two unit tests
  pinning both directions of the fallback decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)