### PR TITLE
Let a collection hold a user-declared enum value

### DIFF
--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -3934,47 +3934,8 @@ impl Emitter {
                     self.emit_heap_string_copy();
                     return Ok(());
                 }
-                match self.expression(hole)? {
-                    ValueType::Str => {}
-                    ValueType::Int => self.emit_int_to_str(),
-                    ValueType::Double => self.emit_double_to_str(hole.span())?,
-                    ValueType::Bool => self.emit_bool_to_str(),
-                    // A collection renders into the hole the way `println`
-                    // renders it, through the same builder.
-                    ValueType::List(elem) => {
-                        self.emit_list_to_str(elem, "[", "]", hole.span())?;
-                    }
-                    ValueType::Set(elem) => {
-                        self.emit_list_to_str(elem, "%(", ")", hole.span())?;
-                    }
-                    ValueType::EmptyList => {
-                        let offset = self.asm.intern_string_object("[]");
-                        self.asm.load_rodata_address(Reg::X0, offset);
-                        self.emit_heap_string_copy();
-                    }
-                    ValueType::EmptySet => {
-                        let offset = self.asm.intern_string_object("%()");
-                        self.asm.load_rodata_address(Reg::X0, offset);
-                        self.emit_heap_string_copy();
-                    }
-                    ValueType::EmptyMap => {
-                        let offset = self.asm.intern_string_object("%[]");
-                        self.asm.load_rodata_address(Reg::X0, offset);
-                        self.emit_heap_string_copy();
-                    }
-                    ValueType::Enum(shape) => {
-                        self.emit_enum_to_str(shape, hole.span())?;
-                    }
-                    ValueType::LoweredEnum(index) => {
-                        self.emit_lowered_enum_to_str(index, hole.span())?;
-                    }
-                    other => {
-                        return Err(unsupported(
-                            hole.span(),
-                            &format!("string interpolation of {}", type_display_name(other)),
-                        ));
-                    }
-                }
+                let ty = self.expression(hole)?;
+                self.emit_value_to_str(ty, "string interpolation of", hole.span())?;
                 Ok(())
             }
         }
@@ -6465,6 +6426,50 @@ exact decimal expansion is too long, or it is NaN/Infinity\n",
         self.asm.bind(done);
     }
 
+    /// Convert the value in x0, of type `ty`, into a string object in x0.
+    ///
+    /// Shared by the two places that need a value's text without printing it:
+    /// a `#{...}` hole and `toString`. They rendered different sets before --
+    /// a hole took a collection or an enum, `toString` took only the scalars --
+    /// which is not a difference anyone writing the program would expect.
+    /// `context` names the caller for the refusal a type neither can render.
+    fn emit_value_to_str(
+        &mut self,
+        ty: ValueType,
+        context: &str,
+        span: Span,
+    ) -> Result<(), Diagnostic> {
+        match ty {
+            ValueType::Str => {}
+            ValueType::Int => self.emit_int_to_str(),
+            ValueType::Double => self.emit_double_to_str(span)?,
+            ValueType::Bool => self.emit_bool_to_str(),
+            // A collection renders the way `println` renders it, through the
+            // same builder.
+            ValueType::List(elem) => self.emit_list_to_str(elem, "[", "]", span)?,
+            ValueType::Set(elem) => self.emit_list_to_str(elem, "%(", ")", span)?,
+            ValueType::EmptyList => self.emit_interned_string("[]"),
+            ValueType::EmptySet => self.emit_interned_string("%()"),
+            ValueType::EmptyMap => self.emit_interned_string("%[]"),
+            ValueType::Enum(shape) => self.emit_enum_to_str(shape, span)?,
+            ValueType::LoweredEnum(index) => self.emit_lowered_enum_to_str(index, span)?,
+            other => {
+                return Err(unsupported(
+                    span,
+                    &format!("{context} {}", type_display_name(other)),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// A fixed string as a fresh heap object in x0.
+    fn emit_interned_string(&mut self, text: &str) {
+        let offset = self.asm.intern_string_object(text);
+        self.asm.load_rodata_address(Reg::X0, offset);
+        self.emit_heap_string_copy();
+    }
+
     /// `toString` of the Bool in x0 → interned "true"/"false" object.
     fn emit_bool_to_str(&mut self) {
         let false_label = self.asm.new_label();
@@ -7370,18 +7375,8 @@ exact decimal expansion is too long, or it is NaN/Infinity\n",
                 Ok(Some(ValueType::Bool))
             }
             ("toString", 1) => {
-                match self.expression(&arguments[0])? {
-                    ValueType::Int => self.emit_int_to_str(),
-                    ValueType::Double => self.emit_double_to_str(arguments[0].span())?,
-                    ValueType::Bool => self.emit_bool_to_str(),
-                    ValueType::Str => {}
-                    other => {
-                        return Err(unsupported(
-                            span,
-                            &format!("toString of {}", type_display_name(other)),
-                        ));
-                    }
-                }
+                let ty = self.expression(&arguments[0])?;
+                self.emit_value_to_str(ty, "toString of", span)?;
                 Ok(Some(ValueType::Str))
             }
             ("toUpperCase", 1) => {

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -4558,6 +4558,21 @@ struct NativeCodeGenerator {
     /// same one.
     gc_shadow_push: TextLabel,
     gc_shadow_pop: TextLabel,
+    /// Called once at startup, and emitted after every collection literal has
+    /// been compiled, so it can push a root for each cell those literals
+    /// spilled a heap pointer into.
+    literal_root_seed: TextLabel,
+    /// The cells themselves. A collection element that is a GC pointer lives
+    /// in one for the whole program, which is what makes it a root the
+    /// collector can trace and update -- a `.data` cell is invisible to it
+    /// otherwise, and the element would be stale the first time a collection
+    /// moved the object.
+    literal_root_cells: Vec<DataLabel>,
+    /// What each of those cells holds, for the ones whose value is a lowered
+    /// enum. Rendering the element needs the enum's shape, which the value
+    /// itself does not carry; the cell is the key because `CompiledLiteralValue`
+    /// already identifies the element by it.
+    literal_enum_shapes: HashMap<DataLabel, ConcreteEnumShape>,
     gc_bounds_error_text: DataLabel,
     /// Lowest rsp the program may reach before the prologue probe
     /// aborts: initial rsp minus RLIMIT_STACK plus a safety margin,
@@ -4800,6 +4815,7 @@ impl NativeCodeGenerator {
             asm.data_label_with_bytes(b"klassic gc: shadow stack overflow\n");
         let gc_shadow_underflow_text =
             asm.data_label_with_bytes(b"klassic gc: shadow stack underflow\n");
+        let literal_root_seed = asm.create_text_label();
         let gc_shadow_push = asm.create_text_label();
         let gc_shadow_pop = asm.create_text_label();
         let gc_bounds_error_text = asm.data_label_with_bytes(b"klassic gc: index out of bounds\n");
@@ -4969,6 +4985,9 @@ impl NativeCodeGenerator {
             gc_shadow_underflow_text,
             gc_shadow_push,
             gc_shadow_pop,
+            literal_root_seed,
+            literal_root_cells: Vec::new(),
+            literal_enum_shapes: HashMap::new(),
             gc_bounds_error_text,
             stack_floor,
             stack_overflow_abort,
@@ -5591,6 +5610,11 @@ impl NativeCodeGenerator {
         self.emit_initialize_stack_floor();
         self.emit_initialize_gc_heap();
         self.emit_initialize_color_registers();
+        // Roots the cells that collection literals spill heap pointers into.
+        // The routine is emitted after every literal has been compiled, so
+        // this call is a forward reference to a body whose size is not known
+        // until then.
+        self.asm.call_label(self.literal_root_seed);
         self.compile_top_level(expr)?;
         self.emit_queued_threads()?;
         if self.gc_log {
@@ -5598,6 +5622,9 @@ impl NativeCodeGenerator {
         }
         self.emit_exit_success();
         self.emit_functions()?;
+        // After `emit_functions`, because a literal inside a function body
+        // allocates its cell while that body compiles.
+        self.emit_literal_root_seed();
         self.emit_stack_overflow_abort_runtime();
         self.emit_print_i64_runtime();
         self.emit_gc_mark_visit_runtime();
@@ -12286,10 +12313,24 @@ impl NativeCodeGenerator {
         ) {
             let slot = self.asm.data_label_with_i64s(&[0]);
             self.emit_store_rax_to_data_slot(slot);
-            CompiledLiteralValue::Scalar { value, slot }
-        } else {
-            CompiledLiteralValue::Native(value)
+            return CompiledLiteralValue::Scalar { value, slot };
         }
+        // A GC pointer spills the same way, but its cell also has to be a
+        // root: the collector traces and *moves* what it points at, and a
+        // plain `.data` cell is invisible to both walks. `emit_literal_root_seed`
+        // pushes one shadow-stack entry per cell at startup.
+        if value == NativeValue::HeapPointer {
+            let slot = self.asm.data_label_with_i64s(&[0]);
+            self.emit_store_rax_to_data_slot(slot);
+            self.literal_root_cells.push(slot);
+            // The value itself does not say which enum it is; the marker the
+            // lowering leaves does, and it published the shape just now.
+            if let Some(shape) = self.pending_enum_shape.clone() {
+                self.literal_enum_shapes.insert(slot, shape);
+            }
+            return CompiledLiteralValue::Scalar { value, slot };
+        }
+        CompiledLiteralValue::Native(value)
     }
 
     fn emit_tail_list_literal_runtime_lines(
@@ -12334,10 +12375,14 @@ impl NativeCodeGenerator {
 
     fn compile_literal_value(&mut self, expr: &Expr) -> Result<CompiledLiteralValue, Diagnostic> {
         let value = self.compile_expr(expr)?;
-        if matches!(value, NativeValue::HeapPointer | NativeValue::HeapString) {
+        // A heap *string* still has no durable form here -- it is a pointer to
+        // a GC object whose text the renderers read through a different path
+        // than a rooted cell provides. A heap *pointer* (a lowered enum value)
+        // does: see `compiled_literal_value_from_native`.
+        if value == NativeValue::HeapString {
             return Err(unsupported(
                 expr.span(),
-                "native high-level collection literals containing GC heap pointers",
+                "native high-level collection literals containing GC heap strings",
             ));
         }
         Ok(self.compiled_literal_value_from_native(value))
@@ -13298,7 +13343,7 @@ impl NativeCodeGenerator {
                 element,
                 span,
                 overflow_message,
-            );
+            )?;
         }
         self.emit_append_text_to_runtime_buffer(output, output_offset, "]", span, overflow_message);
         self.emit_store_runtime_string_len_from_offset(output_len, output_offset);
@@ -13356,7 +13401,7 @@ impl NativeCodeGenerator {
                 key,
                 span,
                 overflow_message,
-            );
+            )?;
             self.emit_append_text_to_runtime_buffer(
                 output,
                 output_offset,
@@ -13370,7 +13415,7 @@ impl NativeCodeGenerator {
                 value,
                 span,
                 overflow_message,
-            );
+            )?;
         }
         self.emit_append_text_to_runtime_buffer(output, output_offset, "]", span, overflow_message);
         self.emit_store_runtime_string_len_from_offset(output_len, output_offset);
@@ -13439,7 +13484,7 @@ impl NativeCodeGenerator {
                 element,
                 span,
                 overflow_message,
-            );
+            )?;
             self.asm.mov_data_addr(Reg::R10, printed_count);
             self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
             self.asm.inc_reg(Reg::Rax);
@@ -13464,7 +13509,7 @@ impl NativeCodeGenerator {
         value: CompiledLiteralValue,
         span: Span,
         overflow_message: &str,
-    ) {
+    ) -> Result<(), Diagnostic> {
         match value {
             CompiledLiteralValue::Native(value) => {
                 self.emit_append_native_value_display_to_runtime_buffer(
@@ -13473,7 +13518,7 @@ impl NativeCodeGenerator {
                     value,
                     span,
                     overflow_message,
-                );
+                )?;
             }
             CompiledLiteralValue::Scalar { value, slot } => {
                 self.asm.mov_data_addr(Reg::R10, slot);
@@ -13502,6 +13547,36 @@ impl NativeCodeGenerator {
                             span,
                             overflow_message,
                         ),
+                    // A lowered enum value. Rax holds the pointer the cell was
+                    // rooted with; the shape recorded beside the cell says
+                    // which enum it is, which the pointer alone does not.
+                    NativeValue::HeapPointer => {
+                        let Some(shape) = self.literal_enum_shapes.get(&slot).cloned() else {
+                            return Err(unsupported(
+                                span,
+                                "rendering a collection element whose enum could not be named",
+                            ));
+                        };
+                        let rendered = self.emit_enum_display_runtime_string(&shape, span)?;
+                        // The display tree can end in a heap string (a
+                        // concatenation whose last piece is one), which the
+                        // buffer append does not read directly.
+                        let rendered =
+                            self.coerce_heap_string_to_runtime(rendered, span, overflow_message);
+                        let Some(text) = self.native_string_ref(rendered) else {
+                            return Err(unsupported(
+                                span,
+                                "rendering a collection element of this enum",
+                            ));
+                        };
+                        self.emit_append_native_string_to_runtime_buffer_offset_label(
+                            data,
+                            offset,
+                            text,
+                            span,
+                            overflow_message,
+                        );
+                    }
                     _ => self.emit_append_text_to_runtime_buffer(
                         data,
                         offset,
@@ -13512,6 +13587,7 @@ impl NativeCodeGenerator {
                 }
             }
         }
+        Ok(())
     }
 
     fn emit_runtime_list_display_runtime_string(
@@ -13519,7 +13595,7 @@ impl NativeCodeGenerator {
         label: RuntimeListLabel,
         span: Span,
         overflow_message: &str,
-    ) -> NativeValue {
+    ) -> Result<NativeValue, Diagnostic> {
         let output = self.runtime_string_scratch_value();
         let NativeValue::RuntimeString { data, len } = output else {
             unreachable!("runtime string scratch should be a runtime string")
@@ -13532,9 +13608,9 @@ impl NativeCodeGenerator {
             label,
             span,
             overflow_message,
-        );
+        )?;
         self.emit_store_runtime_string_len_from_offset(len, offset);
-        output
+        Ok(output)
     }
 
     fn emit_append_runtime_list_display_to_runtime_buffer(
@@ -13544,7 +13620,7 @@ impl NativeCodeGenerator {
         label: RuntimeListLabel,
         span: Span,
         overflow_message: &str,
-    ) {
+    ) -> Result<(), Diagnostic> {
         let kind = self.runtime_list_kind(label);
         let (open, close) = match kind {
             RuntimeListKind::List => ("[", "]"),
@@ -13554,7 +13630,7 @@ impl NativeCodeGenerator {
         let Some(elements) = self.runtime_list_elements(label) else {
             let empty = format!("{open}{close}");
             self.emit_append_text_to_runtime_buffer(data, offset, &empty, span, overflow_message);
-            return;
+            return Ok(());
         };
         self.emit_append_text_to_runtime_buffer(data, offset, open, span, overflow_message);
         match kind {
@@ -13579,7 +13655,7 @@ impl NativeCodeGenerator {
                             *key,
                             span,
                             overflow_message,
-                        );
+                        )?;
                     }
                     self.emit_append_text_to_runtime_buffer(
                         data,
@@ -13595,7 +13671,7 @@ impl NativeCodeGenerator {
                             *value,
                             span,
                             overflow_message,
-                        );
+                        )?;
                     }
                     self.end_runtime_list_dynamic_index_guard(skip);
                 }
@@ -13618,12 +13694,13 @@ impl NativeCodeGenerator {
                         element,
                         span,
                         overflow_message,
-                    );
+                    )?;
                     self.end_runtime_list_dynamic_index_guard(skip);
                 }
             }
         }
         self.emit_append_text_to_runtime_buffer(data, offset, close, span, overflow_message);
+        Ok(())
     }
 
     fn emit_static_string_list_join_runtime_delimiter(
@@ -21325,18 +21402,18 @@ impl NativeCodeGenerator {
             ));
         }
         if let NativeValue::RuntimeRecord { label } = value {
-            return Ok(self.emit_runtime_record_display_runtime_string(
+            return self.emit_runtime_record_display_runtime_string(
                 label,
                 span,
                 "toString result exceeds 65536 bytes",
-            ));
+            );
         }
         if let NativeValue::RuntimeList { label } = value {
-            return Ok(self.emit_runtime_list_display_runtime_string(
+            return self.emit_runtime_list_display_runtime_string(
                 label,
                 span,
                 "toString result exceeds 65536 bytes",
-            ));
+            );
         }
         if value == NativeValue::HeapString {
             return Ok(self.emit_heap_string_to_runtime_string_value(
@@ -26890,7 +26967,7 @@ impl NativeCodeGenerator {
         label: RuntimeRecordLabel,
         span: Span,
         overflow_message: &str,
-    ) -> NativeValue {
+    ) -> Result<NativeValue, Diagnostic> {
         let output = self.runtime_string_scratch_value();
         let NativeValue::RuntimeString { data, len } = output else {
             unreachable!("runtime string scratch should be a runtime string")
@@ -26903,9 +26980,9 @@ impl NativeCodeGenerator {
             label,
             span,
             overflow_message,
-        );
+        )?;
         self.emit_store_runtime_string_len_from_offset(len, offset);
-        output
+        Ok(output)
     }
 
     fn emit_append_runtime_record_display_to_runtime_buffer(
@@ -26915,10 +26992,10 @@ impl NativeCodeGenerator {
         label: RuntimeRecordLabel,
         span: Span,
         overflow_message: &str,
-    ) {
+    ) -> Result<(), Diagnostic> {
         let Some(record) = self.runtime_records.get(label.0).cloned() else {
             self.emit_append_text_to_runtime_buffer(data, offset, "#()", span, overflow_message);
-            return;
+            return Ok(());
         };
         self.emit_append_text_to_runtime_buffer(data, offset, "#", span, overflow_message);
         if !record.name.is_empty() {
@@ -26941,9 +27018,10 @@ impl NativeCodeGenerator {
                 field,
                 span,
                 overflow_message,
-            );
+            )?;
         }
         self.emit_append_text_to_runtime_buffer(data, offset, ")", span, overflow_message);
+        Ok(())
     }
 
     fn emit_append_runtime_record_field_display_to_runtime_buffer(
@@ -26953,7 +27031,7 @@ impl NativeCodeGenerator {
         field: &RuntimeRecordField,
         span: Span,
         overflow_message: &str,
-    ) {
+    ) -> Result<(), Diagnostic> {
         match field {
             RuntimeRecordField::Static(value) => {
                 self.emit_append_static_value_display_to_runtime_buffer(data, offset, value, span);
@@ -26965,7 +27043,7 @@ impl NativeCodeGenerator {
                     *value,
                     span,
                     overflow_message,
-                );
+                )?;
             }
             RuntimeRecordField::Scalar { value, slot } => {
                 self.asm.mov_data_addr(Reg::R10, *slot);
@@ -27004,6 +27082,7 @@ impl NativeCodeGenerator {
                 }
             }
         }
+        Ok(())
     }
 
     fn emit_append_native_value_display_to_runtime_buffer(
@@ -27013,7 +27092,7 @@ impl NativeCodeGenerator {
         value: NativeValue,
         span: Span,
         overflow_message: &str,
-    ) {
+    ) -> Result<(), Diagnostic> {
         if let Some(value) = self.native_string_ref(value) {
             self.emit_append_native_string_to_runtime_buffer_offset_label(
                 data,
@@ -27022,7 +27101,7 @@ impl NativeCodeGenerator {
                 span,
                 overflow_message,
             );
-            return;
+            return Ok(());
         }
         match value {
             NativeValue::Int => self.emit_append_i64_rax_to_runtime_buffer_offset_label(
@@ -27073,7 +27152,7 @@ impl NativeCodeGenerator {
                     label,
                     span,
                     overflow_message,
-                );
+                )?;
             }
             NativeValue::RuntimeList { label } => {
                 self.emit_append_runtime_list_display_to_runtime_buffer(
@@ -27082,7 +27161,7 @@ impl NativeCodeGenerator {
                     label,
                     span,
                     overflow_message,
-                );
+                )?;
             }
             NativeValue::RuntimeMapCallableDispatch(label) => {
                 self.emit_append_runtime_map_callable_dispatch_display_to_runtime_buffer(
@@ -27112,6 +27191,7 @@ impl NativeCodeGenerator {
                 }
             }
         }
+        Ok(())
     }
 
     fn emit_append_callable_value_display_to_runtime_buffer(
@@ -29693,7 +29773,7 @@ impl NativeCodeGenerator {
                 label,
                 span,
                 "string concatenation result exceeds 65536 bytes",
-            );
+            )?;
             return self
                 .native_string_ref(rendered)
                 .ok_or_else(|| unsupported(span, "native string concatenation"));
@@ -29703,7 +29783,7 @@ impl NativeCodeGenerator {
                 label,
                 span,
                 "string concatenation result exceeds 65536 bytes",
-            );
+            )?;
             return self
                 .native_string_ref(rendered)
                 .ok_or_else(|| unsupported(span, "native string concatenation"));
@@ -32875,7 +32955,7 @@ impl NativeCodeGenerator {
                         label,
                         span,
                         "string interpolation result exceeds 65536 bytes",
-                    );
+                    )?;
                 } else if let NativeValue::RuntimeList { label } = fragment {
                     self.emit_append_runtime_list_display_to_runtime_buffer(
                         data,
@@ -32883,7 +32963,7 @@ impl NativeCodeGenerator {
                         label,
                         span,
                         "string interpolation result exceeds 65536 bytes",
-                    );
+                    )?;
                 } else if let Some(static_value) = self.static_value_from_native(fragment) {
                     if self.static_value_has_conditional_builtin_display(&static_value) {
                         self.emit_append_static_value_display_to_runtime_buffer(
@@ -39916,6 +39996,25 @@ impl NativeCodeGenerator {
         self.asm.lea_reg_rbp_neg_disp32(Reg::Rax, rbp_offset);
         self.asm.call_label(self.gc_shadow_push);
         self.asm.pop_reg(Reg::Rax);
+    }
+
+    /// Push one permanent shadow-stack root per cell a collection literal
+    /// spilled a heap pointer into, then return.
+    ///
+    /// Pushed at startup and never popped, which is what the cells need: they
+    /// are allocated once at compile time and reused by every execution of the
+    /// literal, so a push beside the literal itself would run once per loop
+    /// iteration and overflow the shadow stack. A cell that has not been
+    /// written yet reads zero, and both root walks skip a null slot, so
+    /// seeding every cell up front is safe before any of them is live.
+    fn emit_literal_root_seed(&mut self) {
+        let entry = self.literal_root_seed;
+        self.asm.bind_text_label(entry);
+        for cell in self.literal_root_cells.clone() {
+            self.asm.mov_data_addr(Reg::Rax, cell);
+            self.asm.call_label(self.gc_shadow_push);
+        }
+        self.asm.ret();
     }
 
     /// Emit `gc_shadow_top -= count` so a closing scope drops its

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -2200,6 +2200,20 @@ side of a branch.
   way. A list of them therefore rendered from a register the next element had
   already overwritten, and printed `[null, null]` while compiling clean and
   exiting zero. This was unreachable until run-time Doubles existed.
+- x86-64 admits a user-declared enum value into a list, set or map literal
+  (issues #620, #648). A collection element there is a compile-time cell, and a
+  cell is invisible to the collector, which is why a GC pointer was refused
+  outright: the renderer would have read an address a collection had already
+  moved or freed. The cells are shadow-stack roots now -- `emit_literal_root_seed`
+  pushes one entry per cell once at startup, which is also why the push cannot
+  sit beside the literal (a literal in a loop would push per iteration). Both
+  root walks skip a null slot, so seeding a cell before it is written is safe.
+  Rendering needs the enum's identity, which the pointer does not carry, so the
+  shape published by the `__enum_shape_named` marker is recorded beside the
+  cell and read back by the element renderer.
+- aarch64's `toString` renders everything a `#{...}` hole does. The two had
+  drifted -- a hole took a collection or an enum, `toString` took only the
+  scalars -- and they share `emit_value_to_str` now.
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -29352,3 +29352,74 @@ fn build_target_aarch64_apple_darwin_renders_runtime_doubles() {
         "every renderer must agree with the evaluator"
     );
 }
+
+/// A collection element that is a GC pointer has to survive a *moving*
+/// collection, not just be traced through one: the cell it lives in is a
+/// shadow-stack root, so `relocate_fix_roots` rewrites it when the object it
+/// names is evacuated. The churn between the second element and the third is
+/// what forces that, and `--gc-log` confirms the evacuation actually happened
+/// rather than the test passing because nothing moved.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_enum_collection_element_survives_evacuation() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_enum_elem_{stamp}.kl"));
+    let bin_path = dir.join(format!("klassic_enum_elem_{stamp}.bin"));
+    let program = "enum Opt { case Sm(v: Int); case Nn }\n\
+         def churn(n: Int): Int = {\n\
+           mutable i = 0\n\
+           while (i < n) {\n\
+             val garbage = Sm(i)\n\
+             i = i + 1\n\
+           }\n\
+           n\n\
+         }\n\
+         println([Sm(1) Nn Sm(churn(300000))])\n";
+    fs::write(&source_path, program).expect("temp source file should write");
+    let build = Command::new(klassic_bin())
+        .args([
+            "--gc-log",
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build.status.success(),
+        "enum-element build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&bin_path)
+        .output()
+        .expect("generated executable should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&bin_path);
+    assert!(
+        run.status.success(),
+        "enum-element run exited with {:?}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "[Sm(1), Nn, Sm(300000)]\n",
+        "the rooted cells must still name the right objects after evacuation"
+    );
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    let relocated = stderr
+        .split(" relocated=")
+        .nth(1)
+        .and_then(|rest| rest.split_whitespace().next())
+        .and_then(|digits| digits.parse::<u64>().ok())
+        .unwrap_or_else(|| panic!("stats line should report relocated=<n>:\n{stderr}"));
+    assert!(
+        relocated > 0,
+        "the run has to actually evacuate for this to test anything: {stderr}"
+    );
+}

--- a/tests/cross-exec/47-enum-collection-elements.kl
+++ b/tests/cross-exec/47-enum-collection-elements.kl
@@ -1,0 +1,42 @@
+// Cross-target fixture: a user-declared enum value as a collection element.
+//
+// A list of results, a map from a key to a case, a set of tokens -- all of
+// them put an enum value inside a collection, and x86-64 refused every one:
+// a collection element there is a compile-time cell, and a cell is invisible
+// to the collector, so admitting a GC pointer into one would have handed the
+// renderer an address the collector had already moved or freed. The cells are
+// shadow-stack roots now, seeded once at startup, which is what makes the
+// pointer safe to keep and what lets a moving collection update it in place.
+//
+// Every value below is built inside the literal, so under `--gc-stress` a
+// collection runs between one element and the next -- the case that fails
+// first if a cell is not a root.
+
+enum Opt { case Sm(v: Int); case Nn }
+enum Token { case Word(s: String); case Comma }
+enum Colour { case Red; case Green; case Blue }
+
+// A list, including several elements so an element is built while earlier
+// ones are only reachable through their cells.
+println([Sm(1) Nn Sm(2) Sm(3) Nn])
+
+// The same values as a set and as a map's values.
+println(%(Sm(5) Nn Sm(6)))
+println(%["a": Sm(10) "b": Nn])
+
+// A payload that is itself a heap value, so the element's own field has to
+// survive the same collections.
+println([Word("one") Comma Word("two")])
+
+// A nullary-only enum, whose values carry nothing at all.
+println([Red Green Blue])
+println(%(Red Blue))
+
+// Through the two renderers that are not `println` of the collection.
+println("tokens=#{[Word("x") Comma]}")
+println(toString([Sm(7) Nn]))
+
+// Sizes are answered from the literal's own shape rather than the elements.
+println(size([Sm(1) Nn Sm(2)]))
+println(isEmpty([Nn]))
+println("done")

--- a/tests/llvm_backend.rs
+++ b/tests/llvm_backend.rs
@@ -7,6 +7,7 @@
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn klassic_bin() -> &'static str {
@@ -31,6 +32,27 @@ fn find_clang() -> Option<String> {
         .map(str::to_owned)
 }
 
+/// A path fragment no other build in this process or any other can pick.
+///
+/// The timestamp alone is not enough: the suite runs its tests in parallel
+/// threads, and two that start in the same nanosecond chose the same output
+/// path -- one still being linked while the other executed it, which surfaces
+/// as `ETXTBSY` ("Text file busy") rather than as anything about the program.
+/// The same collision hit the C backend's intermediate `.c` and was fixed the
+/// same way.
+fn unique_stamp() -> String {
+    static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_nanos())
+        .unwrap_or_default();
+    format!(
+        "{}-{nanos}-{}",
+        std::process::id(),
+        SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
 /// Evaluate `source`, then build+run it through `--backend llvm`, and
 /// assert the two stdout streams match. No-op when clang is absent.
 fn assert_llvm_matches_evaluator(source: &str) {
@@ -38,10 +60,7 @@ fn assert_llvm_matches_evaluator(source: &str) {
         eprintln!("skipping: no clang >= 15 found");
         return;
     };
-    let stamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time after epoch")
-        .as_nanos();
+    let stamp = unique_stamp();
     let dir = std::env::temp_dir();
     let src = dir.join(format!("klassic_llvm_{stamp}.kl"));
     let bin = dir.join(format!("klassic_llvm_{stamp}.bin"));
@@ -236,10 +255,7 @@ fn gc_log_reports_pause_statistics() {
         eprintln!("skipping: no clang >= 15 found");
         return;
     };
-    let stamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time after epoch")
-        .as_nanos();
+    let stamp = unique_stamp();
     let dir = std::env::temp_dir();
     let src = dir.join(format!("klassic_gclog_{stamp}.kl"));
     let bin = dir.join(format!("klassic_gclog_{stamp}.bin"));

--- a/tests/llvm_gc_link.rs
+++ b/tests/llvm_gc_link.rs
@@ -115,10 +115,19 @@ fn c_gc_links_and_runs_from_llvm_ir() {
     };
     let gc_src = concat!(env!("CARGO_MANIFEST_DIR"), "/runtime/gc/klassic_gc.c");
     let dir = std::env::temp_dir();
-    let stamp = std::time::SystemTime::now()
+    // Unique per build, not merely per nanosecond: parallel tests that start
+    // together otherwise share an output path and execute each other's
+    // half-linked file (`ETXTBSY`).
+    static SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or_default();
+    let stamp = format!(
+        "{}-{nanos}-{}",
+        std::process::id(),
+        SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    );
     let ll = dir.join(format!("klassic-gc-link-{stamp}.ll"));
     let exe = dir.join(format!("klassic-gc-link-{stamp}"));
     std::fs::write(&ll, IR).expect("write IR");


### PR DESCRIPTION
Closes #620. Closes #648.

A list of results, a map from a key to a case, a set of tokens -- every one
puts an enum value inside a collection, and x86-64 refused all of them:

```klassic
enum Opt { case Sm(v: Int); case Nn }
println([Sm(1) Nn])       // evaluator: [Sm(1), Nn]   x86-64: refused
println(%["k": Sm(1)])    // evaluator: %[k: Sm(1)]   x86-64: refused
println(%(Sm(1) Nn))      // evaluator: %(Sm(1), Nn)  x86-64: refused
```

aarch64 already built all three. The record equivalents built on x86-64 too,
which made this look like a missing case -- it was not. A record there is a
`.data` structure behind a label; an enum value after the shared lowering is a
real `gc_alloc` pointer. All three refusals came from one guard rejecting
`NativeValue::HeapPointer`, because admitting a GC pointer into a collection
element meant admitting it into a cell **the collector cannot see**.

## What makes it safe

**The cell becomes a root.** `emit_literal_root_seed` pushes one shadow-stack
entry per cell, once, at startup. Startup rather than beside the literal is
forced: the cell is allocated at compile time and reused by every execution, so
a push next to the literal would run once per loop iteration and overflow the
stack. Both root walks skip a null slot, so seeding a cell before anything
writes it is safe -- and being a root is also what lets `relocate_fix_roots`
rewrite the cell when the object it names is evacuated.

**The element carries its enum's identity.** A pointer does not say which enum
it is; this backend recovers that from the shape the `__enum_shape_named`
marker publishes, stored per *slot* -- and a collection element has no slot. It
is recorded beside the cell instead, keyed by the cell.

Either half alone is a wrong answer rather than a refusal: without the root the
pointer is stale after a collection, without the shape the element cannot be
printed. That is why they land together.

The display path returns a `Result` from here down, because rendering an element
can now fail for a reason the caller has to see rather than print `null` for.

## Also: aarch64's `toString`

It took the scalars; a `#{...}` hole took a collection, an enum and the empty
literals as well. Nothing justifies the difference -- they answer the same
question about the same value -- and it surfaced as `toString of List<an enum>`
refusing a program whose interpolated form built. They share
`emit_value_to_str` now.

## Verification

* `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` green.
* All 54 sample programs build for all three targets and match the evaluator.
* All 47 `tests/cross-exec/` fixtures build for all three targets; x86-64
  matches the evaluator plain and under `--gc-stress --gc-poison`; the aarch64
  builds match under the local emulator too.
* New fixture `47-enum-collection-elements.kl` builds every element inside the
  literal, so under `--gc-stress` a collection runs between one element and the
  next -- the case that fails first if a cell is not a root.
* New `cli_smoke` test pins the *moving* half: it churns 300k allocations
  between the second element and the third and asserts both the output and
  `relocated > 0`, so it cannot pass by nothing having moved. Measured
  `collections=53 ... relocated=438`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)