### PR TITLE
x86-64: pad an empty list branch of an if

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -17432,7 +17432,29 @@ impl NativeCodeGenerator {
         if elements.len() >= capacity {
             return Some(elements);
         }
-        if stride == 0 || elements.len() < stride {
+        if stride == 0 {
+            return None;
+        }
+        // An empty branch has no element to copy a template from, which is why
+        // `[] else [1 2]` was refused while `[1] else []` built. It does not
+        // need one: the branch's run-time length is zero, so nothing ever
+        // reads these slots -- they exist only so both branches agree on the
+        // output's capacity. The null-list branch above fabricates the same
+        // placeholders for the same reason.
+        if elements.is_empty() {
+            return Some(
+                (0..capacity)
+                    .map(|_| {
+                        let slot = self.asm.data_label_with_i64s(&[0]);
+                        CompiledLiteralValue::Scalar {
+                            value: NativeValue::Int,
+                            slot,
+                        }
+                    })
+                    .collect(),
+            );
+        }
+        if elements.len() < stride {
             return None;
         }
         let templates: Vec<CompiledLiteralValue> = elements[..stride].to_vec();

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -2214,6 +2214,17 @@ side of a branch.
 - aarch64's `toString` renders everything a `#{...}` hole does. The two had
   drifted -- a hole took a collection or an enum, `toString` took only the
   scalars -- and they share `emit_value_to_str` now.
+- x86-64 pads an *empty* list branch of an `if` up to the other branch's
+  length. The padding copies a template from the branch's own elements, and an
+  empty branch has none, so `[] else [1 2]` was refused while `[1] else []`
+  built -- a difference in which side the empty literal sat on rather than in
+  what the program meant. The placeholders are never read (the branch's
+  run-time length is zero); they exist so both branches agree on the output's
+  capacity, which is what the null-list branch beside it already fabricated for
+  the same reason. Scalar Int, map and set branches build now; a branch whose
+  other side holds strings, bools or nested lists still refuses, because the
+  placeholder is typed `Int` and the copy into the shared output checks that
+  the two agree (issue #641, partially).
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -29423,3 +29423,57 @@ fn native_enum_collection_element_survives_evacuation() {
         "the run has to actually evacuate for this to test anything: {stderr}"
     );
 }
+
+/// An `if` whose branches are lists of different lengths builds when the
+/// *empty* one comes first, not only when it comes second. The shorter branch
+/// is padded up to the shared capacity by copying a template from its own
+/// elements, and an empty branch has none -- so `[] else [1 2]` was refused
+/// while `[1] else []` built, purely from which side the empty literal was on.
+/// Both directions are asserted because the padding must not change which
+/// branch's values come out.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_if_branches_pad_an_empty_list_on_either_side() {
+    for (condition, expected) in [(0, "[]\n"), (1, "[1, 2]\n")] {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir();
+        let source_path = dir.join(format!("klassic_empty_branch_{condition}_{stamp}.kl"));
+        let bin_path = dir.join(format!("klassic_empty_branch_{condition}_{stamp}.bin"));
+        // `size(args())` is zero, but not knowably zero, so neither branch is
+        // folded away and the join has to be compiled.
+        let program = format!(
+            "import std.process as R\n\
+             val k = size(R.args())\n\
+             println(if (k == {condition}) [] else [1 2])\n"
+        );
+        fs::write(&source_path, program).expect("temp source file should write");
+        let build = Command::new(klassic_bin())
+            .args([
+                "build",
+                source_path.to_str().expect("path should be utf-8"),
+                "-o",
+                bin_path.to_str().expect("path should be utf-8"),
+            ])
+            .output()
+            .expect("binary should run");
+        assert!(
+            build.status.success(),
+            "empty-branch build should succeed\nstderr:\n{}",
+            String::from_utf8_lossy(&build.stderr)
+        );
+        let run = Command::new(&bin_path)
+            .output()
+            .expect("generated executable should run");
+        let _ = fs::remove_file(&source_path);
+        let _ = fs::remove_file(&bin_path);
+        assert!(run.status.success(), "empty-branch run should succeed");
+        assert_eq!(
+            String::from_utf8_lossy(&run.stdout),
+            expected,
+            "the padding must not change which branch's values come out"
+        );
+    }
+}


### PR DESCRIPTION
Partial fix for #641.

```klassic
import std.process as R
val k = size(R.args())      // 0, but not knowably 0

println(if (k == 0) [1] else [])    // built
println(if (k == 0) [] else [1 2])  // refused
```

Same program, mirrored, and only one of them compiled. The shorter branch is
padded up to the shared capacity by copying a template out of **its own**
elements, and an empty branch has none, so the pad gave up and the join was
refused as "incompatible list lengths".

It does not need a template. The branch's run-time length is zero, so nothing
ever reads those slots -- they exist only so both branches agree on the
output's capacity. The null-list branch a few lines above already fabricates
exactly these placeholders for exactly this reason.

## What this does and does not fix

Scalar Int, map and set branches build now, in both directions (verified that
the padding does not change which branch's values come out -- the test asserts
both `[]` and `[1, 2]` from the same source with the condition flipped).

A branch whose other side holds strings, bools or nested lists still refuses.
The placeholder is typed `Int`, and copying the other branch into the shared
output checks that source and output agree, so a mismatch is a **build-time
refusal, not a wrong answer**. Closing that needs the placeholder to take the
other branch's element kind, which the caller cannot know without compiling
that branch.

The `match` form in the issue (`std.option`'s `toList`) is a different join and
is unchanged, so #641 stays open.

## Verification

* `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` green.
* All 54 sample programs still match the evaluator on x86-64.
* All 47 `tests/cross-exec/` fixtures build for all three targets and match the
  evaluator, plain and under `--gc-stress --gc-poison`.
* Probed Int / nested-list / map / set / bool branches with the condition
  flipped both ways: every case is either correct or a build-time refusal, none
  is a wrong answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)