### PR TITLE
x86-64: bind a list of enum values, and read one back out

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -12394,6 +12394,16 @@ impl NativeCodeGenerator {
             CompiledLiteralValue::Scalar { value, slot } => {
                 self.asm.mov_data_addr(Reg::R10, slot);
                 self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
+                // Taking an element out of a collection has to republish what
+                // the element is, the way constructing one does: a heap
+                // pointer alone does not say which enum it names, so without
+                // this `head(xs)` produced a value nothing downstream could
+                // print or match on.
+                if value == NativeValue::HeapPointer
+                    && let Some(shape) = self.literal_enum_shapes.get(&slot).cloned()
+                {
+                    self.pending_enum_shape = Some(shape);
+                }
                 value
             }
         }
@@ -30311,6 +30321,39 @@ impl NativeCodeGenerator {
             || self.expr_may_yield_runtime_list(expr)
             || self.expr_may_yield_runtime_record(expr)
             || self.expr_may_yield_runtime_scalar(expr)
+            || self.expr_may_yield_heap_pointer(expr)
+    }
+
+    /// Whether the expression builds a GC object -- in practice a lowered enum
+    /// value, which reaches codegen as the marker call the lowering wraps its
+    /// `__gc_record` block in.
+    ///
+    /// Without this a list of enum values took the *static* literal path and
+    /// was refused, while the same list written inline as a `println` argument
+    /// took the runtime path and built: `val xs = [Sm(1) Nn]` failed where
+    /// `println([Sm(1) Nn])` worked.
+    fn expr_may_yield_heap_pointer(&self, expr: &Expr) -> bool {
+        if matches!(
+            self.native_value_hint_for_expr(expr),
+            Some(NativeValue::HeapPointer)
+        ) {
+            return true;
+        }
+        match expr {
+            Expr::Call { callee, .. } => matches!(
+                callee.as_ref(),
+                Expr::Identifier { name, .. }
+                    if name == "__enum_shape_named" || name == "__gc_record"
+            ),
+            Expr::Block { expressions, .. } => expressions
+                .last()
+                .is_some_and(|expr| self.expr_may_yield_heap_pointer(expr)),
+            Expr::Identifier { name, .. } => matches!(
+                self.lookup_var(name).map(|slot| slot.value),
+                Some(NativeValue::HeapPointer)
+            ),
+            _ => false,
+        }
     }
 
     fn expr_may_yield_runtime_record(&self, expr: &Expr) -> bool {
@@ -32554,15 +32597,53 @@ impl NativeCodeGenerator {
         }
 
         let value = self.compile_expr(expr)?;
-        if value == NativeValue::HeapPointer
-            && let Some(shape) = self.pending_enum_shape.take()
-        {
+        if value == NativeValue::HeapPointer {
+            // A heap pointer prints as the value it names, never as the
+            // address. Without a shape there is no way to name it, and the
+            // fragment printer below would take it for an integer and print
+            // the address -- a compiled, zero-exit, wrong answer. Refuse
+            // instead, so the gap shows up as a diagnostic.
+            let Some(shape) = self.pending_enum_shape.take() else {
+                return Err(unsupported(
+                    span,
+                    "printing a heap value whose enum could not be named",
+                ));
+            };
             let formatted = self.emit_enum_display_runtime_string(&shape, span)?;
             self.emit_print_value_fragment(fd, formatted, span);
             return Ok(());
         }
+        // A list holding heap pointers cannot take the element-by-element
+        // printer below: that one writes each element straight to the fd and
+        // reads a heap pointer as an integer, so a list of enum values printed
+        // as a list of addresses. The buffer renderer knows to name the enum
+        // from the shape recorded beside the element's cell, so render the
+        // whole list through it and print the text it produced.
+        if let NativeValue::RuntimeList { label } = value
+            && self.runtime_list_holds_heap_pointer(label)
+        {
+            let rendered = self.emit_runtime_list_display_runtime_string(
+                label,
+                span,
+                "collection print result exceeds 65536 bytes",
+            )?;
+            self.emit_print_value_fragment(fd, rendered, span);
+            return Ok(());
+        }
         self.emit_print_value_fragment(fd, value, span);
         Ok(())
+    }
+
+    /// Whether any element of the runtime list is a GC pointer, which decides
+    /// whether printing it can stream element by element.
+    fn runtime_list_holds_heap_pointer(&self, label: RuntimeListLabel) -> bool {
+        self.runtime_list_elements(label)
+            .into_iter()
+            .flatten()
+            .any(|element| match element {
+                CompiledLiteralValue::Scalar { value, .. }
+                | CompiledLiteralValue::Native(value) => value == NativeValue::HeapPointer,
+            })
     }
 
     fn file_input_all_print_call_name(&self, expr: &Expr) -> Option<String> {

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -2225,6 +2225,18 @@ side of a branch.
   other side holds strings, bools or nested lists still refuses, because the
   placeholder is typed `Int` and the copy into the shared output checks that
   the two agree (issue #641, partially).
+- x86-64 binds a list of enum values to a `val`, and reads an element back out
+  of one (issue #663). Three things were in the way, and each would have been a
+  wrong answer on its own. The literal took the *static* path, because
+  `expr_may_yield_runtime_list_element` did not know an expression can build a
+  GC object. Printing a bound list took the element-by-element fd printer,
+  which reads a heap pointer as an integer, so the list printed as addresses --
+  a bound list is rendered through the buffer path instead, which knows to name
+  the enum. And taking an element out did not republish which enum it is, so
+  `head(xs)` produced a value nothing downstream could print or match on;
+  `emit_compiled_literal_value` republishes the shape recorded beside the cell.
+  Printing a heap pointer with no shape is now a refusal rather than an
+  address.
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/tests/cross-exec/47-enum-collection-elements.kl
+++ b/tests/cross-exec/47-enum-collection-elements.kl
@@ -39,4 +39,21 @@ println(toString([Sm(7) Nn]))
 // Sizes are answered from the literal's own shape rather than the elements.
 println(size([Sm(1) Nn Sm(2)]))
 println(isEmpty([Nn]))
+
+// The same list bound to a `val` rather than written inline. These took a
+// different path on x86-64 -- the static-literal one, which refused it -- and
+// then a different renderer, which printed the elements' addresses. Reading an
+// element back out has to republish which enum it is, or nothing downstream
+// can print or match on it.
+val bound = [Sm(1) Nn Sm(2)]
+println(bound)
+println(size(bound))
+println(head(bound))
+println("bound=#{bound}")
+println(toString(bound))
+println(head(bound) match { case Sm(v) => v; case Nn => 0 })
+
+val words = [Word("a") Comma Word("b")]
+println(words)
+println(head(words))
 println("done")


### PR DESCRIPTION
Closes #663.

```klassic
enum Opt { case Sm(v: Int); case Nn }
println([Sm(1) Nn])              // built (since #662)
val xs = [Sm(1) Nn]; println(xs) // refused
```

Same list, and only one of them compiled. **Three** separate things were in the
way, and each would have been a wrong answer rather than a refusal if fixed
alone — which is how the issue got filed in the first place, after the obvious
one-line fix printed raw addresses.

**The literal took the static path.** `expr_may_yield_runtime_list_element`
knows about runtime strings, line lists, lists, records and scalars, but not
about an expression that builds a GC object, so an enum construction looked
static and was refused there.

**Printing a bound list read the addresses.** A bound list reaches the
element-by-element fd printer, which takes a heap pointer for an integer. So
opening the path above on its own gives:

    eval    [Sm(1), Nn]
    x86-64  [126271604391952, 126271604392048]

A list holding heap pointers is rendered through the *buffer* path instead —
the one #662 taught to name the enum from the shape beside the element's cell.

**Taking an element out lost what it was.** `head(xs)` handed back a bare
pointer with no shape published, so nothing downstream could print or match on
it, and printing it hit the same address-as-integer path.
`emit_compiled_literal_value` republishes the shape now, which is exactly what
constructing a value already does.

Printing a heap pointer with no shape is a refusal now rather than an address.
Nothing in user source reaches it today (`__gc_record` is not callable and the
other route hits a different refusal), which is why it has no test of its own:
it is the guard that would have caught the two wrong answers above.

## Verification

* `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` green (505
  cli_smoke tests).
* All 54 sample programs match the evaluator on x86-64.
* All 47 `tests/cross-exec/` fixtures build for all three targets and match the
  evaluator, plain and under `--gc-stress --gc-poison`.
* Fixture 47 extended with the bound forms: printing, `size`, `head`,
  interpolation, `toString`, and a `match` on the element read back out.
* Moving-collector check: 200k allocations between the second element and the
  third, then print the list *and* `head` it — `collections=35 ... relocated=290`
  with output matching the evaluator, so the cells survive evacuation and the
  element read back out is still the right object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)