### PR TITLE
Stop compiling programs the evaluator rejects

### DIFF
--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -3807,6 +3807,20 @@ impl Emitter {
                 {
                     return self.expression(value);
                 }
+                // Three map builtins have no free-standing form in the
+                // language: the evaluator rejects `get(m, k)` as an undefined
+                // variable, and only `Map#get(m, k)` and `m.get(k)` exist.
+                // The method form reaches `builtin_call` with the same bare
+                // name, so the two are told apart here -- by the callee being
+                // a plain identifier -- rather than inside the dispatch.
+                if matches!(name.as_str(), "get" | "containsKey" | "containsValue")
+                    && !self.function_exists(name, arguments.len())
+                {
+                    return Err(Diagnostic::compile(
+                        *span,
+                        format!("undefined variable `{name}`"),
+                    ));
+                }
                 // Builtins first, mirroring the C backend's dispatch.
                 if let Some(ty) = self.builtin_call(name, arguments, *span)? {
                     return Ok(ty);

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -8003,11 +8003,36 @@ impl NativeCodeGenerator {
         Ok(NativeValue::Bool)
     }
 
+    /// A call as the program wrote it.
     fn compile_call(
         &mut self,
         callee: &Expr,
         arguments: &[Expr],
         span: Span,
+    ) -> Result<NativeValue, Diagnostic> {
+        self.compile_call_with_origin(callee, arguments, span, CallOrigin::Source)
+    }
+
+    /// A call this backend built while lowering something else -- a method
+    /// call rewritten to `helper(receiver, args...)`, a stream callback, the
+    /// `getOrElse` conditional. These are allowed to name builtins the
+    /// language has no free-standing spelling for, which is exactly what
+    /// `CallOrigin` separates.
+    fn compile_lowered_call(
+        &mut self,
+        callee: &Expr,
+        arguments: &[Expr],
+        span: Span,
+    ) -> Result<NativeValue, Diagnostic> {
+        self.compile_call_with_origin(callee, arguments, span, CallOrigin::Lowering)
+    }
+
+    fn compile_call_with_origin(
+        &mut self,
+        callee: &Expr,
+        arguments: &[Expr],
+        span: Span,
+        origin: CallOrigin,
     ) -> Result<NativeValue, Diagnostic> {
         if let Expr::If {
             condition,
@@ -8318,6 +8343,24 @@ impl NativeCodeGenerator {
             )
         {
             return self.compile_native_callable_value_call(slot.value, arguments, span);
+        }
+        // Three map builtins have no free-standing form in the language: the
+        // evaluator rejects `get(m, k)` as an undefined variable, and only
+        // `Map#get(m, k)` and `m.get(k)` exist. Codegen reached them by the
+        // bare name anyway, so the backend compiled programs the language
+        // refuses -- the one place measured where it is *more* permissive than
+        // its own oracle. The lowered method call spells them the same way, so
+        // where the call came from is what tells the two apart.
+        if origin == CallOrigin::Source
+            && matches!(
+                callee_name.as_str(),
+                "get" | "containsKey" | "containsValue"
+            )
+        {
+            return Err(Diagnostic::compile(
+                span,
+                format!("undefined variable `{callee_name}`"),
+            ));
         }
         let name = self.builtin_name_for_identifier(callee_name);
         match name.as_str() {
@@ -15678,7 +15721,7 @@ impl NativeCodeGenerator {
                 .cloned()
                 .ok_or_else(|| unsupported(span, "native static builtin method"))?;
             let callee = Expr::Identifier { name, span };
-            return self.compile_call(&callee, arguments, span);
+            return self.compile_lowered_call(&callee, arguments, span);
         }
         // Receiver-type-aware dispatch for an extension method whose name
         // is ambiguous (declared on more than one type, so the pre-codegen
@@ -15822,7 +15865,7 @@ impl NativeCodeGenerator {
             name: helper_name.to_string(),
             span,
         };
-        self.compile_call(&callee, &lowered, span)
+        self.compile_lowered_call(&callee, &lowered, span)
     }
 
     /// Lower `m.getOrElse(k, d)` to a temp-bound conditional that reuses the
@@ -16349,7 +16392,7 @@ impl NativeCodeGenerator {
         let mut lowered = Vec::with_capacity(arguments.len() + 1);
         lowered.push(target.clone());
         lowered.extend(arguments.iter().cloned());
-        Ok(Some(self.compile_call(&callee, &lowered, span)?))
+        Ok(Some(self.compile_lowered_call(&callee, &lowered, span)?))
     }
 
     fn compile_static_lambda_method_call(
@@ -42375,6 +42418,15 @@ fn native_feature_name(expr: &Expr) -> &'static str {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 struct TextLabel(usize);
+
+/// Whether a call is what the program wrote or one this backend synthesized
+/// while lowering something else. Only the first is held to the language's
+/// spelling: a lowering may name a builtin that has no free-standing form.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CallOrigin {
+    Source,
+    Lowering,
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 struct DataLabel(usize);

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -2237,6 +2237,17 @@ side of a branch.
   `emit_compiled_literal_value` republishes the shape recorded beside the cell.
   Printing a heap pointer with no shape is now a refusal rather than an
   address.
+- A call carries where it came from (`CallOrigin`). The language has no
+  free-standing `get` / `containsKey` / `containsValue` -- only `Map#get(m, k)`
+  and `m.get(k)` -- but codegen reached them by the bare name, so
+  `klassic build` compiled programs `klassic` refuses to run: the one place
+  measured where a backend was *more* permissive than the evaluator. Refusing
+  the bare name is not enough on its own, because the dot form is lowered to a
+  call on that same name; the two are distinguished by whether the call is what
+  the program wrote or one this backend synthesized while lowering something
+  else (issue #667). aarch64 had the same divergence and tells the two apart
+  the same way, at its own call site -- the two backends resolve the name
+  independently, so fixing one says nothing about the other.
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -29477,3 +29477,94 @@ fn native_if_branches_pad_an_empty_list_on_either_side() {
         );
     }
 }
+
+/// The language has no free-standing `get` / `containsKey` / `containsValue`
+/// -- only `Map#get(m, k)` and `m.get(k)`. The backend reached them by the
+/// bare name anyway, so `klassic build` compiled a program `klassic` refuses
+/// to run. The dot form is lowered to a call on that same bare name, so the
+/// two are told apart by where the call came from, not by how it is spelled;
+/// this pins both halves.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_rejects_the_bare_map_builtins_the_evaluator_rejects() {
+    // Both hand-emitted backends had the divergence and both are asserted:
+    // they resolve the name separately, so fixing one says nothing about the
+    // other. The aarch64 build is only built here, never run, which is enough
+    // -- the whole point is which programs it accepts.
+    for target in [None, Some("aarch64-apple-darwin")] {
+        native_bare_map_builtins_match_the_evaluator(target);
+    }
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn native_bare_map_builtins_match_the_evaluator(target: Option<&str>) {
+    let cases = [
+        ("get(m, \"a\")", None),
+        ("containsKey(m, \"a\")", None),
+        ("containsValue(m, 1)", None),
+        ("m.get(\"a\")", Some("1\n")),
+        ("m.containsKey(\"a\")", Some("true\n")),
+        ("m.containsValue(1)", Some("true\n")),
+        ("Map#get(m, \"a\")", Some("1\n")),
+        ("m.getOrElse(\"z\", -1)", Some("-1\n")),
+    ];
+    for (index, (call, expected)) in cases.iter().enumerate() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir();
+        let source_path = dir.join(format!("klassic_bare_map_{index}_{stamp}.kl"));
+        let bin_path = dir.join(format!("klassic_bare_map_{index}_{stamp}.bin"));
+        let program = format!("val m = %[\"a\": 1]\nprintln({call})\n");
+        fs::write(&source_path, program).expect("temp source file should write");
+
+        let eval = Command::new(klassic_bin())
+            .arg(&source_path)
+            .output()
+            .expect("evaluator should run");
+        let mut command = Command::new(klassic_bin());
+        if let Some(target) = target {
+            command.args(["--target", target]);
+        }
+        let build = command
+            .args([
+                "build",
+                source_path.to_str().expect("path should be utf-8"),
+                "-o",
+                bin_path.to_str().expect("path should be utf-8"),
+            ])
+            .output()
+            .expect("binary should run");
+        assert_eq!(
+            eval.status.success(),
+            build.status.success(),
+            "`{call}`: the build must accept exactly what the evaluator accepts\n\
+             evaluator:\n{}\nbuild:\n{}",
+            String::from_utf8_lossy(&eval.stderr),
+            String::from_utf8_lossy(&build.stderr)
+        );
+        match expected {
+            None => {
+                let stderr = String::from_utf8_lossy(&build.stderr);
+                assert!(
+                    stderr.contains("undefined variable"),
+                    "`{call}`: the build should say what the evaluator says:\n{stderr}"
+                );
+            }
+            Some(_) if target.is_some() => {}
+            Some(expected) => {
+                let run = Command::new(&bin_path)
+                    .output()
+                    .expect("generated executable should run");
+                assert_eq!(
+                    String::from_utf8_lossy(&run.stdout),
+                    *expected,
+                    "`{call}` should print what the evaluator prints"
+                );
+            }
+        }
+        let _ = fs::remove_file(&source_path);
+        let _ = fs::remove_file(&bin_path);
+    }
+}


### PR DESCRIPTION
Closes #667.

```
$ klassic prog.kl
prog.kl:2:9: undefined variable `containsKey`     (exit 1)

$ klassic build prog.kl -o prog && ./prog
true                                              (exit 0)
```

The language has no free-standing `get` / `containsKey` / `containsValue` --
only `Map#get(m, k)` and `m.get(k)` -- but codegen reached them by the bare
name, so a program the evaluator refuses to run compiled into a working
executable. The evaluator is this project's oracle; this was the one place
measured where a backend was *more* permissive than it.

Found by sweeping every bare builtin name through the evaluator and the build
over map / list / string / set receivers with 1–2 arguments. Exactly three
names diverge; every other name already agrees. **Both** hand-emitted backends
had it, and they resolve the name independently — the aarch64 half was only
found because the sweep was re-run per target after the x86-64 fix.

## Why refusing the name is not enough

The dot form is lowered to a call on that same bare name, so `m.get(k)` and
`get(m, k)` arrive at codegen as the same thing. Dropping the bare
alternatives from the dispatch breaks `m.get(k)`; renaming the desugaring to
the qualified name instead breaks `m.getOrElse(k, d)`, which is itself lowered
into `containsKey`/`get` calls that take a different path under the qualified
name (both measured, both recorded on the issue).

What separates them is **where the call came from**, which is now carried
explicitly: a `CallOrigin` on x86-64, and the callee's shape at the aarch64
call site. A lowering may still name a builtin the language has no
free-standing spelling for; only what the program wrote is held to the
language's own spelling.

## Verification

* `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` green.
* The sweep re-run across **all three** targets: 0 divergences.
* All 54 sample programs still match the evaluator on x86-64.
* All 47 `tests/cross-exec/` fixtures build for all three targets and match the
  evaluator, plain and under `--gc-stress --gc-poison`.
* New `cli_smoke` test pins both halves on both backends: the three bare forms
  must be refused exactly where the evaluator refuses them, and `m.get(k)`,
  `Map#get(m, k)` and `m.getOrElse(k, d)` must keep working. Confirmed it goes
  red by reverting the aarch64 half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)