### PR TITLE
x86-64: a match whose arms build lists of different lengths

### DIFF
--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -30090,9 +30090,23 @@ impl NativeCodeGenerator {
                 else_branch: Some(else_branch),
                 ..
             } => {
-                let then = self.expr_static_list_length_hint(then_branch)?;
-                let other = self.expr_static_list_length_hint(else_branch)?;
-                Some(then.max(other))
+                // A branch that never returns contributes no length, so it
+                // must not turn the answer into "unknown". The enum lowering
+                // ends every `match` in `__match_fail()`, so without this the
+                // innermost `if` of a lowered match had no hint, the join
+                // above it took a static length from one side, and copying the
+                // other side in was refused for disagreeing with it -- which
+                // is why a `match` with an empty arm did not build while the
+                // same shape written as an `if` did.
+                let then = (!Self::expr_always_diverges(then_branch))
+                    .then(|| self.expr_static_list_length_hint(then_branch));
+                let other = (!Self::expr_always_diverges(else_branch))
+                    .then(|| self.expr_static_list_length_hint(else_branch));
+                match (then, other) {
+                    (Some(then), Some(other)) => Some(then?.max(other?)),
+                    (Some(only), None) | (None, Some(only)) => only,
+                    (None, None) => None,
+                }
             }
             Expr::Call {
                 callee, arguments, ..

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -2248,6 +2248,15 @@ side of a branch.
   else (issue #667). aarch64 had the same divergence and tells the two apart
   the same way, at its own call site -- the two backends resolve the name
   independently, so fixing one says nothing about the other.
+- A branch that never returns contributes no list length rather than an
+  unknown one. The enum lowering ends every `match` in `__match_fail()`, so the
+  innermost `if` of a lowered match had no length hint at all; the join above
+  it then fixed a static length from one side and refused the other for
+  disagreeing with it, which is why `std.option`'s `toList` did not build while
+  the same shape written as an `if` did. Skipping the diverging branch gives
+  the join the *maximum over the arms that can return*, which is also the
+  capacity -- forcing a dynamic length without that (tried, reverted) made the
+  widest arm print truncated (issue #641).
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -29568,3 +29568,58 @@ fn native_bare_map_builtins_match_the_evaluator(target: Option<&str>) {
         let _ = fs::remove_file(&bin_path);
     }
 }
+
+/// A `match` whose arms build lists of different lengths must take the
+/// *maximum* over the arms that can return, not merely agree to disagree.
+/// An earlier attempt forced a dynamic length without fixing the capacity,
+/// and the widest arm then printed a truncated list -- compiled, exit zero,
+/// wrong. This asserts every arm, so that failure mode cannot come back
+/// disguised as a build that merely succeeds.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_match_arms_of_different_list_lengths_keep_every_arm() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_match_widths_{stamp}.kl"));
+    let bin_path = dir.join(format!("klassic_match_widths_{stamp}.bin"));
+    let program = "enum Step { case One; case Two; case Three; case Four }\n\
+         def widths(s: Step): List<Int> = s match {\n\
+           case One => [1]\n\
+           case Two => []\n\
+           case Three => [1 2]\n\
+           case Four => [1 2 3]\n\
+         }\n\
+         println(widths(One))\n\
+         println(widths(Two))\n\
+         println(widths(Three))\n\
+         println(widths(Four))\n";
+    fs::write(&source_path, program).expect("temp source file should write");
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build.status.success(),
+        "match-arm build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&bin_path)
+        .output()
+        .expect("generated executable should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&bin_path);
+    assert!(run.status.success(), "match-arm run should succeed");
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "[1]\n[]\n[1, 2]\n[1, 2, 3]\n",
+        "every arm must come out whole, the widest one included"
+    );
+}

--- a/tests/cross-exec/48-match-arms-of-different-lengths.kl
+++ b/tests/cross-exec/48-match-arms-of-different-lengths.kl
@@ -1,0 +1,55 @@
+// Cross-target fixture: a `match` whose arms build lists of different lengths.
+//
+// `std.option`'s `toList` is the shape everyone writes -- one arm yields a
+// one-element list, the other an empty one -- and x86-64 refused it while the
+// same shape written as an `if` built. A `match` is lowered to nested `if`s
+// ending in `__match_fail()`, and a branch that never returns has no list
+// length; that read as "length unknown" rather than "no constraint", so the
+// join above it fixed a static length from one side and then refused the
+// other for disagreeing with it.
+//
+// Taking the maximum over the arms that *can* return is what makes this both
+// build and be right: an earlier attempt forced a dynamic length without
+// fixing the capacity, and the three-arm case below silently printed `[0]`
+// for the longest arm. It is here to keep that from coming back.
+
+import std.option
+
+enum Colour { case Red; case Green; case Blue }
+
+def pick(c: Colour): List<Int> = c match {
+  case Red => [1]
+  case Green => []
+  case Blue => [1 2]
+}
+
+println(pick(Red))
+println(pick(Green))
+println(pick(Blue))
+
+// Four arms, so the widest one is not the last decision the join makes.
+enum Step { case One; case Two; case Three; case Four }
+
+def widths(s: Step): List<Int> = s match {
+  case One => [1]
+  case Two => []
+  case Three => [1 2]
+  case Four => [1 2 3]
+}
+
+println(widths(One))
+println(widths(Two))
+println(widths(Three))
+println(widths(Four))
+
+// Only Int arms here. Three arms of Strings -- or of nested lists -- still
+// refuse on x86-64, because the placeholder an empty arm is padded with is
+// typed `Int` and the copy into the shared output checks that source and
+// output agree. That refusal predates this change (it read as "incompatible
+// list lengths" before and as "incompatible scalar elements" now) and is
+// tracked on the issue.
+
+// The stdlib helper this issue was filed about, both ways round.
+println(toList(Some(1)))
+println(toList(None))
+println("done")


### PR DESCRIPTION
Closes #641.

```klassic
import std.option
println(toList(Some(1)))   // evaluator: [1]   x86-64: refused
```

The shape everyone writes — one arm yields a one-element list, the other an
empty one — and it did not build, while the same shape written as an `if` did.

A `match` is lowered to nested `if`s ending in `__match_fail()`, and a branch
that never returns has no list length. That read as **"length unknown"** rather
than **"no constraint"**, so the innermost `if` had no hint at all; the join
above it fixed a static length from one side and then refused the other for
disagreeing with it.

Skipping the diverging branch gives the join the **maximum over the arms that
can actually return** — which is also the capacity, and that is the part that
matters. Forcing a dynamic length without fixing the capacity (tried while
investigating this, reverted, written up on the issue) built the program and
then printed the widest arm truncated:

```klassic
enum C { case A; case B; case D }
def f(c: C): List<Int> = c match { case A => [1]; case B => []; case D => [1 2] }
println(f(D))     // eval: [1, 2]    that attempt: [0]
```

The new `cli_smoke` test asserts **every** arm of a four-arm match, so that
failure mode cannot come back disguised as a build that merely succeeds.

## What still refuses

Three arms of Strings, or of nested lists. The placeholder an empty arm is
padded with is typed `Int` (from #664), and the copy into the shared output
checks that source and output agree. That refusal predates this change — it
read as "incompatible list lengths" before and reads as "incompatible scalar
elements" now — and is verified against `main` in this PR's testing, not
assumed.

## Verification

* `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` green.
* All 54 sample programs match the evaluator on x86-64.
* All 48 `tests/cross-exec/` fixtures build for all three targets and match the
  evaluator, plain and under `--gc-stress --gc-poison`.
* New fixture `48-match-arms-of-different-lengths.kl`: three- and four-arm
  matches with every arm printed, plus `toList(Some(1))` / `toList(None)`.
* Probed three- and four-arm matches in both arm orders, plus Strings and
  nested lists: every case is either correct or a build-time refusal that also
  refuses on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)