### PR TITLE
A set removes a duplicate heap value

### DIFF
--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -2123,6 +2123,11 @@ struct Emitter {
     /// membership scans and a cons-list reverse.
     member_scalar_label: Option<Label>,
     member_string_label: Option<Label>,
+    /// Membership for elements that are heap values (a lowered enum, a
+    /// record). Those compare by *contents*: two separately built `Sm(1)`s
+    /// are one value, so the scalar scan -- which compares the boxed word,
+    /// i.e. the address -- let a set keep both.
+    member_deep_label: Option<Label>,
     list_reverse_label: Option<Label>,
     /// Label of the GC load barrier's slow path (`gc_load_barrier_slow`).
     /// Created lazily so the first user -- a barriered read or
@@ -2144,6 +2149,10 @@ struct Emitter {
     /// Label of `gc_alloc`, shared between the mutator's allocation sites
     /// and the GC runtime that defines it.
     gc_alloc_label: Option<Label>,
+    /// `gc_deep_equal`, shared between the set literal's membership scan and
+    /// the GC runtime that defines it -- the same lazy hand-off `gc_alloc`
+    /// uses, because the scan is emitted before the runtime is.
+    gc_deep_equal_label: Option<Label>,
     /// Whether declining this program hands it to the portable C backend
     /// rather than failing the build. It decides what to do with a Double
     /// whose value is not known until run time: the emitted formatter is
@@ -4616,6 +4625,17 @@ impl Emitter {
         Ok(ValueType::Unit)
     }
 
+    fn gc_deep_equal_label(&mut self) -> Label {
+        match self.gc_deep_equal_label {
+            Some(label) => label,
+            None => {
+                let label = self.asm.new_label();
+                self.gc_deep_equal_label = Some(label);
+                label
+            }
+        }
+    }
+
     fn gc_alloc_entry_label(&mut self) -> Label {
         match self.gc_alloc_label {
             Some(label) => label,
@@ -6550,6 +6570,10 @@ exact decimal expansion is too long, or it is NaN/Infinity\n",
     fn member_label(&mut self, elem: ListElem) -> Label {
         let slot = match elem {
             ListElem::Str => &mut self.member_string_label,
+            ListElem::LoweredEnum(_)
+            | ListElem::Enum(_)
+            | ListElem::Record(_)
+            | ListElem::Nested { .. } => &mut self.member_deep_label,
             _ => &mut self.member_scalar_label,
         };
         match slot {
@@ -6917,6 +6941,56 @@ exact decimal expansion is too long, or it is NaN/Infinity\n",
         self.asm.ret();
         self.asm.bind(not_found);
         self.asm.mov_imm64(Reg::X0, 0);
+        self.asm.ret();
+    }
+
+    /// `bl`-called deep membership scan: x0 = list, x1 = candidate (a heap
+    /// pointer) -> x0 = Bool. Compares with `gc_deep_equal`, the routine `==`
+    /// already uses on a heap value, so a set removes a duplicate enum the way
+    /// the evaluator does.
+    ///
+    /// `gc_deep_equal` takes its operands in x5 and x4 (`V7`/`V6` in the
+    /// portable register naming) and is free to clobber x0-x9, so the cursor
+    /// and candidate are kept in a stack scratch addressed off x10 -- above
+    /// everything the callee can see.
+    fn emit_member_deep_routine(&mut self, label: Label) {
+        let deep_equal = self.gc_deep_equal_label();
+        self.asm.bind(label);
+        self.asm.push_frame_record();
+        self.asm.sub_sp_imm(16);
+        self.asm.add_reg_sp_imm(Reg::X10, 0);
+        self.asm.str_imm(Reg::X1, Reg::X10, 0); // candidate
+        self.asm.str_imm(Reg::X0, Reg::X10, 8); // cursor
+        let loop_start = self.asm.new_label();
+        let found = self.asm.new_label();
+        let not_found = self.asm.new_label();
+        let done = self.asm.new_label();
+        self.asm.bind(loop_start);
+        self.asm.add_reg_sp_imm(Reg::X10, 0);
+        self.asm.ldr_imm(Reg::X2, Reg::X10, 8);
+        self.asm.branch(not_found, BranchKind::CompareZero(Reg::X2));
+        self.emit_gc_load_ptr(Reg::X2, 0); // x0 = this element
+        self.asm.add_reg_sp_imm(Reg::X10, 0);
+        self.asm.mov_reg(Reg::X5, Reg::X0);
+        self.asm.ldr_imm(Reg::X4, Reg::X10, 0); // the candidate
+        self.asm.branch(deep_equal, BranchKind::Link);
+        // The callee restores sp but not x10, so the scratch base is
+        // re-derived rather than kept live across the call.
+        self.asm.add_reg_sp_imm(Reg::X10, 0);
+        self.asm.branch(found, BranchKind::CompareNonZero(Reg::X0));
+        self.asm.ldr_imm(Reg::X2, Reg::X10, 8);
+        self.emit_gc_load_ptr(Reg::X2, 8); // x0 = next
+        self.asm.add_reg_sp_imm(Reg::X10, 0);
+        self.asm.str_imm(Reg::X0, Reg::X10, 8);
+        self.asm.branch(loop_start, BranchKind::Unconditional);
+        self.asm.bind(found);
+        self.asm.mov_imm64(Reg::X0, 1);
+        self.asm.branch(done, BranchKind::Unconditional);
+        self.asm.bind(not_found);
+        self.asm.mov_imm64(Reg::X0, 0);
+        self.asm.bind(done);
+        self.asm.add_sp_imm(16);
+        self.asm.pop_frame_record();
         self.asm.ret();
     }
 
@@ -13241,6 +13315,7 @@ impl Emitter {
         let l_load_barrier_slow = self.load_barrier_label();
         // Likewise shared with every mutator allocation site.
         let l_alloc = self.gc_alloc_entry_label();
+        let l_deep_equal = self.gc_deep_equal_label();
 
         GcState {
             heap_base,
@@ -13301,7 +13376,7 @@ impl Emitter {
             l_mark_start: self.asm.new_label(),
             l_mark_end: self.asm.new_label(),
             l_mark_visit: self.asm.new_label(),
-            l_deep_equal: self.asm.new_label(),
+            l_deep_equal,
             l_load_barrier_slow,
             l_acquire_region: self.asm.new_label(),
             l_alloc_large: self.asm.new_label(),
@@ -13676,6 +13751,9 @@ pub(crate) fn emit_macho_program(
     }
     if let Some(label) = emitter.member_string_label {
         emitter.emit_member_string_routine(label);
+    }
+    if let Some(label) = emitter.member_deep_label {
+        emitter.emit_member_deep_routine(label);
     }
     if let Some(label) = emitter.list_reverse_label {
         emitter.emit_list_reverse_routine(label);

--- a/crates/klassic-native/src/lib.rs
+++ b/crates/klassic-native/src/lib.rs
@@ -29097,6 +29097,50 @@ impl NativeCodeGenerator {
         actual_value: NativeValue,
         actual_slot: DataLabel,
     ) {
+        // Two heap values are equal when their *contents* are, not when they
+        // are the same address -- two separate `Sm(1)`s are one value. Saying
+        // "not equal" here instead is what let a set keep a duplicate enum:
+        // `%(Sm(1) Sm(1) Nn)` printed all three. `gc_deep_equal` is the same
+        // routine `==` and `assertResult` use on a heap value.
+        if expected_value == NativeValue::HeapPointer && actual_value == NativeValue::HeapPointer {
+            self.asm.mov_data_addr(Reg::R10, expected_slot);
+            self.asm.load_ptr_disp32(Reg::Rdi, Reg::R10, 0);
+            self.asm.mov_data_addr(Reg::R10, actual_slot);
+            self.asm.load_ptr_disp32(Reg::Rsi, Reg::R10, 0);
+            self.asm.call_label(self.gc_deep_equal);
+            return;
+        }
+        // Two Doubles are equal when IEEE says so, which is the bit pattern
+        // plus one exception: `0.0 == -0.0` is true and the evaluator dedups
+        // them, while their bits differ. NaN is left unequal, matching IEEE --
+        // and unreachable in a printed set anyway, since the formatter refuses
+        // to render one. Answering "not equal" for every Double, as this did,
+        // let a set keep a duplicate.
+        if expected_value == NativeValue::RuntimeDouble
+            && actual_value == NativeValue::RuntimeDouble
+        {
+            let equal = self.asm.create_text_label();
+            let done = self.asm.create_text_label();
+            self.asm.mov_data_addr(Reg::R10, expected_slot);
+            self.asm.load_ptr_disp32(Reg::Rcx, Reg::R10, 0);
+            self.asm.mov_data_addr(Reg::R10, actual_slot);
+            self.asm.load_ptr_disp32(Reg::Rax, Reg::R10, 0);
+            self.asm.cmp_reg_reg(Reg::Rcx, Reg::Rax);
+            self.asm.jcc_label(Condition::Equal, equal);
+            // Both zero, whatever their signs?
+            self.asm.mov_imm64(Reg::Rbx, 0x7fff_ffff_ffff_ffff);
+            self.asm.and_reg_reg(Reg::Rcx, Reg::Rbx);
+            self.asm.and_reg_reg(Reg::Rax, Reg::Rbx);
+            self.asm.or_reg_reg(Reg::Rax, Reg::Rcx);
+            self.asm.cmp_reg_imm8(Reg::Rax, 0);
+            self.asm.jcc_label(Condition::Equal, equal);
+            self.asm.mov_imm64(Reg::Rax, 0);
+            self.asm.jmp_label(done);
+            self.asm.bind_text_label(equal);
+            self.asm.mov_imm64(Reg::Rax, 1);
+            self.asm.bind_text_label(done);
+            return;
+        }
         if expected_value != actual_value
             || !matches!(expected_value, NativeValue::Int | NativeValue::Bool)
         {

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -2257,6 +2257,15 @@ side of a branch.
   the join the *maximum over the arms that can return*, which is also the
   capacity -- forcing a dynamic length without that (tried, reverted) made the
   widest arm print truncated (issue #641).
+- A set removes a duplicate heap value by comparing contents, not addresses.
+  Letting an enum into a collection made two separately built `Sm(1)`s reach
+  the dedup as two different pointers, and the comparison answered "different"
+  for anything that was not an Int or a Bool, so `%(Sm(1) Sm(1) Nn)` kept all
+  three. Both backends compare with `gc_deep_equal` now -- the routine `==` and
+  `assertResult` already used on a heap value -- x86-64 in its slot comparison
+  and aarch64 through a third membership scan beside the scalar and string
+  ones. A `RuntimeDouble` had the same hole and compares by bit pattern plus
+  the `0.0 == -0.0` case the evaluator dedups (issue #670).
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -29623,3 +29623,61 @@ fn native_match_arms_of_different_list_lengths_keep_every_arm() {
         "every arm must come out whole, the widest one included"
     );
 }
+
+/// A set removes duplicates by comparing what its elements *are*. Two
+/// separately built `Sm(1)`s are one value; the slot comparison answered
+/// "different" for every heap element, so a set kept both -- compiled, exit
+/// zero, wrong. Both hand-emitted backends had it and both compare with
+/// `gc_deep_equal` now, so both are asserted here.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_set_removes_duplicate_enum_values() {
+    let program = "enum Opt { case Sm(v: Int); case Nn }\n\
+         enum T { case W(s: String); case E }\n\
+         println(%(Sm(1) Sm(1) Nn))\n\
+         println(%(Sm(1) Sm(2) Sm(1)))\n\
+         println(%(Nn Sm(1) Nn))\n\
+         println(%(W(\"a\") W(\"a\") E))\n";
+    let expected = "%(Sm(1), Nn)\n%(Sm(1), Sm(2))\n%(Nn, Sm(1))\n%(W(a), E)\n";
+    for target in [None, Some("aarch64-apple-darwin")] {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir();
+        let source_path = dir.join(format!("klassic_set_dedup_{stamp}.kl"));
+        let bin_path = dir.join(format!("klassic_set_dedup_{stamp}.bin"));
+        fs::write(&source_path, program).expect("temp source file should write");
+        let mut command = Command::new(klassic_bin());
+        if let Some(target) = target {
+            command.args(["--target", target]);
+        }
+        let build = command
+            .args([
+                "build",
+                source_path.to_str().expect("path should be utf-8"),
+                "-o",
+                bin_path.to_str().expect("path should be utf-8"),
+            ])
+            .output()
+            .expect("binary should run");
+        assert!(
+            build.status.success(),
+            "set-dedup build should succeed for {target:?}\nstderr:\n{}",
+            String::from_utf8_lossy(&build.stderr)
+        );
+        // The aarch64 image is only built here; the host cannot run it.
+        if target.is_none() {
+            let run = Command::new(&bin_path)
+                .output()
+                .expect("generated executable should run");
+            assert_eq!(
+                String::from_utf8_lossy(&run.stdout),
+                expected,
+                "a set must keep one of each value"
+            );
+        }
+        let _ = fs::remove_file(&source_path);
+        let _ = fs::remove_file(&bin_path);
+    }
+}

--- a/tests/cross-exec/47-enum-collection-elements.kl
+++ b/tests/cross-exec/47-enum-collection-elements.kl
@@ -20,8 +20,16 @@ enum Colour { case Red; case Green; case Blue }
 // ones are only reachable through their cells.
 println([Sm(1) Nn Sm(2) Sm(3) Nn])
 
-// The same values as a set and as a map's values.
+// The same values as a set and as a map's values. A set removes duplicates by
+// comparing what its elements *are*, not where they live: two separately built
+// `Sm(1)`s are one value, and answering "different" for every heap element --
+// which is what a slot comparison did before it knew about them -- let a set
+// keep both.
 println(%(Sm(5) Nn Sm(6)))
+println(%(Sm(1) Sm(1) Nn))
+println(%(Sm(1) Sm(2) Sm(1)))
+println(%(Red Red Green Red))
+println(%(Word("a") Word("a") Comma))
 println(%["a": Sm(10) "b": Nn])
 
 // A payload that is itself a heap value, so the element's own field has to


### PR DESCRIPTION
Closes #670. A regression from #662, which let a collection hold an enum value.

```klassic
enum Opt { case Sm(v: Int); case Nn }
println(%(Sm(1) Sm(1) Nn))
```

    evaluator   %(Sm(1), Nn)
    x86-64      %(Sm(1), Sm(1), Nn)     <- compiled, exit 0, wrong

Two separately built `Sm(1)`s arrive at the dedup as two different pointers,
and the comparison answered "different" for anything that was not an `Int` or
a `Bool`. Bisected: refused at `0fee4b9^`, wrong at `0fee4b9`.

Both backends compare with `gc_deep_equal` now — the routine `==` and
`assertResult` already use on a heap value. x86-64 does it in the slot
comparison the set literal's scan calls; aarch64 needed a *third* membership
routine beside its scalar and string ones, because its scan compares the boxed
word, which for a heap element is the address.

## Two AArch64 hazards, found by disassembling the fault

* `gc_deep_equal` takes its operands in **x5 and x4** (`V7`/`V6` in the
  portable naming) — and x5 is exactly what the neighbouring string scan uses
  as its stack-scratch base. Passing the operands in x0/x1 (the obvious guess)
  faulted.
* The callee restores `sp` but not **x10**, so a scratch base kept live across
  the call is gone when it returns. It is re-derived from `sp` after every call
  instead. This one only showed up as `ldr x2, [x10, #8]` reading unmapped
  memory in the disassembly.

## Doubles had the same hole

`%(1.0 1.0)` kept both. They compare by bit pattern plus the one case the bits
get wrong: `0.0 == -0.0` is true and the evaluator dedups them. NaN stays
unequal, matching IEEE, and is unreachable in a printed set anyway since the
formatter refuses to render one.

## Verification

* `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` green.
* All 54 sample programs match the evaluator on x86-64.
* All 48 `tests/cross-exec/` fixtures build for all three targets and match the
  evaluator, plain and under `--gc-stress --gc-poison`; fixture 47 gained four
  duplicate-bearing sets and passes under stress on **both** hand-emitted
  backends.
* Eight duplicate patterns (same payload, different payload, nullary-only,
  interleaved, String payloads, empty String) swept against the evaluator on
  x86-64 **and** aarch64: 0 mismatches.
* New `cli_smoke` test builds the same program for both backends and asserts
  the output on the one the host can run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)