### PR TITLE
aarch64: == on a heap value compares contents

### DIFF
--- a/crates/klassic-native/src/aarch64.rs
+++ b/crates/klassic-native/src/aarch64.rs
@@ -4585,6 +4585,33 @@ impl Emitter {
                     }
                     return Ok(ValueType::Bool);
                 }
+                // The same holds for any other heap value: two separately
+                // built `Sm(1)`s are one value, and a nullary variant has
+                // nothing that *could* differ, so comparing the pointers
+                // called both of them unequal. `gc_deep_equal` is what x86-64
+                // has always used here.
+                // A map is a chain of two-slot entries, and its equality is
+                // insertion-ordered (`%[1: 2 3: 4] == %[3: 4 1: 2]` is false
+                // in the evaluator), so the structural walk is exactly right
+                // for one.
+                if matches!(
+                    lhs_ty,
+                    ValueType::LoweredEnum(_)
+                        | ValueType::Enum(_)
+                        | ValueType::Record(_)
+                        | ValueType::Map(..)
+                        | ValueType::Ptr
+                ) {
+                    let deep_equal = self.gc_deep_equal_label();
+                    self.asm.mov_reg(Reg::X5, Reg::X0);
+                    self.asm.mov_reg(Reg::X4, Reg::X1);
+                    self.asm.branch(deep_equal, BranchKind::Link);
+                    if op == BinaryOp::NotEqual {
+                        self.asm.cmp_imm(Reg::X0, 0);
+                        self.asm.cset(Reg::X0, Cond::Eq);
+                    }
+                    return Ok(ValueType::Bool);
+                }
                 let cond = if op == BinaryOp::Equal {
                     Cond::Eq
                 } else {
@@ -6564,6 +6591,34 @@ exact decimal expansion is too long, or it is NaN/Infinity\n",
         self.asm.str_imm(Reg::X1, Reg::X0, 0); // [cell + 0] = head
     }
 
+    /// Compare the element in x0 against the one in x1 -> x0 = Bool, where
+    /// the right side is still boxed. Shared by the map builtins' scans, which
+    /// all had the same shape and all compared a heap element by address:
+    /// `Map#containsValue(%[1: Sm(1)], Sm(1))` answered false because the two
+    /// `Sm(1)`s were two allocations.
+    fn emit_elem_eq_boxed_rhs(&mut self, elem: ListElem) {
+        if elem == ListElem::Str {
+            self.emit_str_eq();
+            return;
+        }
+        let elem_ty = elem_value_type(elem);
+        if is_boxed_scalar(elem_ty) {
+            self.asm.ldr_imm(Reg::X1, Reg::X1, 0);
+        }
+        if matches!(
+            elem_ty,
+            ValueType::LoweredEnum(_) | ValueType::Enum(_) | ValueType::Record(_) | ValueType::Ptr
+        ) {
+            let deep_equal = self.gc_deep_equal_label();
+            self.asm.mov_reg(Reg::X5, Reg::X0);
+            self.asm.mov_reg(Reg::X4, Reg::X1);
+            self.asm.branch(deep_equal, BranchKind::Link);
+            return;
+        }
+        self.asm.cmp_reg(Reg::X0, Reg::X1);
+        self.asm.cset(Reg::X0, Cond::Eq);
+    }
+
     /// Get/create the lazily-emitted membership-scan routine label for
     /// an element type. Both the routines take `x0` = list head and
     /// `x1` = candidate and return a Bool in `x0`.
@@ -8056,16 +8111,7 @@ exact decimal expansion is too long, or it is NaN/Infinity\n",
                     self.emit_unbox_scalar();
                 }
                 self.asm.load_local(Reg::X1, key_slot);
-                match key_elem {
-                    ListElem::Str => self.emit_str_eq(),
-                    _ => {
-                        if is_boxed_scalar(elem_value_type(key_elem)) {
-                            self.asm.ldr_imm(Reg::X1, Reg::X1, 0);
-                        }
-                        self.asm.cmp_reg(Reg::X0, Reg::X1);
-                        self.asm.cset(Reg::X0, Cond::Eq);
-                    }
-                }
+                self.emit_elem_eq_boxed_rhs(key_elem);
                 self.asm.branch(keep, BranchKind::CompareZero(Reg::X0));
                 self.pop_rooted(Reg::X1); // the old entry, replaced
                 self.asm.mov_imm64(Reg::X0, 1);
@@ -8143,16 +8189,7 @@ exact decimal expansion is too long, or it is NaN/Infinity\n",
                     self.emit_unbox_scalar();
                 }
                 self.asm.load_local(Reg::X1, wanted);
-                match value_elem {
-                    ListElem::Str => self.emit_str_eq(),
-                    _ => {
-                        if is_boxed_scalar(elem_value_type(value_elem)) {
-                            self.asm.ldr_imm(Reg::X1, Reg::X1, 0);
-                        }
-                        self.asm.cmp_reg(Reg::X0, Reg::X1);
-                        self.asm.cset(Reg::X0, Cond::Eq);
-                    }
-                }
+                self.emit_elem_eq_boxed_rhs(value_elem);
                 self.asm.branch(found, BranchKind::CompareNonZero(Reg::X0));
                 self.asm.load_local(Reg::X0, cursor);
                 self.emit_gc_load_ptr(Reg::X0, 8);
@@ -8219,16 +8256,7 @@ exact decimal expansion is too long, or it is NaN/Infinity\n",
                     self.emit_unbox_scalar();
                 }
                 self.asm.load_local(Reg::X1, key_slot);
-                match key_elem {
-                    ListElem::Str => self.emit_str_eq(),
-                    _ => {
-                        if is_boxed_scalar(elem_value_type(key_elem)) {
-                            self.asm.ldr_imm(Reg::X1, Reg::X1, 0);
-                        }
-                        self.asm.cmp_reg(Reg::X0, Reg::X1);
-                        self.asm.cset(Reg::X0, Cond::Eq);
-                    }
-                }
+                self.emit_elem_eq_boxed_rhs(key_elem);
                 self.asm.branch(keep, BranchKind::CompareZero(Reg::X0));
                 self.pop_rooted(Reg::X1); // the matching entry, dropped
                 self.asm.branch(next, BranchKind::Unconditional);
@@ -10200,6 +10228,16 @@ exact decimal expansion is too long, or it is NaN/Infinity\n",
             // element type existed. The recursion is at codegen time and
             // terminates because the depth decreases.
             self.emit_list_eq(inner, span)?;
+        } else if matches!(
+            elem_ty,
+            ValueType::LoweredEnum(_) | ValueType::Enum(_) | ValueType::Record(_) | ValueType::Ptr
+        ) {
+            // A heap element compares by contents, for the same reason a
+            // nested list does: two separately built `Sm(1)`s are one value.
+            let deep_equal = self.gc_deep_equal_label();
+            self.asm.mov_reg(Reg::X5, Reg::X0);
+            self.asm.mov_reg(Reg::X4, Reg::X1);
+            self.asm.branch(deep_equal, BranchKind::Link);
         } else {
             self.asm.cmp_reg(Reg::X0, Reg::X1);
             self.asm.cset(Reg::X0, Cond::Eq);

--- a/docs/architecture-rust.md
+++ b/docs/architecture-rust.md
@@ -2266,6 +2266,14 @@ side of a branch.
   and aarch64 through a third membership scan beside the scalar and string
   ones. A `RuntimeDouble` had the same hole and compares by bit pattern plus
   the `0.0 == -0.0` case the evaluator dedups (issue #670).
+- aarch64's `==` compares a heap value's contents. It compared the pointers,
+  so two separately built `Sm(1)`s were unequal -- and so were two `Nn`s, which
+  carry nothing that could differ. x86-64 had always used `gc_deep_equal` here;
+  aarch64 now does too, in the operator itself, in `emit_list_eq`'s element
+  comparison, and in the map builtins' scans (which shared one shape and are a
+  single helper now). A map joins the same path: its chain of two-slot entries
+  compares structurally, and its equality is insertion-ordered, which is what
+  the walk gives (issue #672).
 - The workspace keeps crate boundaries explicit so future optimizer or runtime
   work can stay isolated.
 

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -29681,3 +29681,62 @@ fn native_set_removes_duplicate_enum_values() {
         let _ = fs::remove_file(&bin_path);
     }
 }
+
+/// `==` on a heap value compares contents, not addresses: two separately
+/// built `Sm(1)`s are one value, and two `Nn`s carry nothing that *could*
+/// differ. The same comparison backs list equality and the map scans, so all
+/// three are asserted.
+///
+/// This covers x86-64 only. aarch64 had the bug and building its image here
+/// would prove nothing -- a wrong comparison builds perfectly well -- so its
+/// half is checked by `tests/cross-exec/47-enum-collection-elements.kl`,
+/// which the macOS job *runs* on real hardware. Confirmed that fixture goes
+/// red when the aarch64 fix is reverted.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn native_equality_on_heap_values_compares_contents() {
+    let program = "enum Opt { case Sm(v: Int); case Nn }\n\
+         record P { a: Int; b: Int }\n\
+         println(Sm(1) == Sm(1))\n\
+         println(Sm(1) == Sm(2))\n\
+         println(Nn == Nn)\n\
+         println(Nn == Sm(1))\n\
+         println(#P(1, 2) == #P(1, 2))\n\
+         println([Sm(1) Nn] == [Sm(1) Nn])\n\
+         println(Map#containsValue(%[1: Sm(1)], Sm(1)))\n\
+         println(%[1: 2] == %[1: 2])\n\
+         println(%[1: 2 3: 4] == %[3: 4 1: 2])\n";
+    let expected = "true\nfalse\ntrue\nfalse\ntrue\ntrue\ntrue\ntrue\nfalse\n";
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let source_path = dir.join(format!("klassic_heap_eq_{stamp}.kl"));
+    let bin_path = dir.join(format!("klassic_heap_eq_{stamp}.bin"));
+    fs::write(&source_path, program).expect("temp source file should write");
+    let build = Command::new(klassic_bin())
+        .args([
+            "build",
+            source_path.to_str().expect("path should be utf-8"),
+            "-o",
+            bin_path.to_str().expect("path should be utf-8"),
+        ])
+        .output()
+        .expect("binary should run");
+    assert!(
+        build.status.success(),
+        "heap-equality build should succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let run = Command::new(&bin_path)
+        .output()
+        .expect("generated executable should run");
+    let _ = fs::remove_file(&source_path);
+    let _ = fs::remove_file(&bin_path);
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        expected,
+        "two separately built values of the same shape are one value"
+    );
+}

--- a/tests/cross-exec/47-enum-collection-elements.kl
+++ b/tests/cross-exec/47-enum-collection-elements.kl
@@ -48,6 +48,23 @@ println(toString([Sm(7) Nn]))
 println(size([Sm(1) Nn Sm(2)]))
 println(isEmpty([Nn]))
 
+// Equality on a heap value compares contents, not addresses -- two separately
+// built `Sm(1)`s are one value, and a nullary variant has nothing that *could*
+// differ. aarch64 compared the pointers and answered false for both.
+println(Sm(1) == Sm(1))
+println(Sm(1) == Sm(2))
+println(Nn == Nn)
+println(Nn == Sm(1))
+println(Sm(1) != Sm(2))
+println(Word("a") == Word("a"))
+println([Sm(1) Nn] == [Sm(1) Nn])
+println([Sm(1)] == [Sm(2)])
+println(Map#containsValue(%[1: Sm(1)], Sm(1)))
+println(Map#containsValue(%[1: Sm(1)], Sm(2)))
+// A map's equality is insertion-ordered, which the structural walk gives.
+println(%[1: 2] == %[1: 2])
+println(%[1: 2 3: 4] == %[3: 4 1: 2])
+
 // The same list bound to a `val` rather than written inline. These took a
 // different path on x86-64 -- the static-literal one, which refused it -- and
 // then a different renderer, which printed the elements' addresses. Reading an


### PR DESCRIPTION
Closes #672. Pre-existing on `main`; x86-64 was already right.

```klassic
enum Opt { case Sm(v: Int); case Nn }
println(Sm(1) == Sm(1))
println(Nn == Nn)
```

    evaluator   true / true
    x86-64      true / true
    aarch64     false / false     <- compiled, exit 0, wrong

Two separately built values of the same variant are one value. aarch64
compared the pointers, so anything built twice was unequal — including a
nullary variant, where there is nothing that *could* differ.

## Four places, found by sweeping rather than reading

* the `==` / `!=` operator itself;
* `emit_list_eq`'s element comparison, so `[Sm(1)] == [Sm(1)]` was false too;
* the map builtins' scans — four sites with one shape, now a single helper —
  which is what made `Map#containsValue(%[1: Sm(1)], Sm(1))` answer false;
* map equality itself, which joins the same structural walk: a map is a chain
  of two-slot entries and its equality is insertion-ordered
  (`%[1: 2 3: 4] == %[3: 4 1: 2]` is false), which is what the walk gives.

The sweep is what found all four: after fixing set dedup (#671) I ran every
operation that compares heap values through the evaluator on both hand-emitted
backends. x86-64: 0 mismatches. aarch64: three, and the fourth turned up when
the first fix let the next case run. 33 cases now agree on both.

## A note on the test

The `cli_smoke` test covers x86-64 **only**, deliberately. My first version
looped over both targets, building the aarch64 image — and it did not go red
when the fix was reverted, because a wrong comparison builds perfectly well.
The aarch64 half is checked by `tests/cross-exec/47-enum-collection-elements.kl`,
which the macOS job *runs* on real hardware; I confirmed that fixture goes red
with this change reverted, and that the build-only test did not.

## Verification

* `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` green.
* 33 equality cases (enum, record, list, set, map, scalars, both orders) swept
  against the evaluator on x86-64 **and** aarch64: 0 mismatches.
* All 48 `tests/cross-exec/` fixtures build for all three targets and match the
  evaluator, plain and under `--gc-stress --gc-poison`; fixture 47 gained the
  equality assertions and passes under stress on aarch64 too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)